### PR TITLE
feat(cards): add French translation for A Series sets

### DIFF
--- a/dist/cards/A1.json
+++ b/dist/cards/A1.json
@@ -3,7 +3,10 @@
     "set": "A1",
     "number": 1,
     "rarity": "C",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "image": "cPK_10_000010_00_FUSHIGIDANE_C.webp",
     "packs": [
       "Mewtwo"
@@ -13,7 +16,10 @@
     "set": "A1",
     "number": 2,
     "rarity": "U",
-    "name": "Ivysaur",
+    "name": {
+      "en": "Ivysaur",
+      "fr": "Herbizarre"
+    },
     "image": "cPK_10_000020_00_FUSHIGISOU_U.webp",
     "packs": [
       "Mewtwo"
@@ -23,7 +29,10 @@
     "set": "A1",
     "number": 3,
     "rarity": "R",
-    "name": "Venusaur",
+    "name": {
+      "en": "Venusaur",
+      "fr": "Florizarre"
+    },
     "image": "cPK_10_000030_00_FUSHIGIBANA_R.webp",
     "packs": [
       "Mewtwo"
@@ -33,7 +42,10 @@
     "set": "A1",
     "number": 4,
     "rarity": "RR",
-    "name": "Venusaur ex",
+    "name": {
+      "en": "Venusaur ex",
+      "fr": "Florizarre-ex"
+    },
     "image": "cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
     "packs": [
       "Mewtwo"
@@ -43,7 +55,10 @@
     "set": "A1",
     "number": 5,
     "rarity": "C",
-    "name": "Caterpie",
+    "name": {
+      "en": "Caterpie",
+      "fr": "Chenipan"
+    },
     "image": "cPK_10_000050_00_CATERPIE_C.webp",
     "packs": [
       "Pikachu"
@@ -53,7 +68,10 @@
     "set": "A1",
     "number": 6,
     "rarity": "C",
-    "name": "Metapod",
+    "name": {
+      "en": "Metapod",
+      "fr": "Chrysacier"
+    },
     "image": "cPK_10_000060_00_TRANSEL_C.webp",
     "packs": [
       "Pikachu"
@@ -63,7 +81,10 @@
     "set": "A1",
     "number": 7,
     "rarity": "R",
-    "name": "Butterfree",
+    "name": {
+      "en": "Butterfree",
+      "fr": "Papilusion"
+    },
     "image": "cPK_10_000070_00_BUTTERFREE_R.webp",
     "packs": [
       "Pikachu"
@@ -73,7 +94,10 @@
     "set": "A1",
     "number": 8,
     "rarity": "C",
-    "name": "Weedle",
+    "name": {
+      "en": "Weedle",
+      "fr": "Aspicot"
+    },
     "image": "cPK_10_000080_00_BEEDLE_C.webp",
     "packs": [
       "Mewtwo"
@@ -83,7 +107,10 @@
     "set": "A1",
     "number": 9,
     "rarity": "C",
-    "name": "Kakuna",
+    "name": {
+      "en": "Kakuna",
+      "fr": "Coconfort"
+    },
     "image": "cPK_10_000090_00_COCOON_C.webp",
     "packs": [
       "Mewtwo"
@@ -93,7 +120,10 @@
     "set": "A1",
     "number": 10,
     "rarity": "R",
-    "name": "Beedrill",
+    "name": {
+      "en": "Beedrill",
+      "fr": "Dardargnan"
+    },
     "image": "cPK_10_000100_00_SPEAR_R.webp",
     "packs": [
       "Mewtwo"
@@ -103,7 +133,10 @@
     "set": "A1",
     "number": 11,
     "rarity": "C",
-    "name": "Oddish",
+    "name": {
+      "en": "Oddish",
+      "fr": "Mystherbe"
+    },
     "image": "cPK_10_000110_00_NAZONOKUSA_C.webp",
     "packs": [
       "Charizard"
@@ -113,7 +146,10 @@
     "set": "A1",
     "number": 12,
     "rarity": "U",
-    "name": "Gloom",
+    "name": {
+      "en": "Gloom",
+      "fr": "Ortide"
+    },
     "image": "cPK_10_000120_00_KUSAIHANA_U.webp",
     "packs": [
       "Charizard"
@@ -123,7 +159,10 @@
     "set": "A1",
     "number": 13,
     "rarity": "R",
-    "name": "Vileplume",
+    "name": {
+      "en": "Vileplume",
+      "fr": "Rafflesia"
+    },
     "image": "cPK_10_000130_00_RUFFRESIA_R.webp",
     "packs": [
       "Charizard"
@@ -133,7 +172,10 @@
     "set": "A1",
     "number": 14,
     "rarity": "C",
-    "name": "Paras",
+    "name": {
+      "en": "Paras",
+      "fr": "Paras"
+    },
     "image": "cPK_10_000140_00_PARAS_C.webp",
     "packs": [
       "Pikachu"
@@ -143,7 +185,10 @@
     "set": "A1",
     "number": 15,
     "rarity": "U",
-    "name": "Parasect",
+    "name": {
+      "en": "Parasect",
+      "fr": "Parasect"
+    },
     "image": "cPK_10_000150_00_PARASECT_U.webp",
     "packs": [
       "Pikachu"
@@ -153,7 +198,10 @@
     "set": "A1",
     "number": 16,
     "rarity": "C",
-    "name": "Venonat",
+    "name": {
+      "en": "Venonat",
+      "fr": "Mimitoss"
+    },
     "image": "cPK_10_000160_00_KONGPANG_C.webp",
     "packs": [
       "Mewtwo"
@@ -163,7 +211,10 @@
     "set": "A1",
     "number": 17,
     "rarity": "U",
-    "name": "Venomoth",
+    "name": {
+      "en": "Venomoth",
+      "fr": "Aéromite"
+    },
     "image": "cPK_10_000170_00_MORPHON_U.webp",
     "packs": [
       "Mewtwo"
@@ -173,7 +224,10 @@
     "set": "A1",
     "number": 18,
     "rarity": "C",
-    "name": "Bellsprout",
+    "name": {
+      "en": "Bellsprout",
+      "fr": "Chétiflor"
+    },
     "image": "cPK_10_000180_00_MADATSUBOMI_C.webp",
     "packs": [
       "Charizard"
@@ -183,7 +237,10 @@
     "set": "A1",
     "number": 19,
     "rarity": "U",
-    "name": "Weepinbell",
+    "name": {
+      "en": "Weepinbell",
+      "fr": "Boustiflor"
+    },
     "image": "cPK_10_000190_00_UTSUDON_U.webp",
     "packs": [
       "Charizard"
@@ -193,7 +250,10 @@
     "set": "A1",
     "number": 20,
     "rarity": "R",
-    "name": "Victreebel",
+    "name": {
+      "en": "Victreebel",
+      "fr": "Empiflor"
+    },
     "image": "cPK_10_000200_00_UTSUBOT_R.webp",
     "packs": [
       "Charizard"
@@ -203,7 +263,10 @@
     "set": "A1",
     "number": 21,
     "rarity": "C",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_10_000210_00_TAMATAMA_C.webp",
     "packs": [
       "Charizard"
@@ -213,7 +276,10 @@
     "set": "A1",
     "number": 22,
     "rarity": "R",
-    "name": "Exeggutor",
+    "name": {
+      "en": "Exeggutor",
+      "fr": "Noadkoko"
+    },
     "image": "cPK_10_000220_00_NASSY_R.webp",
     "packs": [
       "Charizard"
@@ -223,7 +289,10 @@
     "set": "A1",
     "number": 23,
     "rarity": "RR",
-    "name": "Exeggutor ex",
+    "name": {
+      "en": "Exeggutor ex",
+      "fr": "Noadkoko-ex"
+    },
     "image": "cPK_10_000230_00_NASSYex_RR.webp",
     "packs": [
       "Charizard"
@@ -233,7 +302,10 @@
     "set": "A1",
     "number": 24,
     "rarity": "C",
-    "name": "Tangela",
+    "name": {
+      "en": "Tangela",
+      "fr": "Saquedeneu"
+    },
     "image": "cPK_10_000240_00_MONJARA_C.webp",
     "packs": [
       "Charizard"
@@ -243,7 +315,10 @@
     "set": "A1",
     "number": 25,
     "rarity": "C",
-    "name": "Scyther",
+    "name": {
+      "en": "Scyther",
+      "fr": "Insécateur"
+    },
     "image": "cPK_10_000250_00_STRIKE_C.webp",
     "packs": [
       "Mewtwo"
@@ -253,7 +328,10 @@
     "set": "A1",
     "number": 26,
     "rarity": "U",
-    "name": "Pinsir",
+    "name": {
+      "en": "Pinsir",
+      "fr": "Scarabrute"
+    },
     "image": "cPK_10_000260_00_KAILIOS_U.webp",
     "packs": [
       "Charizard",
@@ -265,7 +343,10 @@
     "set": "A1",
     "number": 27,
     "rarity": "C",
-    "name": "Cottonee",
+    "name": {
+      "en": "Cottonee",
+      "fr": "Doudouvet"
+    },
     "image": "cPK_10_000270_00_MONMEN_C.webp",
     "packs": [
       "Charizard",
@@ -277,7 +358,10 @@
     "set": "A1",
     "number": 28,
     "rarity": "U",
-    "name": "Whimsicott",
+    "name": {
+      "en": "Whimsicott",
+      "fr": "Farfaduvet"
+    },
     "image": "cPK_10_000280_00_ELFUUN_U.webp",
     "packs": [
       "Charizard",
@@ -289,7 +373,10 @@
     "set": "A1",
     "number": 29,
     "rarity": "C",
-    "name": "Petilil",
+    "name": {
+      "en": "Petilil",
+      "fr": "Chlorobule"
+    },
     "image": "cPK_10_000290_00_CHURINE_C.webp",
     "packs": [
       "Charizard",
@@ -301,7 +388,10 @@
     "set": "A1",
     "number": 30,
     "rarity": "U",
-    "name": "Lilligant",
+    "name": {
+      "en": "Lilligant",
+      "fr": "Fragilady"
+    },
     "image": "cPK_10_000300_00_DREDEAR_U.webp",
     "packs": [
       "Charizard",
@@ -313,7 +403,10 @@
     "set": "A1",
     "number": 31,
     "rarity": "C",
-    "name": "Skiddo",
+    "name": {
+      "en": "Skiddo",
+      "fr": "Cabriolaine"
+    },
     "image": "cPK_10_000310_00_MEECLE_C.webp",
     "packs": [
       "Charizard"
@@ -323,7 +416,10 @@
     "set": "A1",
     "number": 32,
     "rarity": "C",
-    "name": "Gogoat",
+    "name": {
+      "en": "Gogoat",
+      "fr": "Chevroum"
+    },
     "image": "cPK_10_000320_00_GOGOAT_C.webp",
     "packs": [
       "Charizard"
@@ -333,7 +429,10 @@
     "set": "A1",
     "number": 33,
     "rarity": "C",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_10_000330_00_HITOKAGE_C.webp",
     "packs": [
       "Charizard"
@@ -343,7 +442,10 @@
     "set": "A1",
     "number": 34,
     "rarity": "U",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "image": "cPK_10_000340_00_LIZARDO_U.webp",
     "packs": [
       "Charizard"
@@ -353,7 +455,10 @@
     "set": "A1",
     "number": 35,
     "rarity": "R",
-    "name": "Charizard",
+    "name": {
+      "en": "Charizard",
+      "fr": "Dracaufeu"
+    },
     "image": "cPK_10_000350_00_LIZARDON_R.webp",
     "packs": [
       "Charizard"
@@ -363,7 +468,10 @@
     "set": "A1",
     "number": 36,
     "rarity": "RR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_10_000360_00_LIZARDONex_RR.webp",
     "packs": [
       "Charizard"
@@ -373,7 +481,10 @@
     "set": "A1",
     "number": 37,
     "rarity": "C",
-    "name": "Vulpix",
+    "name": {
+      "en": "Vulpix",
+      "fr": "Goupix"
+    },
     "image": "cPK_10_000370_00_ROKON_C.webp",
     "packs": [
       "Charizard"
@@ -383,7 +494,10 @@
     "set": "A1",
     "number": 38,
     "rarity": "U",
-    "name": "Ninetales",
+    "name": {
+      "en": "Ninetales",
+      "fr": "Feunard"
+    },
     "image": "cPK_10_000380_00_KYUKON_U.webp",
     "packs": [
       "Charizard"
@@ -393,7 +507,10 @@
     "set": "A1",
     "number": 39,
     "rarity": "C",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_10_000390_00_GARDIE_C.webp",
     "packs": [
       "Pikachu"
@@ -403,7 +520,10 @@
     "set": "A1",
     "number": 40,
     "rarity": "R",
-    "name": "Arcanine",
+    "name": {
+      "en": "Arcanine",
+      "fr": "Arcanin"
+    },
     "image": "cPK_10_000400_00_WINDIE_R.webp",
     "packs": [
       "Pikachu"
@@ -413,7 +533,10 @@
     "set": "A1",
     "number": 41,
     "rarity": "RR",
-    "name": "Arcanine ex",
+    "name": {
+      "en": "Arcanine ex",
+      "fr": "Arcanin-ex"
+    },
     "image": "cPK_10_000410_00_WINDIEex_RR.webp",
     "packs": [
       "Pikachu"
@@ -423,7 +546,10 @@
     "set": "A1",
     "number": 42,
     "rarity": "C",
-    "name": "Ponyta",
+    "name": {
+      "en": "Ponyta",
+      "fr": "Ponyta"
+    },
     "image": "cPK_10_000420_00_PONYTA_C.webp",
     "packs": [
       "Charizard",
@@ -435,7 +561,10 @@
     "set": "A1",
     "number": 43,
     "rarity": "U",
-    "name": "Rapidash",
+    "name": {
+      "en": "Rapidash",
+      "fr": "Galopa"
+    },
     "image": "cPK_10_000430_00_GALLOP_U.webp",
     "packs": [
       "Charizard",
@@ -447,7 +576,10 @@
     "set": "A1",
     "number": 44,
     "rarity": "C",
-    "name": "Magmar",
+    "name": {
+      "en": "Magmar",
+      "fr": "Magmar"
+    },
     "image": "cPK_10_000440_00_BOOBER_C.webp",
     "packs": [
       "Charizard"
@@ -457,7 +589,10 @@
     "set": "A1",
     "number": 45,
     "rarity": "R",
-    "name": "Flareon",
+    "name": {
+      "en": "Flareon",
+      "fr": "Pyroli"
+    },
     "image": "cPK_10_000450_00_BOOSTER_R.webp",
     "packs": [
       "Charizard"
@@ -467,7 +602,10 @@
     "set": "A1",
     "number": 46,
     "rarity": "R",
-    "name": "Moltres",
+    "name": {
+      "en": "Moltres",
+      "fr": "Sulfura"
+    },
     "image": "cPK_10_000460_00_FIRE_R.webp",
     "packs": [
       "Charizard"
@@ -477,7 +615,10 @@
     "set": "A1",
     "number": 47,
     "rarity": "RR",
-    "name": "Moltres ex",
+    "name": {
+      "en": "Moltres ex",
+      "fr": "Sulfura-ex"
+    },
     "image": "cPK_10_000470_00_FIREex_RR.webp",
     "packs": [
       "Charizard"
@@ -487,7 +628,10 @@
     "set": "A1",
     "number": 48,
     "rarity": "C",
-    "name": "Heatmor",
+    "name": {
+      "en": "Heatmor",
+      "fr": "Aflamanoir"
+    },
     "image": "cPK_10_000480_00_KUITARAN_C.webp",
     "packs": [
       "Charizard",
@@ -499,7 +643,10 @@
     "set": "A1",
     "number": 49,
     "rarity": "C",
-    "name": "Salandit",
+    "name": {
+      "en": "Salandit",
+      "fr": "Tritox"
+    },
     "image": "cPK_10_000490_00_YATOUMORI_C.webp",
     "packs": [
       "Mewtwo"
@@ -509,7 +656,10 @@
     "set": "A1",
     "number": 50,
     "rarity": "C",
-    "name": "Salazzle",
+    "name": {
+      "en": "Salazzle",
+      "fr": "Malamandre"
+    },
     "image": "cPK_10_000500_00_ENNEWT_C.webp",
     "packs": [
       "Mewtwo"
@@ -519,7 +669,10 @@
     "set": "A1",
     "number": 51,
     "rarity": "C",
-    "name": "Sizzlipede",
+    "name": {
+      "en": "Sizzlipede",
+      "fr": "Grillepattes"
+    },
     "image": "cPK_10_000510_00_YAKUDE_C.webp",
     "packs": [
       "Charizard",
@@ -531,7 +684,10 @@
     "set": "A1",
     "number": 52,
     "rarity": "U",
-    "name": "Centiskorch",
+    "name": {
+      "en": "Centiskorch",
+      "fr": "Scolocendre"
+    },
     "image": "cPK_10_000520_00_MARUYAKUDE_U.webp",
     "packs": [
       "Charizard",
@@ -543,7 +699,10 @@
     "set": "A1",
     "number": 53,
     "rarity": "C",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "image": "cPK_10_000530_00_ZENIGAME_C.webp",
     "packs": [
       "Pikachu"
@@ -553,7 +712,10 @@
     "set": "A1",
     "number": 54,
     "rarity": "U",
-    "name": "Wartortle",
+    "name": {
+      "en": "Wartortle",
+      "fr": "Carabaffe"
+    },
     "image": "cPK_10_000540_00_KAMEIL_U.webp",
     "packs": [
       "Pikachu"
@@ -563,7 +725,10 @@
     "set": "A1",
     "number": 55,
     "rarity": "R",
-    "name": "Blastoise",
+    "name": {
+      "en": "Blastoise",
+      "fr": "Tortank"
+    },
     "image": "cPK_10_000550_00_KAMEX_R.webp",
     "packs": [
       "Pikachu"
@@ -573,7 +738,10 @@
     "set": "A1",
     "number": 56,
     "rarity": "RR",
-    "name": "Blastoise ex",
+    "name": {
+      "en": "Blastoise ex",
+      "fr": "Tortank-ex"
+    },
     "image": "cPK_10_000560_00_KAMEXex_RR.webp",
     "packs": [
       "Pikachu"
@@ -583,7 +751,10 @@
     "set": "A1",
     "number": 57,
     "rarity": "C",
-    "name": "Psyduck",
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    },
     "image": "cPK_10_000570_00_KODUCK_C.webp",
     "packs": [
       "Charizard",
@@ -595,7 +766,10 @@
     "set": "A1",
     "number": 58,
     "rarity": "U",
-    "name": "Golduck",
+    "name": {
+      "en": "Golduck",
+      "fr": "Akwakwak"
+    },
     "image": "cPK_10_000580_00_GOLDUCK_U.webp",
     "packs": [
       "Charizard",
@@ -607,7 +781,10 @@
     "set": "A1",
     "number": 59,
     "rarity": "C",
-    "name": "Poliwag",
+    "name": {
+      "en": "Poliwag",
+      "fr": "Ptitard"
+    },
     "image": "cPK_10_000590_00_NYOROMO_C.webp",
     "packs": [
       "Charizard"
@@ -617,7 +794,10 @@
     "set": "A1",
     "number": 60,
     "rarity": "U",
-    "name": "Poliwhirl",
+    "name": {
+      "en": "Poliwhirl",
+      "fr": "Têtarte"
+    },
     "image": "cPK_10_000600_00_NYOROZO_U.webp",
     "packs": [
       "Charizard"
@@ -627,7 +807,10 @@
     "set": "A1",
     "number": 61,
     "rarity": "R",
-    "name": "Poliwrath",
+    "name": {
+      "en": "Poliwrath",
+      "fr": "Tartard"
+    },
     "image": "cPK_10_000610_00_NYOROBON_R.webp",
     "packs": [
       "Charizard"
@@ -637,7 +820,10 @@
     "set": "A1",
     "number": 62,
     "rarity": "C",
-    "name": "Tentacool",
+    "name": {
+      "en": "Tentacool",
+      "fr": "Tentacool"
+    },
     "image": "cPK_10_000620_00_MENOKURAGE_C.webp",
     "packs": [
       "Mewtwo"
@@ -647,7 +833,10 @@
     "set": "A1",
     "number": 63,
     "rarity": "U",
-    "name": "Tentacruel",
+    "name": {
+      "en": "Tentacruel",
+      "fr": "Tentacruel"
+    },
     "image": "cPK_10_000630_00_DOKUKURAGE_U.webp",
     "packs": [
       "Mewtwo"
@@ -657,7 +846,10 @@
     "set": "A1",
     "number": 64,
     "rarity": "C",
-    "name": "Seel",
+    "name": {
+      "en": "Seel",
+      "fr": "Otaria"
+    },
     "image": "cPK_10_000640_00_PAWOU_C.webp",
     "packs": [
       "Pikachu"
@@ -667,7 +859,10 @@
     "set": "A1",
     "number": 65,
     "rarity": "U",
-    "name": "Dewgong",
+    "name": {
+      "en": "Dewgong",
+      "fr": "Lamantine"
+    },
     "image": "cPK_10_000650_00_JUGON_U.webp",
     "packs": [
       "Pikachu"
@@ -677,7 +872,10 @@
     "set": "A1",
     "number": 66,
     "rarity": "C",
-    "name": "Shellder",
+    "name": {
+      "en": "Shellder",
+      "fr": "Kokiyas"
+    },
     "image": "cPK_10_000660_00_SHELLDER_C.webp",
     "packs": [
       "Mewtwo"
@@ -687,7 +885,10 @@
     "set": "A1",
     "number": 67,
     "rarity": "U",
-    "name": "Cloyster",
+    "name": {
+      "en": "Cloyster",
+      "fr": "Crustabri"
+    },
     "image": "cPK_10_000670_00_PARSHEN_U.webp",
     "packs": [
       "Mewtwo"
@@ -697,7 +898,10 @@
     "set": "A1",
     "number": 68,
     "rarity": "C",
-    "name": "Krabby",
+    "name": {
+      "en": "Krabby",
+      "fr": "Krabby"
+    },
     "image": "cPK_10_000680_00_CRAB_C.webp",
     "packs": [
       "Mewtwo"
@@ -707,7 +911,10 @@
     "set": "A1",
     "number": 69,
     "rarity": "U",
-    "name": "Kingler",
+    "name": {
+      "en": "Kingler",
+      "fr": "Krabboss"
+    },
     "image": "cPK_10_000690_00_KINGLER_U.webp",
     "packs": [
       "Mewtwo"
@@ -717,7 +924,10 @@
     "set": "A1",
     "number": 70,
     "rarity": "C",
-    "name": "Horsea",
+    "name": {
+      "en": "Horsea",
+      "fr": "Hypotrempe"
+    },
     "image": "cPK_10_000700_00_TATTU_C.webp",
     "packs": [
       "Pikachu"
@@ -727,7 +937,10 @@
     "set": "A1",
     "number": 71,
     "rarity": "U",
-    "name": "Seadra",
+    "name": {
+      "en": "Seadra",
+      "fr": "Hypotrempe"
+    },
     "image": "cPK_10_000710_00_SEADRA_U.webp",
     "packs": [
       "Pikachu"
@@ -737,7 +950,10 @@
     "set": "A1",
     "number": 72,
     "rarity": "C",
-    "name": "Goldeen",
+    "name": {
+      "en": "Goldeen",
+      "fr": "Poissirène"
+    },
     "image": "cPK_10_000720_00_TOSAKINTO_C.webp",
     "packs": [
       "Pikachu"
@@ -747,7 +963,10 @@
     "set": "A1",
     "number": 73,
     "rarity": "C",
-    "name": "Seaking",
+    "name": {
+      "en": "Seaking",
+      "fr": "Poissoroy"
+    },
     "image": "cPK_10_000730_00_AZUMAO_C.webp",
     "packs": [
       "Pikachu"
@@ -757,7 +976,10 @@
     "set": "A1",
     "number": 74,
     "rarity": "C",
-    "name": "Staryu",
+    "name": {
+      "en": "Staryu",
+      "fr": "Stari"
+    },
     "image": "cPK_10_000740_00_HITODEMAN_C.webp",
     "packs": [
       "Charizard"
@@ -767,7 +989,10 @@
     "set": "A1",
     "number": 75,
     "rarity": "U",
-    "name": "Starmie",
+    "name": {
+      "en": "Starmie",
+      "fr": "Staross"
+    },
     "image": "cPK_10_000750_00_STARMIE_U.webp",
     "packs": [
       "Charizard"
@@ -777,7 +1002,10 @@
     "set": "A1",
     "number": 76,
     "rarity": "RR",
-    "name": "Starmie ex",
+    "name": {
+      "en": "Starmie ex",
+      "fr": "Staross-ex"
+    },
     "image": "cPK_10_000760_00_STARMIEex_RR.webp",
     "packs": [
       "Charizard"
@@ -787,7 +1015,10 @@
     "set": "A1",
     "number": 77,
     "rarity": "C",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_10_000770_00_KOIKING_C.webp",
     "packs": [
       "Pikachu"
@@ -797,7 +1028,10 @@
     "set": "A1",
     "number": 78,
     "rarity": "R",
-    "name": "Gyarados",
+    "name": {
+      "en": "Gyarados",
+      "fr": "Léviator"
+    },
     "image": "cPK_10_000780_00_GYARADOS_R.webp",
     "packs": [
       "Pikachu"
@@ -807,7 +1041,10 @@
     "set": "A1",
     "number": 79,
     "rarity": "R",
-    "name": "Lapras",
+    "name": {
+      "en": "Lapras",
+      "fr": "Lokhlass"
+    },
     "image": "cPK_10_000790_00_LAPLACE_R.webp",
     "packs": [
       "Charizard"
@@ -817,7 +1054,10 @@
     "set": "A1",
     "number": 80,
     "rarity": "R",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_10_000800_00_SHOWERS_R.webp",
     "packs": [
       "Mewtwo"
@@ -827,7 +1067,10 @@
     "set": "A1",
     "number": 81,
     "rarity": "U",
-    "name": "Omanyte",
+    "name": {
+      "en": "Omanyte",
+      "fr": "Amonita"
+    },
     "image": "cPK_10_000810_00_OMNITE_U.webp",
     "packs": [
       "Pikachu"
@@ -837,7 +1080,10 @@
     "set": "A1",
     "number": 82,
     "rarity": "R",
-    "name": "Omastar",
+    "name": {
+      "en": "Omastar",
+      "fr": "Amonistar"
+    },
     "image": "cPK_10_000820_00_OMSTAR_R.webp",
     "packs": [
       "Pikachu"
@@ -847,7 +1093,10 @@
     "set": "A1",
     "number": 83,
     "rarity": "R",
-    "name": "Articuno",
+    "name": {
+      "en": "Articuno",
+      "fr": "Artikodin"
+    },
     "image": "cPK_10_000830_00_FREEZER_R.webp",
     "packs": [
       "Mewtwo"
@@ -857,7 +1106,10 @@
     "set": "A1",
     "number": 84,
     "rarity": "RR",
-    "name": "Articuno ex",
+    "name": {
+      "en": "Articuno ex",
+      "fr": "Artikodin-ex"
+    },
     "image": "cPK_10_000840_00_FREEZERex_RR.webp",
     "packs": [
       "Mewtwo"
@@ -867,7 +1119,10 @@
     "set": "A1",
     "number": 85,
     "rarity": "C",
-    "name": "Ducklett",
+    "name": {
+      "en": "Ducklett",
+      "fr": "Couaneton"
+    },
     "image": "cPK_10_000850_00_KOARUHIE_C.webp",
     "packs": [
       "Charizard"
@@ -877,7 +1132,10 @@
     "set": "A1",
     "number": 86,
     "rarity": "U",
-    "name": "Swanna",
+    "name": {
+      "en": "Swanna",
+      "fr": "Lakmécygne"
+    },
     "image": "cPK_10_000860_00_SWANNA_U.webp",
     "packs": [
       "Charizard"
@@ -887,7 +1145,10 @@
     "set": "A1",
     "number": 87,
     "rarity": "C",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_10_000870_00_KEROMATSU_C.webp",
     "packs": [
       "Charizard"
@@ -897,7 +1158,10 @@
     "set": "A1",
     "number": 88,
     "rarity": "U",
-    "name": "Frogadier",
+    "name": {
+      "en": "Frogadier",
+      "fr": "Croâporal"
+    },
     "image": "cPK_10_000880_00_GEKOGASHIRA_U.webp",
     "packs": [
       "Charizard"
@@ -907,7 +1171,10 @@
     "set": "A1",
     "number": 89,
     "rarity": "R",
-    "name": "Greninja",
+    "name": {
+      "en": "Greninja",
+      "fr": "Amphinobi"
+    },
     "image": "cPK_10_000890_00_GEKKOUGA_R.webp",
     "packs": [
       "Charizard"
@@ -917,7 +1184,10 @@
     "set": "A1",
     "number": 90,
     "rarity": "C",
-    "name": "Pyukumuku",
+    "name": {
+      "en": "Pyukumuku",
+      "fr": "Concombaffe"
+    },
     "image": "cPK_10_000900_00_NAMAKOBUSHI_C.webp",
     "packs": [
       "Charizard"
@@ -927,7 +1197,10 @@
     "set": "A1",
     "number": 91,
     "rarity": "U",
-    "name": "Bruxish",
+    "name": {
+      "en": "Bruxish",
+      "fr": "Denticrisse"
+    },
     "image": "cPK_10_000910_00_HAGIGISHIRI_U.webp",
     "packs": [
       "Charizard",
@@ -939,7 +1212,10 @@
     "set": "A1",
     "number": 92,
     "rarity": "C",
-    "name": "Snom",
+    "name": {
+      "en": "Snom",
+      "fr": "Frissonille"
+    },
     "image": "cPK_10_000920_00_YUKIHAMI_C.webp",
     "packs": [
       "Charizard",
@@ -951,7 +1227,10 @@
     "set": "A1",
     "number": 93,
     "rarity": "U",
-    "name": "Frosmoth",
+    "name": {
+      "en": "Frosmoth",
+      "fr": "Beldeneige"
+    },
     "image": "cPK_10_000930_00_MOTHNOW_U.webp",
     "packs": [
       "Charizard",
@@ -963,7 +1242,10 @@
     "set": "A1",
     "number": 94,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_10_000940_00_PIKACHU_C.webp",
     "packs": [
       "Pikachu"
@@ -973,7 +1255,10 @@
     "set": "A1",
     "number": 95,
     "rarity": "R",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "image": "cPK_10_000950_00_RAICHU_R.webp",
     "packs": [
       "Pikachu"
@@ -983,7 +1268,10 @@
     "set": "A1",
     "number": 96,
     "rarity": "RR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_10_000960_00_PIKACHUex_RR.webp",
     "packs": [
       "Pikachu"
@@ -993,7 +1281,10 @@
     "set": "A1",
     "number": 97,
     "rarity": "C",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_10_000970_00_COIL_C.webp",
     "packs": [
       "Pikachu"
@@ -1003,7 +1294,10 @@
     "set": "A1",
     "number": 98,
     "rarity": "R",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "image": "cPK_10_000980_00_RARECOIL_R.webp",
     "packs": [
       "Pikachu"
@@ -1013,7 +1307,10 @@
     "set": "A1",
     "number": 99,
     "rarity": "C",
-    "name": "Voltorb",
+    "name": {
+      "en": "Voltorb",
+      "fr": "Voltorbe"
+    },
     "image": "cPK_10_000990_00_BIRIRIDAMA_C.webp",
     "packs": [
       "Pikachu"
@@ -1023,7 +1320,10 @@
     "set": "A1",
     "number": 100,
     "rarity": "U",
-    "name": "Electrode",
+    "name": {
+      "en": "Electrode",
+      "fr": "Électrode"
+    },
     "image": "cPK_10_001000_00_MARUMINE_U.webp",
     "packs": [
       "Pikachu"
@@ -1033,7 +1333,10 @@
     "set": "A1",
     "number": 101,
     "rarity": "C",
-    "name": "Electabuzz",
+    "name": {
+      "en": "Electabuzz",
+      "fr": "Élektek"
+    },
     "image": "cPK_10_001010_00_ELEBOO_C.webp",
     "packs": [
       "Pikachu"
@@ -1043,7 +1346,10 @@
     "set": "A1",
     "number": 102,
     "rarity": "R",
-    "name": "Jolteon",
+    "name": {
+      "en": "Jolteon",
+      "fr": "Voltali"
+    },
     "image": "cPK_10_001020_00_THUNDERS_R.webp",
     "packs": [
       "Pikachu"
@@ -1053,7 +1359,10 @@
     "set": "A1",
     "number": 103,
     "rarity": "R",
-    "name": "Zapdos",
+    "name": {
+      "en": "Zapdos",
+      "fr": "Électhor"
+    },
     "image": "cPK_10_001030_00_THUNDER_R.webp",
     "packs": [
       "Pikachu"
@@ -1063,7 +1372,10 @@
     "set": "A1",
     "number": 104,
     "rarity": "RR",
-    "name": "Zapdos ex",
+    "name": {
+      "en": "Zapdos ex",
+      "fr": "Électhor-ex"
+    },
     "image": "cPK_10_001040_00_THUNDERex_RR.webp",
     "packs": [
       "Pikachu"
@@ -1073,7 +1385,10 @@
     "set": "A1",
     "number": 105,
     "rarity": "C",
-    "name": "Blitzle",
+    "name": {
+      "en": "Blitzle",
+      "fr": "Zébibron"
+    },
     "image": "cPK_10_001050_00_SHIMAMA_C.webp",
     "packs": [
       "Charizard",
@@ -1085,7 +1400,10 @@
     "set": "A1",
     "number": 106,
     "rarity": "U",
-    "name": "Zebstrika",
+    "name": {
+      "en": "Zebstrika",
+      "fr": "Zéblitz"
+    },
     "image": "cPK_10_001060_00_ZEBRAIKA_U.webp",
     "packs": [
       "Charizard",
@@ -1097,7 +1415,10 @@
     "set": "A1",
     "number": 107,
     "rarity": "C",
-    "name": "Tynamo",
+    "name": {
+      "en": "Tynamo",
+      "fr": "Anchwatt"
+    },
     "image": "cPK_10_001070_00_SHIBISHIRASU_C.webp",
     "packs": [
       "Mewtwo"
@@ -1107,7 +1428,10 @@
     "set": "A1",
     "number": 108,
     "rarity": "U",
-    "name": "Eelektrik",
+    "name": {
+      "en": "Eelektrik",
+      "fr": "Lampéroie"
+    },
     "image": "cPK_10_001080_00_SHIBIBEEL_U.webp",
     "packs": [
       "Mewtwo"
@@ -1117,7 +1441,10 @@
     "set": "A1",
     "number": 109,
     "rarity": "R",
-    "name": "Eelektross",
+    "name": {
+      "en": "Eelektross",
+      "fr": "Ohmassacre"
+    },
     "image": "cPK_10_001090_00_SHIBIRUDON_R.webp",
     "packs": [
       "Mewtwo"
@@ -1127,7 +1454,10 @@
     "set": "A1",
     "number": 110,
     "rarity": "C",
-    "name": "Helioptile",
+    "name": {
+      "en": "Helioptile",
+      "fr": "Galvaran"
+    },
     "image": "cPK_10_001100_00_ERIKITERU_C.webp",
     "packs": [
       "Charizard",
@@ -1139,7 +1469,10 @@
     "set": "A1",
     "number": 111,
     "rarity": "C",
-    "name": "Heliolisk",
+    "name": {
+      "en": "Heliolisk",
+      "fr": "Iguolta"
+    },
     "image": "cPK_10_001110_00_ELEZARD_C.webp",
     "packs": [
       "Charizard",
@@ -1151,7 +1484,10 @@
     "set": "A1",
     "number": 112,
     "rarity": "U",
-    "name": "Pincurchin",
+    "name": {
+      "en": "Pincurchin",
+      "fr": "Wattapik"
+    },
     "image": "cPK_10_001120_00_BACHINUNI_U.webp",
     "packs": [
       "Charizard",
@@ -1163,7 +1499,10 @@
     "set": "A1",
     "number": 113,
     "rarity": "C",
-    "name": "Clefairy",
+    "name": {
+      "en": "Clefairy",
+      "fr": "Mélofée"
+    },
     "image": "cPK_10_001130_00_PIPPI_C.webp",
     "packs": [
       "Pikachu"
@@ -1173,7 +1512,10 @@
     "set": "A1",
     "number": 114,
     "rarity": "U",
-    "name": "Clefable",
+    "name": {
+      "en": "Clefable",
+      "fr": "Mélodelfe"
+    },
     "image": "cPK_10_001140_00_PIXY_U.webp",
     "packs": [
       "Pikachu"
@@ -1183,7 +1525,10 @@
     "set": "A1",
     "number": 115,
     "rarity": "C",
-    "name": "Abra",
+    "name": {
+      "en": "Abra",
+      "fr": "Abra"
+    },
     "image": "cPK_10_001150_00_CASEY_C.webp",
     "packs": [
       "Charizard"
@@ -1193,7 +1538,10 @@
     "set": "A1",
     "number": 116,
     "rarity": "U",
-    "name": "Kadabra",
+    "name": {
+      "en": "Kadabra",
+      "fr": "Kadabra"
+    },
     "image": "cPK_10_001160_00_YUNGERER_U.webp",
     "packs": [
       "Charizard"
@@ -1203,7 +1551,10 @@
     "set": "A1",
     "number": 117,
     "rarity": "R",
-    "name": "Alakazam",
+    "name": {
+      "en": "Alakazam",
+      "fr": "Alakazam"
+    },
     "image": "cPK_10_001170_00_FOODIN_R.webp",
     "packs": [
       "Charizard"
@@ -1213,7 +1564,10 @@
     "set": "A1",
     "number": 118,
     "rarity": "C",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "image": "cPK_10_001180_00_YADON_C.webp",
     "packs": [
       "Charizard",
@@ -1225,7 +1579,10 @@
     "set": "A1",
     "number": 119,
     "rarity": "U",
-    "name": "Slowbro",
+    "name": {
+      "en": "Slowbro",
+      "fr": "Flagadoss"
+    },
     "image": "cPK_10_001190_00_YADORAN_U.webp",
     "packs": [
       "Charizard",
@@ -1237,7 +1594,10 @@
     "set": "A1",
     "number": 120,
     "rarity": "C",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "image": "cPK_10_001200_00_GHOS_C.webp",
     "packs": [
       "Mewtwo"
@@ -1247,7 +1607,10 @@
     "set": "A1",
     "number": 121,
     "rarity": "U",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "image": "cPK_10_001210_00_GHOST_U.webp",
     "packs": [
       "Mewtwo"
@@ -1257,7 +1620,10 @@
     "set": "A1",
     "number": 122,
     "rarity": "R",
-    "name": "Gengar",
+    "name": {
+      "en": "Gengar",
+      "fr": "Ectoplasma"
+    },
     "image": "cPK_10_001220_00_GANGAR_R.webp",
     "packs": [
       "Mewtwo"
@@ -1267,7 +1633,10 @@
     "set": "A1",
     "number": 123,
     "rarity": "RR",
-    "name": "Gengar ex",
+    "name": {
+      "en": "Gengar ex",
+      "fr": "Ectoplasma-ex"
+    },
     "image": "cPK_10_001230_00_GANGARex_RR.webp",
     "packs": [
       "Mewtwo"
@@ -1277,7 +1646,10 @@
     "set": "A1",
     "number": 124,
     "rarity": "C",
-    "name": "Drowzee",
+    "name": {
+      "en": "Drowzee",
+      "fr": "Soporifik"
+    },
     "image": "cPK_10_001240_00_SLEEPE_C.webp",
     "packs": [
       "Pikachu"
@@ -1287,7 +1659,10 @@
     "set": "A1",
     "number": 125,
     "rarity": "R",
-    "name": "Hypno",
+    "name": {
+      "en": "Hypno",
+      "fr": "Hypnomade"
+    },
     "image": "cPK_10_001250_00_SLEEPER_R.webp",
     "packs": [
       "Pikachu"
@@ -1297,7 +1672,10 @@
     "set": "A1",
     "number": 126,
     "rarity": "U",
-    "name": "Mr. Mime",
+    "name": {
+      "en": "Mr. Mime",
+      "fr": "M. Mime"
+    },
     "image": "cPK_10_001260_00_BARRIERD_U.webp",
     "packs": [
       "Mewtwo"
@@ -1307,7 +1685,10 @@
     "set": "A1",
     "number": 127,
     "rarity": "C",
-    "name": "Jynx",
+    "name": {
+      "en": "Jynx",
+      "fr": "Lippoutou"
+    },
     "image": "cPK_10_001270_00_ROUGELA_C.webp",
     "packs": [
       "Mewtwo"
@@ -1317,7 +1698,10 @@
     "set": "A1",
     "number": 128,
     "rarity": "R",
-    "name": "Mewtwo",
+    "name": {
+      "en": "Mewtwo",
+      "fr": "Mewtwo"
+    },
     "image": "cPK_10_001280_00_MEWTWO_R.webp",
     "packs": [
       "Mewtwo"
@@ -1327,7 +1711,10 @@
     "set": "A1",
     "number": 129,
     "rarity": "RR",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_10_001290_00_MEWTWOex_RR.webp",
     "packs": [
       "Mewtwo"
@@ -1337,7 +1724,10 @@
     "set": "A1",
     "number": 130,
     "rarity": "C",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "image": "cPK_10_001300_00_RALTS_C.webp",
     "packs": [
       "Mewtwo"
@@ -1347,7 +1737,10 @@
     "set": "A1",
     "number": 131,
     "rarity": "U",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "image": "cPK_10_001310_00_KIRLIA_U.webp",
     "packs": [
       "Mewtwo"
@@ -1357,7 +1750,10 @@
     "set": "A1",
     "number": 132,
     "rarity": "R",
-    "name": "Gardevoir",
+    "name": {
+      "en": "Gardevoir",
+      "fr": "Gardevoir"
+    },
     "image": "cPK_10_001320_00_SIRNIGHT_R.webp",
     "packs": [
       "Mewtwo"
@@ -1367,7 +1763,10 @@
     "set": "A1",
     "number": 133,
     "rarity": "C",
-    "name": "Woobat",
+    "name": {
+      "en": "Woobat",
+      "fr": "Chovsourir"
+    },
     "image": "cPK_10_001330_00_KOROMORI_C.webp",
     "packs": [
       "Charizard",
@@ -1379,7 +1778,10 @@
     "set": "A1",
     "number": 134,
     "rarity": "C",
-    "name": "Swoobat",
+    "name": {
+      "en": "Swoobat",
+      "fr": "Rhinolove"
+    },
     "image": "cPK_10_001340_00_KOKOROMORI_C.webp",
     "packs": [
       "Charizard",
@@ -1391,7 +1793,10 @@
     "set": "A1",
     "number": 135,
     "rarity": "C",
-    "name": "Golett",
+    "name": {
+      "en": "Golett",
+      "fr": "Gringolem"
+    },
     "image": "cPK_10_001350_00_GOBIT_C.webp",
     "packs": [
       "Charizard",
@@ -1403,7 +1808,10 @@
     "set": "A1",
     "number": 136,
     "rarity": "U",
-    "name": "Golurk",
+    "name": {
+      "en": "Golurk",
+      "fr": "Golemastoc"
+    },
     "image": "cPK_10_001360_00_GOLOOG_U.webp",
     "packs": [
       "Charizard",
@@ -1415,7 +1823,10 @@
     "set": "A1",
     "number": 137,
     "rarity": "C",
-    "name": "Sandshrew",
+    "name": {
+      "en": "Sandshrew",
+      "fr": "Sabelette"
+    },
     "image": "cPK_10_001370_00_SAND_C.webp",
     "packs": [
       "Charizard",
@@ -1427,7 +1838,10 @@
     "set": "A1",
     "number": 138,
     "rarity": "U",
-    "name": "Sandslash",
+    "name": {
+      "en": "Sandslash",
+      "fr": "Sablaireau"
+    },
     "image": "cPK_10_001380_00_SANDPAN_U.webp",
     "packs": [
       "Charizard",
@@ -1439,7 +1853,10 @@
     "set": "A1",
     "number": 139,
     "rarity": "C",
-    "name": "Diglett",
+    "name": {
+      "en": "Diglett",
+      "fr": "Taupiqueur"
+    },
     "image": "cPK_10_001390_00_DIGDA_C.webp",
     "packs": [
       "Pikachu"
@@ -1449,7 +1866,10 @@
     "set": "A1",
     "number": 140,
     "rarity": "U",
-    "name": "Dugtrio",
+    "name": {
+      "en": "Dugtrio",
+      "fr": "Triopikeur"
+    },
     "image": "cPK_10_001400_00_DUGTRIO_U.webp",
     "packs": [
       "Pikachu"
@@ -1459,7 +1879,10 @@
     "set": "A1",
     "number": 141,
     "rarity": "C",
-    "name": "Mankey",
+    "name": {
+      "en": "Mankey",
+      "fr": "Férosinge"
+    },
     "image": "cPK_10_001410_00_MANKEY_C.webp",
     "packs": [
       "Charizard"
@@ -1469,7 +1892,10 @@
     "set": "A1",
     "number": 142,
     "rarity": "U",
-    "name": "Primeape",
+    "name": {
+      "en": "Primeape",
+      "fr": "Colossinge"
+    },
     "image": "cPK_10_001420_00_OKORIZARU_U.webp",
     "packs": [
       "Charizard"
@@ -1479,7 +1905,10 @@
     "set": "A1",
     "number": 143,
     "rarity": "C",
-    "name": "Machop",
+    "name": {
+      "en": "Machop",
+      "fr": "Machoc"
+    },
     "image": "cPK_10_001430_00_WANRIKY_C.webp",
     "packs": [
       "Charizard"
@@ -1489,7 +1918,10 @@
     "set": "A1",
     "number": 144,
     "rarity": "U",
-    "name": "Machoke",
+    "name": {
+      "en": "Machoke",
+      "fr": "Machopeur"
+    },
     "image": "cPK_10_001440_00_GORIKY_U.webp",
     "packs": [
       "Charizard"
@@ -1499,7 +1931,10 @@
     "set": "A1",
     "number": 145,
     "rarity": "R",
-    "name": "Machamp",
+    "name": {
+      "en": "Machamp",
+      "fr": "Machoc"
+    },
     "image": "cPK_10_001450_00_KAIRIKY_R.webp",
     "packs": [
       "Charizard"
@@ -1509,7 +1944,10 @@
     "set": "A1",
     "number": 146,
     "rarity": "RR",
-    "name": "Machamp ex",
+    "name": {
+      "en": "Machamp ex",
+      "fr": "Mackogneur-ex"
+    },
     "image": "cPK_10_001460_00_KAIRIKYex_RR.webp",
     "packs": [
       "Charizard"
@@ -1519,7 +1957,10 @@
     "set": "A1",
     "number": 147,
     "rarity": "C",
-    "name": "Geodude",
+    "name": {
+      "en": "Geodude",
+      "fr": "Racaillou"
+    },
     "image": "cPK_10_001470_00_ISITSUBUTE_C.webp",
     "packs": [
       "Pikachu"
@@ -1529,7 +1970,10 @@
     "set": "A1",
     "number": 148,
     "rarity": "U",
-    "name": "Graveler",
+    "name": {
+      "en": "Graveler",
+      "fr": "Gravalanch"
+    },
     "image": "cPK_10_001480_00_GOLONE_U.webp",
     "packs": [
       "Pikachu"
@@ -1539,7 +1983,10 @@
     "set": "A1",
     "number": 149,
     "rarity": "R",
-    "name": "Golem",
+    "name": {
+      "en": "Golem",
+      "fr": "Grolem"
+    },
     "image": "cPK_10_001490_00_GOLONYA_R.webp",
     "packs": [
       "Pikachu"
@@ -1549,7 +1996,10 @@
     "set": "A1",
     "number": 150,
     "rarity": "U",
-    "name": "Onix",
+    "name": {
+      "en": "Onix",
+      "fr": "Onix"
+    },
     "image": "cPK_10_001500_00_IWARK_U.webp",
     "packs": [
       "Pikachu"
@@ -1559,7 +2009,10 @@
     "set": "A1",
     "number": 151,
     "rarity": "C",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "image": "cPK_10_001510_00_KARAKARA_C.webp",
     "packs": [
       "Mewtwo"
@@ -1569,7 +2022,10 @@
     "set": "A1",
     "number": 152,
     "rarity": "U",
-    "name": "Marowak",
+    "name": {
+      "en": "Marowak",
+      "fr": "Ossatueur"
+    },
     "image": "cPK_10_001520_00_GARAGARA_U.webp",
     "packs": [
       "Mewtwo"
@@ -1579,7 +2035,10 @@
     "set": "A1",
     "number": 153,
     "rarity": "RR",
-    "name": "Marowak ex",
+    "name": {
+      "en": "Marowak ex",
+      "fr": "Ossatueur-ex"
+    },
     "image": "cPK_10_001530_00_GARAGARAex_RR.webp",
     "packs": [
       "Mewtwo"
@@ -1589,7 +2048,10 @@
     "set": "A1",
     "number": 154,
     "rarity": "C",
-    "name": "Hitmonlee",
+    "name": {
+      "en": "Hitmonlee",
+      "fr": "Kicklee"
+    },
     "image": "cPK_10_001540_00_SAWAMULAR_C.webp",
     "packs": [
       "Mewtwo"
@@ -1599,7 +2061,10 @@
     "set": "A1",
     "number": 155,
     "rarity": "C",
-    "name": "Hitmonchan",
+    "name": {
+      "en": "Hitmonchan",
+      "fr": "Tygnon"
+    },
     "image": "cPK_10_001550_00_EBIWALAR_C.webp",
     "packs": [
       "Charizard"
@@ -1609,7 +2074,10 @@
     "set": "A1",
     "number": 156,
     "rarity": "C",
-    "name": "Rhyhorn",
+    "name": {
+      "en": "Rhyhorn",
+      "fr": "Rhinocorne"
+    },
     "image": "cPK_10_001560_00_SIHORN_C.webp",
     "packs": [
       "Mewtwo"
@@ -1619,7 +2087,10 @@
     "set": "A1",
     "number": 157,
     "rarity": "U",
-    "name": "Rhydon",
+    "name": {
+      "en": "Rhydon",
+      "fr": "Rhinoféros"
+    },
     "image": "cPK_10_001570_00_SIDON_U.webp",
     "packs": [
       "Mewtwo"
@@ -1629,7 +2100,10 @@
     "set": "A1",
     "number": 158,
     "rarity": "U",
-    "name": "Kabuto",
+    "name": {
+      "en": "Kabuto",
+      "fr": "Kabuto"
+    },
     "image": "cPK_10_001580_00_KABUTO_U.webp",
     "packs": [
       "Charizard"
@@ -1639,7 +2113,10 @@
     "set": "A1",
     "number": 159,
     "rarity": "R",
-    "name": "Kabutops",
+    "name": {
+      "en": "Kabutops",
+      "fr": "Kabutops"
+    },
     "image": "cPK_10_001590_00_KABUTOPS_R.webp",
     "packs": [
       "Charizard"
@@ -1649,7 +2126,10 @@
     "set": "A1",
     "number": 160,
     "rarity": "C",
-    "name": "Mienfoo",
+    "name": {
+      "en": "Mienfoo",
+      "fr": "Kungfouine"
+    },
     "image": "cPK_10_001600_00_KOJOFU_C.webp",
     "packs": [
       "Pikachu"
@@ -1659,7 +2139,10 @@
     "set": "A1",
     "number": 161,
     "rarity": "U",
-    "name": "Mienshao",
+    "name": {
+      "en": "Mienshao",
+      "fr": "Shaofouine"
+    },
     "image": "cPK_10_001610_00_KOJONDO_U.webp",
     "packs": [
       "Pikachu"
@@ -1669,7 +2152,10 @@
     "set": "A1",
     "number": 162,
     "rarity": "C",
-    "name": "Clobbopus",
+    "name": {
+      "en": "Clobbopus",
+      "fr": "Poulpaf"
+    },
     "image": "cPK_10_001620_00_TATAKKO_C.webp",
     "packs": [
       "Charizard",
@@ -1681,7 +2167,10 @@
     "set": "A1",
     "number": 163,
     "rarity": "U",
-    "name": "Grapploct",
+    "name": {
+      "en": "Grapploct",
+      "fr": "Krakos"
+    },
     "image": "cPK_10_001630_00_OTOSUPUS_U.webp",
     "packs": [
       "Charizard",
@@ -1693,7 +2182,10 @@
     "set": "A1",
     "number": 164,
     "rarity": "C",
-    "name": "Ekans",
+    "name": {
+      "en": "Ekans",
+      "fr": "Abo"
+    },
     "image": "cPK_10_001640_00_ARBO_C.webp",
     "packs": [
       "Charizard",
@@ -1705,7 +2197,10 @@
     "set": "A1",
     "number": 165,
     "rarity": "U",
-    "name": "Arbok",
+    "name": {
+      "en": "Arbok",
+      "fr": "Arbok"
+    },
     "image": "cPK_10_001650_00_ARBOK_U.webp",
     "packs": [
       "Charizard",
@@ -1717,7 +2212,10 @@
     "set": "A1",
     "number": 166,
     "rarity": "C",
-    "name": "Nidoran♀",
+    "name": {
+      "en": "Nidoran♀",
+      "fr": "Nidoran♂"
+    },
     "image": "cPK_10_001660_00_NIDORAN♀_C.webp",
     "packs": [
       "Pikachu"
@@ -1727,7 +2225,10 @@
     "set": "A1",
     "number": 167,
     "rarity": "U",
-    "name": "Nidorina",
+    "name": {
+      "en": "Nidorina",
+      "fr": "Nidorina"
+    },
     "image": "cPK_10_001670_00_NIDORINA_U.webp",
     "packs": [
       "Pikachu"
@@ -1737,7 +2238,10 @@
     "set": "A1",
     "number": 168,
     "rarity": "R",
-    "name": "Nidoqueen",
+    "name": {
+      "en": "Nidoqueen",
+      "fr": "Nidoqueen"
+    },
     "image": "cPK_10_001680_00_NIDOQUEEN_R.webp",
     "packs": [
       "Pikachu"
@@ -1747,7 +2251,10 @@
     "set": "A1",
     "number": 169,
     "rarity": "C",
-    "name": "Nidoran♂",
+    "name": {
+      "en": "Nidoran♂",
+      "fr": "Nidoran♂"
+    },
     "image": "cPK_10_001690_00_NIDORAN♂_C.webp",
     "packs": [
       "Pikachu"
@@ -1757,7 +2264,10 @@
     "set": "A1",
     "number": 170,
     "rarity": "U",
-    "name": "Nidorino",
+    "name": {
+      "en": "Nidorino",
+      "fr": "Nidorino"
+    },
     "image": "cPK_10_001700_00_NIDORINO_U.webp",
     "packs": [
       "Pikachu"
@@ -1767,7 +2277,10 @@
     "set": "A1",
     "number": 171,
     "rarity": "R",
-    "name": "Nidoking",
+    "name": {
+      "en": "Nidoking",
+      "fr": "Nidoking"
+    },
     "image": "cPK_10_001710_00_NIDOKING_R.webp",
     "packs": [
       "Pikachu"
@@ -1777,7 +2290,10 @@
     "set": "A1",
     "number": 172,
     "rarity": "C",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "image": "cPK_10_001720_00_ZUBAT_C.webp",
     "packs": [
       "Mewtwo"
@@ -1787,7 +2303,10 @@
     "set": "A1",
     "number": 173,
     "rarity": "U",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "image": "cPK_10_001730_00_GOLBAT_U.webp",
     "packs": [
       "Mewtwo"
@@ -1797,7 +2316,10 @@
     "set": "A1",
     "number": 174,
     "rarity": "C",
-    "name": "Grimer",
+    "name": {
+      "en": "Grimer",
+      "fr": "Tadmorv"
+    },
     "image": "cPK_10_001740_00_BETBETER_C.webp",
     "packs": [
       "Mewtwo"
@@ -1807,7 +2329,10 @@
     "set": "A1",
     "number": 175,
     "rarity": "R",
-    "name": "Muk",
+    "name": {
+      "en": "Muk",
+      "fr": "Grotadmorv"
+    },
     "image": "cPK_10_001750_00_BETBETON_R.webp",
     "packs": [
       "Mewtwo"
@@ -1817,7 +2342,10 @@
     "set": "A1",
     "number": 176,
     "rarity": "C",
-    "name": "Koffing",
+    "name": {
+      "en": "Koffing",
+      "fr": "Smogo"
+    },
     "image": "cPK_10_001760_00_DOGARS_C.webp",
     "packs": [
       "Mewtwo"
@@ -1827,7 +2355,10 @@
     "set": "A1",
     "number": 177,
     "rarity": "R",
-    "name": "Weezing",
+    "name": {
+      "en": "Weezing",
+      "fr": "Smogogo"
+    },
     "image": "cPK_10_001770_00_MATADOGAS_R.webp",
     "packs": [
       "Mewtwo"
@@ -1837,7 +2368,10 @@
     "set": "A1",
     "number": 178,
     "rarity": "C",
-    "name": "Mawile",
+    "name": {
+      "en": "Mawile",
+      "fr": "Mysdibule"
+    },
     "image": "cPK_10_001780_00_KUCHEAT_C.webp",
     "packs": [
       "Charizard"
@@ -1847,7 +2381,10 @@
     "set": "A1",
     "number": 179,
     "rarity": "C",
-    "name": "Pawniard",
+    "name": {
+      "en": "Pawniard",
+      "fr": "Scalpion"
+    },
     "image": "cPK_10_001790_00_KOMATANA_C.webp",
     "packs": [
       "Charizard",
@@ -1859,7 +2396,10 @@
     "set": "A1",
     "number": 180,
     "rarity": "U",
-    "name": "Bisharp",
+    "name": {
+      "en": "Bisharp",
+      "fr": "Scalproie"
+    },
     "image": "cPK_10_001800_00_KIRIKIZAN_U.webp",
     "packs": [
       "Charizard",
@@ -1871,7 +2411,10 @@
     "set": "A1",
     "number": 181,
     "rarity": "C",
-    "name": "Meltan",
+    "name": {
+      "en": "Meltan",
+      "fr": "Meltan"
+    },
     "image": "cPK_10_001810_00_MELTAN_C.webp",
     "packs": [
       "Charizard"
@@ -1881,7 +2424,10 @@
     "set": "A1",
     "number": 182,
     "rarity": "R",
-    "name": "Melmetal",
+    "name": {
+      "en": "Melmetal",
+      "fr": "Melmetal"
+    },
     "image": "cPK_10_001820_00_MELMETAL_R.webp",
     "packs": [
       "Charizard"
@@ -1891,7 +2437,10 @@
     "set": "A1",
     "number": 183,
     "rarity": "C",
-    "name": "Dratini",
+    "name": {
+      "en": "Dratini",
+      "fr": "Minidraco"
+    },
     "image": "cPK_10_001830_00_MINIRYU_C.webp",
     "packs": [
       "Mewtwo"
@@ -1901,7 +2450,10 @@
     "set": "A1",
     "number": 184,
     "rarity": "U",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "image": "cPK_10_001840_00_HAKURYU_U.webp",
     "packs": [
       "Mewtwo"
@@ -1911,7 +2463,10 @@
     "set": "A1",
     "number": 185,
     "rarity": "R",
-    "name": "Dragonite",
+    "name": {
+      "en": "Dragonite",
+      "fr": "Dracolosse"
+    },
     "image": "cPK_10_001850_00_KAIRYU_R.webp",
     "packs": [
       "Mewtwo"
@@ -1921,7 +2476,10 @@
     "set": "A1",
     "number": 186,
     "rarity": "C",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_10_001860_00_POPPO_C.webp",
     "packs": [
       "Mewtwo"
@@ -1931,7 +2489,10 @@
     "set": "A1",
     "number": 187,
     "rarity": "C",
-    "name": "Pidgeotto",
+    "name": {
+      "en": "Pidgeotto",
+      "fr": "Roucoups"
+    },
     "image": "cPK_10_001870_00_PIGEON_C.webp",
     "packs": [
       "Mewtwo"
@@ -1941,7 +2502,10 @@
     "set": "A1",
     "number": 188,
     "rarity": "R",
-    "name": "Pidgeot",
+    "name": {
+      "en": "Pidgeot",
+      "fr": "Roucarnage"
+    },
     "image": "cPK_10_001880_00_PIGEOT_R.webp",
     "packs": [
       "Mewtwo"
@@ -1951,7 +2515,10 @@
     "set": "A1",
     "number": 189,
     "rarity": "C",
-    "name": "Rattata",
+    "name": {
+      "en": "Rattata",
+      "fr": "Rattata"
+    },
     "image": "cPK_10_001890_00_KORATTA_C.webp",
     "packs": [
       "Charizard",
@@ -1963,7 +2530,10 @@
     "set": "A1",
     "number": 190,
     "rarity": "C",
-    "name": "Raticate",
+    "name": {
+      "en": "Raticate",
+      "fr": "Rattatac"
+    },
     "image": "cPK_10_001900_00_RATTA_C.webp",
     "packs": [
       "Charizard",
@@ -1975,7 +2545,10 @@
     "set": "A1",
     "number": 191,
     "rarity": "C",
-    "name": "Spearow",
+    "name": {
+      "en": "Spearow",
+      "fr": "Piafabec"
+    },
     "image": "cPK_10_001910_00_ONISUZUME_C.webp",
     "packs": [
       "Charizard"
@@ -1985,7 +2558,10 @@
     "set": "A1",
     "number": 192,
     "rarity": "C",
-    "name": "Fearow",
+    "name": {
+      "en": "Fearow",
+      "fr": "Rapasdepic"
+    },
     "image": "cPK_10_001920_00_ONIDRILL_C.webp",
     "packs": [
       "Charizard"
@@ -1995,7 +2571,10 @@
     "set": "A1",
     "number": 193,
     "rarity": "C",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "image": "cPK_10_001930_00_PURIN_C.webp",
     "packs": [
       "Pikachu"
@@ -2005,7 +2584,10 @@
     "set": "A1",
     "number": 194,
     "rarity": "C",
-    "name": "Wigglytuff",
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    },
     "image": "cPK_10_001940_00_PUKURIN_C.webp",
     "packs": [
       "Pikachu"
@@ -2015,7 +2597,10 @@
     "set": "A1",
     "number": 195,
     "rarity": "RR",
-    "name": "Wigglytuff ex",
+    "name": {
+      "en": "Wigglytuff ex",
+      "fr": "Grodoudou-ex"
+    },
     "image": "cPK_10_001950_00_PUKURINex_RR.webp",
     "packs": [
       "Pikachu"
@@ -2025,7 +2610,10 @@
     "set": "A1",
     "number": 196,
     "rarity": "C",
-    "name": "Meowth",
+    "name": {
+      "en": "Meowth",
+      "fr": "Miaouss"
+    },
     "image": "cPK_10_001960_00_NYARTH_C.webp",
     "packs": [
       "Charizard"
@@ -2035,7 +2623,10 @@
     "set": "A1",
     "number": 197,
     "rarity": "U",
-    "name": "Persian",
+    "name": {
+      "en": "Persian",
+      "fr": "Persian"
+    },
     "image": "cPK_10_001970_00_PERSIAN_U.webp",
     "packs": [
       "Charizard"
@@ -2045,7 +2636,10 @@
     "set": "A1",
     "number": 198,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_10_001980_00_KAMONEGI_C.webp",
     "packs": [
       "Charizard",
@@ -2057,7 +2651,10 @@
     "set": "A1",
     "number": 199,
     "rarity": "C",
-    "name": "Doduo",
+    "name": {
+      "en": "Doduo",
+      "fr": "Doduo"
+    },
     "image": "cPK_10_001990_00_DODO_C.webp",
     "packs": [
       "Charizard",
@@ -2069,7 +2666,10 @@
     "set": "A1",
     "number": 200,
     "rarity": "U",
-    "name": "Dodrio",
+    "name": {
+      "en": "Dodrio",
+      "fr": "Dodrio"
+    },
     "image": "cPK_10_002000_00_DODORIO_U.webp",
     "packs": [
       "Charizard",
@@ -2081,7 +2681,10 @@
     "set": "A1",
     "number": 201,
     "rarity": "U",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_10_002010_00_BERORINGA_U.webp",
     "packs": [
       "Mewtwo"
@@ -2091,7 +2694,10 @@
     "set": "A1",
     "number": 202,
     "rarity": "U",
-    "name": "Chansey",
+    "name": {
+      "en": "Chansey",
+      "fr": "Leveinard"
+    },
     "image": "cPK_10_002020_00_LUCKY_U.webp",
     "packs": [
       "Pikachu"
@@ -2101,7 +2707,10 @@
     "set": "A1",
     "number": 203,
     "rarity": "R",
-    "name": "Kangaskhan",
+    "name": {
+      "en": "Kangaskhan",
+      "fr": "Kangourex"
+    },
     "image": "cPK_10_002030_00_GARURA_R.webp",
     "packs": [
       "Charizard"
@@ -2111,7 +2720,10 @@
     "set": "A1",
     "number": 204,
     "rarity": "U",
-    "name": "Tauros",
+    "name": {
+      "en": "Tauros",
+      "fr": "Tauros"
+    },
     "image": "cPK_10_002040_00_KENTAUROS_U.webp",
     "packs": [
       "Charizard"
@@ -2121,7 +2733,10 @@
     "set": "A1",
     "number": 205,
     "rarity": "R",
-    "name": "Ditto",
+    "name": {
+      "en": "Ditto",
+      "fr": "Métamorph"
+    },
     "image": "cPK_10_002050_00_METAMON_R.webp",
     "packs": [
       "Mewtwo"
@@ -2131,7 +2746,10 @@
     "set": "A1",
     "number": 206,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_002060_00_EIEVUI_C.webp",
     "packs": [
       "Charizard"
@@ -2141,7 +2759,10 @@
     "set": "A1",
     "number": 207,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_002060_01_EIEVUI_C.webp",
     "packs": [
       "Mewtwo"
@@ -2151,7 +2772,10 @@
     "set": "A1",
     "number": 208,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_002060_02_EIEVUI_C.webp",
     "packs": [
       "Pikachu"
@@ -2161,7 +2785,10 @@
     "set": "A1",
     "number": 209,
     "rarity": "U",
-    "name": "Porygon",
+    "name": {
+      "en": "Porygon",
+      "fr": "Porygon"
+    },
     "image": "cPK_10_002070_00_PORYGON_U.webp",
     "packs": [
       "Mewtwo"
@@ -2171,7 +2798,10 @@
     "set": "A1",
     "number": 210,
     "rarity": "R",
-    "name": "Aerodactyl",
+    "name": {
+      "en": "Aerodactyl",
+      "fr": "Ptéra"
+    },
     "image": "cPK_10_002080_00_PTERA_R.webp",
     "packs": [
       "Mewtwo"
@@ -2181,7 +2811,10 @@
     "set": "A1",
     "number": 211,
     "rarity": "R",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "image": "cPK_10_002090_00_KABIGON_R.webp",
     "packs": [
       "Pikachu"
@@ -2191,7 +2824,10 @@
     "set": "A1",
     "number": 212,
     "rarity": "C",
-    "name": "Minccino",
+    "name": {
+      "en": "Minccino",
+      "fr": "Chinchidou"
+    },
     "image": "cPK_10_002100_00_CHILLARMY_C.webp",
     "packs": [
       "Charizard",
@@ -2203,7 +2839,10 @@
     "set": "A1",
     "number": 213,
     "rarity": "U",
-    "name": "Cinccino",
+    "name": {
+      "en": "Cinccino",
+      "fr": "Pashmilla"
+    },
     "image": "cPK_10_002110_00_CHILLACCINO_U.webp",
     "packs": [
       "Charizard",
@@ -2215,7 +2854,10 @@
     "set": "A1",
     "number": 214,
     "rarity": "C",
-    "name": "Wooloo",
+    "name": {
+      "en": "Wooloo",
+      "fr": "Moumouton"
+    },
     "image": "cPK_10_002120_00_WOOLUU_C.webp",
     "packs": [
       "Charizard",
@@ -2227,7 +2869,10 @@
     "set": "A1",
     "number": 215,
     "rarity": "C",
-    "name": "Dubwool",
+    "name": {
+      "en": "Dubwool",
+      "fr": "Moumouflon"
+    },
     "image": "cPK_10_002130_00_BAIWOOLUU_C.webp",
     "packs": [
       "Charizard",
@@ -2239,7 +2884,10 @@
     "set": "A1",
     "number": 216,
     "rarity": "C",
-    "name": "Helix Fossil",
+    "name": {
+      "en": "Helix Fossil",
+      "fr": "Fossile Nautile"
+    },
     "image": "cTR_10_000080_00_KAINOKASEKI_C.webp",
     "packs": [
       "Pikachu"
@@ -2249,7 +2897,10 @@
     "set": "A1",
     "number": 217,
     "rarity": "C",
-    "name": "Dome Fossil",
+    "name": {
+      "en": "Dome Fossil",
+      "fr": "Fossile Dôme"
+    },
     "image": "cTR_10_000090_00_KOURANOKASEKI_C.webp",
     "packs": [
       "Charizard"
@@ -2259,7 +2910,10 @@
     "set": "A1",
     "number": 218,
     "rarity": "C",
-    "name": "Old Amber",
+    "name": {
+      "en": "Old Amber",
+      "fr": "Vieil Ambre"
+    },
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
     "packs": [
       "Mewtwo"
@@ -2269,7 +2923,10 @@
     "set": "A1",
     "number": 219,
     "rarity": "U",
-    "name": "Erika",
+    "name": {
+      "en": "Erika",
+      "fr": "Erika"
+    },
     "image": "cTR_10_000110_00_ERIKA_U.webp",
     "packs": [
       "Charizard"
@@ -2279,7 +2936,10 @@
     "set": "A1",
     "number": 220,
     "rarity": "U",
-    "name": "Misty",
+    "name": {
+      "en": "Misty",
+      "fr": "Ondine"
+    },
     "image": "cTR_10_000120_00_KASUMI_U.webp",
     "packs": [
       "Pikachu"
@@ -2289,7 +2949,10 @@
     "set": "A1",
     "number": 221,
     "rarity": "U",
-    "name": "Blaine",
+    "name": {
+      "en": "Blaine",
+      "fr": "Auguste"
+    },
     "image": "cTR_10_000130_00_KATSURA_U.webp",
     "packs": [
       "Charizard"
@@ -2299,7 +2962,10 @@
     "set": "A1",
     "number": 222,
     "rarity": "U",
-    "name": "Koga",
+    "name": {
+      "en": "Koga",
+      "fr": "Koga"
+    },
     "image": "cTR_10_000140_00_KYOU_U.webp",
     "packs": [
       "Mewtwo"
@@ -2309,7 +2975,10 @@
     "set": "A1",
     "number": 223,
     "rarity": "U",
-    "name": "Giovanni",
+    "name": {
+      "en": "Giovanni",
+      "fr": "Giovanni"
+    },
     "image": "cTR_10_000150_00_SAKAKI_U.webp",
     "packs": [
       "Mewtwo"
@@ -2319,7 +2988,10 @@
     "set": "A1",
     "number": 224,
     "rarity": "U",
-    "name": "Brock",
+    "name": {
+      "en": "Brock",
+      "fr": "Pierre"
+    },
     "image": "cTR_10_000160_00_TAKESHI_U.webp",
     "packs": [
       "Pikachu"
@@ -2329,7 +3001,10 @@
     "set": "A1",
     "number": 225,
     "rarity": "U",
-    "name": "Sabrina",
+    "name": {
+      "en": "Sabrina",
+      "fr": "Morgane"
+    },
     "image": "cTR_10_000170_00_NATSUME_U.webp",
     "packs": [
       "Charizard"
@@ -2339,7 +3014,10 @@
     "set": "A1",
     "number": 226,
     "rarity": "U",
-    "name": "Lt. Surge",
+    "name": {
+      "en": "Lt. Surge",
+      "fr": "Major Bob"
+    },
     "image": "cTR_10_000180_00_MATISSE_U.webp",
     "packs": [
       "Pikachu"
@@ -2349,7 +3027,10 @@
     "set": "A1",
     "number": 227,
     "rarity": "AR",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "image": "cPK_20_000010_00_FUSHIGIDANE_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2359,7 +3040,10 @@
     "set": "A1",
     "number": 228,
     "rarity": "AR",
-    "name": "Gloom",
+    "name": {
+      "en": "Gloom",
+      "fr": "Ortide"
+    },
     "image": "cPK_20_000120_00_KUSAIHANA_AR.webp",
     "packs": [
       "Charizard"
@@ -2369,7 +3053,10 @@
     "set": "A1",
     "number": 229,
     "rarity": "AR",
-    "name": "Pinsir",
+    "name": {
+      "en": "Pinsir",
+      "fr": "Scarabrute"
+    },
     "image": "cPK_20_000260_00_KAILIOS_AR.webp",
     "packs": [
       "Charizard"
@@ -2379,7 +3066,10 @@
     "set": "A1",
     "number": 230,
     "rarity": "AR",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_20_000330_00_HITOKAGE_AR.webp",
     "packs": [
       "Charizard"
@@ -2389,7 +3079,10 @@
     "set": "A1",
     "number": 231,
     "rarity": "AR",
-    "name": "Rapidash",
+    "name": {
+      "en": "Rapidash",
+      "fr": "Galopa"
+    },
     "image": "cPK_20_000430_00_GALLOP_AR.webp",
     "packs": [
       "Charizard"
@@ -2399,7 +3092,10 @@
     "set": "A1",
     "number": 232,
     "rarity": "AR",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "image": "cPK_20_000530_00_ZENIGAME_AR.webp",
     "packs": [
       "Pikachu"
@@ -2409,7 +3105,10 @@
     "set": "A1",
     "number": 233,
     "rarity": "AR",
-    "name": "Gyarados",
+    "name": {
+      "en": "Gyarados",
+      "fr": "Léviator"
+    },
     "image": "cPK_20_000780_00_GYARADOS_AR.webp",
     "packs": [
       "Pikachu"
@@ -2419,7 +3118,10 @@
     "set": "A1",
     "number": 234,
     "rarity": "AR",
-    "name": "Lapras",
+    "name": {
+      "en": "Lapras",
+      "fr": "Lokhlass"
+    },
     "image": "cPK_20_000790_00_LAPLACE_AR.webp",
     "packs": [
       "Charizard"
@@ -2429,7 +3131,10 @@
     "set": "A1",
     "number": 235,
     "rarity": "AR",
-    "name": "Electrode",
+    "name": {
+      "en": "Electrode",
+      "fr": "Électrode"
+    },
     "image": "cPK_20_001000_00_MARUMINE_AR.webp",
     "packs": [
       "Pikachu"
@@ -2439,7 +3144,10 @@
     "set": "A1",
     "number": 236,
     "rarity": "AR",
-    "name": "Alakazam",
+    "name": {
+      "en": "Alakazam",
+      "fr": "Alakazam"
+    },
     "image": "cPK_20_001170_00_FOODIN_AR.webp",
     "packs": [
       "Charizard"
@@ -2449,7 +3157,10 @@
     "set": "A1",
     "number": 237,
     "rarity": "AR",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "image": "cPK_20_001180_00_YADON_AR.webp",
     "packs": [
       "Charizard"
@@ -2459,7 +3170,10 @@
     "set": "A1",
     "number": 238,
     "rarity": "AR",
-    "name": "Diglett",
+    "name": {
+      "en": "Diglett",
+      "fr": "Taupiqueur"
+    },
     "image": "cPK_20_001390_00_DIGDA_AR.webp",
     "packs": [
       "Pikachu"
@@ -2469,7 +3183,10 @@
     "set": "A1",
     "number": 239,
     "rarity": "AR",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "image": "cPK_20_001510_00_KARAKARA_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2479,7 +3196,10 @@
     "set": "A1",
     "number": 240,
     "rarity": "AR",
-    "name": "Nidoqueen",
+    "name": {
+      "en": "Nidoqueen",
+      "fr": "Nidoqueen"
+    },
     "image": "cPK_20_001680_00_NIDOQUEEN_AR.webp",
     "packs": [
       "Pikachu"
@@ -2489,7 +3209,10 @@
     "set": "A1",
     "number": 241,
     "rarity": "AR",
-    "name": "Nidoking",
+    "name": {
+      "en": "Nidoking",
+      "fr": "Nidoking"
+    },
     "image": "cPK_20_001710_00_NIDOKING_AR.webp",
     "packs": [
       "Pikachu"
@@ -2499,7 +3222,10 @@
     "set": "A1",
     "number": 242,
     "rarity": "AR",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "image": "cPK_20_001730_00_GOLBAT_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2509,7 +3235,10 @@
     "set": "A1",
     "number": 243,
     "rarity": "AR",
-    "name": "Weezing",
+    "name": {
+      "en": "Weezing",
+      "fr": "Smogogo"
+    },
     "image": "cPK_20_001770_00_MATADOGAS_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2519,7 +3248,10 @@
     "set": "A1",
     "number": 244,
     "rarity": "AR",
-    "name": "Dragonite",
+    "name": {
+      "en": "Dragonite",
+      "fr": "Dracolosse"
+    },
     "image": "cPK_20_001850_00_KAIRYU_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2529,7 +3261,10 @@
     "set": "A1",
     "number": 245,
     "rarity": "AR",
-    "name": "Pidgeot",
+    "name": {
+      "en": "Pidgeot",
+      "fr": "Roucarnage"
+    },
     "image": "cPK_20_001880_00_PIGEOT_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2539,7 +3274,10 @@
     "set": "A1",
     "number": 246,
     "rarity": "AR",
-    "name": "Meowth",
+    "name": {
+      "en": "Meowth",
+      "fr": "Miaouss"
+    },
     "image": "cPK_20_001960_00_NYARTH_AR.webp",
     "packs": [
       "Charizard"
@@ -2549,7 +3287,10 @@
     "set": "A1",
     "number": 247,
     "rarity": "AR",
-    "name": "Ditto",
+    "name": {
+      "en": "Ditto",
+      "fr": "Métamorph"
+    },
     "image": "cPK_20_002050_00_METAMON_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2559,7 +3300,10 @@
     "set": "A1",
     "number": 248,
     "rarity": "AR",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_20_002060_00_EIEVUI_AR.webp",
     "packs": [
       "Pikachu"
@@ -2569,7 +3313,10 @@
     "set": "A1",
     "number": 249,
     "rarity": "AR",
-    "name": "Porygon",
+    "name": {
+      "en": "Porygon",
+      "fr": "Porygon"
+    },
     "image": "cPK_20_002070_00_PORYGON_AR.webp",
     "packs": [
       "Mewtwo"
@@ -2579,7 +3326,10 @@
     "set": "A1",
     "number": 250,
     "rarity": "AR",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "image": "cPK_20_002090_00_KABIGON_AR.webp",
     "packs": [
       "Pikachu"
@@ -2589,7 +3339,10 @@
     "set": "A1",
     "number": 251,
     "rarity": "SR",
-    "name": "Venusaur ex",
+    "name": {
+      "en": "Venusaur ex",
+      "fr": "Florizarre-ex"
+    },
     "image": "cPK_20_000040_00_FUSHIGIBANAex_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2599,7 +3352,10 @@
     "set": "A1",
     "number": 252,
     "rarity": "SR",
-    "name": "Exeggutor ex",
+    "name": {
+      "en": "Exeggutor ex",
+      "fr": "Noadkoko-ex"
+    },
     "image": "cPK_20_000230_00_NASSYex_SR.webp",
     "packs": [
       "Charizard"
@@ -2609,7 +3365,10 @@
     "set": "A1",
     "number": 253,
     "rarity": "SR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_20_000360_00_LIZARDONex_SR.webp",
     "packs": [
       "Charizard"
@@ -2619,7 +3378,10 @@
     "set": "A1",
     "number": 254,
     "rarity": "SR",
-    "name": "Arcanine ex",
+    "name": {
+      "en": "Arcanine ex",
+      "fr": "Arcanin-ex"
+    },
     "image": "cPK_20_000410_00_WINDIEex_SR.webp",
     "packs": [
       "Pikachu"
@@ -2629,7 +3391,10 @@
     "set": "A1",
     "number": 255,
     "rarity": "SR",
-    "name": "Moltres ex",
+    "name": {
+      "en": "Moltres ex",
+      "fr": "Sulfura-ex"
+    },
     "image": "cPK_20_000470_00_FIREex_SR.webp",
     "packs": [
       "Charizard"
@@ -2639,7 +3404,10 @@
     "set": "A1",
     "number": 256,
     "rarity": "SR",
-    "name": "Blastoise ex",
+    "name": {
+      "en": "Blastoise ex",
+      "fr": "Tortank-ex"
+    },
     "image": "cPK_20_000560_00_KAMEXex_SR.webp",
     "packs": [
       "Pikachu"
@@ -2649,7 +3417,10 @@
     "set": "A1",
     "number": 257,
     "rarity": "SR",
-    "name": "Starmie ex",
+    "name": {
+      "en": "Starmie ex",
+      "fr": "Staross-ex"
+    },
     "image": "cPK_20_000760_00_STARMIEex_SR.webp",
     "packs": [
       "Charizard"
@@ -2659,7 +3430,10 @@
     "set": "A1",
     "number": 258,
     "rarity": "SR",
-    "name": "Articuno ex",
+    "name": {
+      "en": "Articuno ex",
+      "fr": "Artikodin-ex"
+    },
     "image": "cPK_20_000840_00_FREEZERex_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2669,7 +3443,10 @@
     "set": "A1",
     "number": 259,
     "rarity": "SR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_000960_00_PIKACHUex_SR.webp",
     "packs": [
       "Pikachu"
@@ -2679,7 +3456,10 @@
     "set": "A1",
     "number": 260,
     "rarity": "SR",
-    "name": "Zapdos ex",
+    "name": {
+      "en": "Zapdos ex",
+      "fr": "Électhor-ex"
+    },
     "image": "cPK_20_001040_00_THUNDERex_SR.webp",
     "packs": [
       "Pikachu"
@@ -2689,7 +3469,10 @@
     "set": "A1",
     "number": 261,
     "rarity": "SR",
-    "name": "Gengar ex",
+    "name": {
+      "en": "Gengar ex",
+      "fr": "Ectoplasma-ex"
+    },
     "image": "cPK_20_001230_00_GANGARex_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2699,7 +3482,10 @@
     "set": "A1",
     "number": 262,
     "rarity": "SR",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_20_001290_00_MEWTWOex_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2709,7 +3495,10 @@
     "set": "A1",
     "number": 263,
     "rarity": "SR",
-    "name": "Machamp ex",
+    "name": {
+      "en": "Machamp ex",
+      "fr": "Mackogneur-ex"
+    },
     "image": "cPK_20_001460_00_KAIRIKYex_SR.webp",
     "packs": [
       "Charizard"
@@ -2719,7 +3508,10 @@
     "set": "A1",
     "number": 264,
     "rarity": "SR",
-    "name": "Marowak ex",
+    "name": {
+      "en": "Marowak ex",
+      "fr": "Ossatueur-ex"
+    },
     "image": "cPK_20_001530_00_GARAGARAex_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2729,7 +3521,10 @@
     "set": "A1",
     "number": 265,
     "rarity": "SR",
-    "name": "Wigglytuff ex",
+    "name": {
+      "en": "Wigglytuff ex",
+      "fr": "Grodoudou-ex"
+    },
     "image": "cPK_20_001950_00_PUKURINex_SR.webp",
     "packs": [
       "Pikachu"
@@ -2739,7 +3534,10 @@
     "set": "A1",
     "number": 266,
     "rarity": "SR",
-    "name": "Erika",
+    "name": {
+      "en": "Erika",
+      "fr": "Erika"
+    },
     "image": "cTR_20_000110_00_ERIKA_SR.webp",
     "packs": [
       "Charizard"
@@ -2749,7 +3547,10 @@
     "set": "A1",
     "number": 267,
     "rarity": "SR",
-    "name": "Misty",
+    "name": {
+      "en": "Misty",
+      "fr": "Ondine"
+    },
     "image": "cTR_20_000120_00_KASUMI_SR.webp",
     "packs": [
       "Pikachu"
@@ -2759,7 +3560,10 @@
     "set": "A1",
     "number": 268,
     "rarity": "SR",
-    "name": "Blaine",
+    "name": {
+      "en": "Blaine",
+      "fr": "Auguste"
+    },
     "image": "cTR_20_000130_00_KATSURA_SR.webp",
     "packs": [
       "Charizard"
@@ -2769,7 +3573,10 @@
     "set": "A1",
     "number": 269,
     "rarity": "SR",
-    "name": "Koga",
+    "name": {
+      "en": "Koga",
+      "fr": "Koga"
+    },
     "image": "cTR_20_000140_00_KYOU_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2779,7 +3586,10 @@
     "set": "A1",
     "number": 270,
     "rarity": "SR",
-    "name": "Giovanni",
+    "name": {
+      "en": "Giovanni",
+      "fr": "Giovanni"
+    },
     "image": "cTR_20_000150_00_SAKAKI_SR.webp",
     "packs": [
       "Mewtwo"
@@ -2789,7 +3599,10 @@
     "set": "A1",
     "number": 271,
     "rarity": "SR",
-    "name": "Brock",
+    "name": {
+      "en": "Brock",
+      "fr": "Pierre"
+    },
     "image": "cTR_20_000160_00_TAKESHI_SR.webp",
     "packs": [
       "Pikachu"
@@ -2799,7 +3612,10 @@
     "set": "A1",
     "number": 272,
     "rarity": "SR",
-    "name": "Sabrina",
+    "name": {
+      "en": "Sabrina",
+      "fr": "Morgane"
+    },
     "image": "cTR_20_000170_00_NATSUME_SR.webp",
     "packs": [
       "Charizard"
@@ -2809,7 +3625,10 @@
     "set": "A1",
     "number": 273,
     "rarity": "SR",
-    "name": "Lt. Surge",
+    "name": {
+      "en": "Lt. Surge",
+      "fr": "Major Bob"
+    },
     "image": "cTR_20_000180_00_MATISSE_SR.webp",
     "packs": [
       "Pikachu"
@@ -2819,7 +3638,10 @@
     "set": "A1",
     "number": 274,
     "rarity": "SAR",
-    "name": "Moltres ex",
+    "name": {
+      "en": "Moltres ex",
+      "fr": "Sulfura-ex"
+    },
     "image": "cPK_20_000470_01_FIREex_SAR.webp",
     "packs": [
       "Charizard"
@@ -2829,7 +3651,10 @@
     "set": "A1",
     "number": 275,
     "rarity": "SAR",
-    "name": "Articuno ex",
+    "name": {
+      "en": "Articuno ex",
+      "fr": "Artikodin-ex"
+    },
     "image": "cPK_20_000840_01_FREEZERex_SAR.webp",
     "packs": [
       "Mewtwo"
@@ -2839,7 +3664,10 @@
     "set": "A1",
     "number": 276,
     "rarity": "SAR",
-    "name": "Zapdos ex",
+    "name": {
+      "en": "Zapdos ex",
+      "fr": "Électhor-ex"
+    },
     "image": "cPK_20_001040_01_THUNDERex_SAR.webp",
     "packs": [
       "Pikachu"
@@ -2849,7 +3677,10 @@
     "set": "A1",
     "number": 277,
     "rarity": "SAR",
-    "name": "Gengar ex",
+    "name": {
+      "en": "Gengar ex",
+      "fr": "Ectoplasma-ex"
+    },
     "image": "cPK_20_001230_01_GANGARex_SAR.webp",
     "packs": [
       "Mewtwo"
@@ -2859,7 +3690,10 @@
     "set": "A1",
     "number": 278,
     "rarity": "SAR",
-    "name": "Machamp ex",
+    "name": {
+      "en": "Machamp ex",
+      "fr": "Mackogneur-ex"
+    },
     "image": "cPK_20_001460_01_KAIRIKYex_SAR.webp",
     "packs": [
       "Charizard"
@@ -2869,7 +3703,10 @@
     "set": "A1",
     "number": 279,
     "rarity": "SAR",
-    "name": "Wigglytuff ex",
+    "name": {
+      "en": "Wigglytuff ex",
+      "fr": "Grodoudou-ex"
+    },
     "image": "cPK_20_001950_01_PUKURINex_SAR.webp",
     "packs": [
       "Pikachu"
@@ -2879,7 +3716,10 @@
     "set": "A1",
     "number": 280,
     "rarity": "IM",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_20_000360_01_LIZARDONex_IM.webp",
     "packs": [
       "Charizard"
@@ -2889,7 +3729,10 @@
     "set": "A1",
     "number": 281,
     "rarity": "IM",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_000960_01_PIKACHUex_IM.webp",
     "packs": [
       "Pikachu"
@@ -2899,7 +3742,10 @@
     "set": "A1",
     "number": 282,
     "rarity": "IM",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_20_001290_01_MEWTWOex_IM.webp",
     "packs": [
       "Mewtwo"
@@ -2909,14 +3755,20 @@
     "set": "A1",
     "number": 283,
     "rarity": "IM",
-    "name": "Mew",
+    "name": {
+      "en": "Mew",
+      "fr": "Mew"
+    },
     "image": "cPK_20_002140_00_MEW_IM.webp"
   },
   {
     "set": "A1",
     "number": 284,
     "rarity": "UR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_20_000360_02_LIZARDONex_UR.webp",
     "packs": [
       "Charizard",
@@ -2928,7 +3780,10 @@
     "set": "A1",
     "number": 285,
     "rarity": "UR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_000960_02_PIKACHUex_UR.webp",
     "packs": [
       "Charizard",
@@ -2940,7 +3795,10 @@
     "set": "A1",
     "number": 286,
     "rarity": "UR",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_20_001290_02_MEWTWOex_UR.webp",
     "packs": [
       "Charizard",

--- a/dist/cards/A1a.json
+++ b/dist/cards/A1a.json
@@ -3,7 +3,10 @@
     "set": "A1a",
     "number": 1,
     "rarity": "C",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_10_002150_00_TAMATAMA_C.webp",
     "packs": [
       "Mew"
@@ -13,7 +16,10 @@
     "set": "A1a",
     "number": 2,
     "rarity": "U",
-    "name": "Exeggutor",
+    "name": {
+      "en": "Exeggutor",
+      "fr": "Noadkoko"
+    },
     "image": "cPK_10_002160_00_NASSY_U.webp",
     "packs": [
       "Mew"
@@ -23,7 +29,10 @@
     "set": "A1a",
     "number": 3,
     "rarity": "RR",
-    "name": "Celebi ex",
+    "name": {
+      "en": "Celebi ex",
+      "fr": "Celebi-ex"
+    },
     "image": "cPK_10_002170_00_CELEBIex_RR.webp",
     "packs": [
       "Mew"
@@ -33,7 +42,10 @@
     "set": "A1a",
     "number": 4,
     "rarity": "C",
-    "name": "Snivy",
+    "name": {
+      "en": "Snivy",
+      "fr": "Vipélierre"
+    },
     "image": "cPK_10_002180_00_TSUTARJA_C.webp",
     "packs": [
       "Mew"
@@ -43,7 +55,10 @@
     "set": "A1a",
     "number": 5,
     "rarity": "U",
-    "name": "Servine",
+    "name": {
+      "en": "Servine",
+      "fr": "Lianaja"
+    },
     "image": "cPK_10_002190_00_JANOVY_U.webp",
     "packs": [
       "Mew"
@@ -53,7 +68,10 @@
     "set": "A1a",
     "number": 6,
     "rarity": "R",
-    "name": "Serperior",
+    "name": {
+      "en": "Serperior",
+      "fr": "Majaspic"
+    },
     "image": "cPK_10_002200_00_JALORDA_R.webp",
     "packs": [
       "Mew"
@@ -63,7 +81,10 @@
     "set": "A1a",
     "number": 7,
     "rarity": "C",
-    "name": "Morelull",
+    "name": {
+      "en": "Morelull",
+      "fr": "Spododo"
+    },
     "image": "cPK_10_002210_00_NEMASYU_C.webp",
     "packs": [
       "Mew"
@@ -73,7 +94,10 @@
     "set": "A1a",
     "number": 8,
     "rarity": "U",
-    "name": "Shiinotic",
+    "name": {
+      "en": "Shiinotic",
+      "fr": "Lampignon"
+    },
     "image": "cPK_10_002220_00_MASHADE_U.webp",
     "packs": [
       "Mew"
@@ -83,7 +107,10 @@
     "set": "A1a",
     "number": 9,
     "rarity": "U",
-    "name": "Dhelmise",
+    "name": {
+      "en": "Dhelmise",
+      "fr": "Sinistrail"
+    },
     "image": "cPK_10_002230_00_DADARIN_U.webp",
     "packs": [
       "Mew"
@@ -93,7 +120,10 @@
     "set": "A1a",
     "number": 10,
     "rarity": "C",
-    "name": "Ponyta",
+    "name": {
+      "en": "Ponyta",
+      "fr": "Ponyta"
+    },
     "image": "cPK_10_002240_00_PONYTA_C.webp",
     "packs": [
       "Mew"
@@ -103,7 +133,10 @@
     "set": "A1a",
     "number": 11,
     "rarity": "U",
-    "name": "Rapidash",
+    "name": {
+      "en": "Rapidash",
+      "fr": "Galopa"
+    },
     "image": "cPK_10_002250_00_GALLOP_U.webp",
     "packs": [
       "Mew"
@@ -113,7 +146,10 @@
     "set": "A1a",
     "number": 12,
     "rarity": "U",
-    "name": "Magmar",
+    "name": {
+      "en": "Magmar",
+      "fr": "Magmar"
+    },
     "image": "cPK_10_002260_00_BOOBER_U.webp",
     "packs": [
       "Mew"
@@ -123,7 +159,10 @@
     "set": "A1a",
     "number": 13,
     "rarity": "C",
-    "name": "Larvesta",
+    "name": {
+      "en": "Larvesta",
+      "fr": "Pyronille"
+    },
     "image": "cPK_10_002270_00_MERLARVA_C.webp",
     "packs": [
       "Mew"
@@ -133,7 +172,10 @@
     "set": "A1a",
     "number": 14,
     "rarity": "R",
-    "name": "Volcarona",
+    "name": {
+      "en": "Volcarona",
+      "fr": "Pyrax"
+    },
     "image": "cPK_10_002280_00_ULGAMOTH_R.webp",
     "packs": [
       "Mew"
@@ -143,7 +185,10 @@
     "set": "A1a",
     "number": 15,
     "rarity": "C",
-    "name": "Salandit",
+    "name": {
+      "en": "Salandit",
+      "fr": "Tritox"
+    },
     "image": "cPK_10_002290_00_YATOUMORI_C.webp",
     "packs": [
       "Mew"
@@ -153,7 +198,10 @@
     "set": "A1a",
     "number": 16,
     "rarity": "C",
-    "name": "Salazzle",
+    "name": {
+      "en": "Salazzle",
+      "fr": "Malamandre"
+    },
     "image": "cPK_10_002300_00_ENNEWT_C.webp",
     "packs": [
       "Mew"
@@ -163,7 +211,10 @@
     "set": "A1a",
     "number": 17,
     "rarity": "C",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_10_002310_00_KOIKING_C.webp",
     "packs": [
       "Mew"
@@ -173,7 +224,10 @@
     "set": "A1a",
     "number": 18,
     "rarity": "RR",
-    "name": "Gyarados ex",
+    "name": {
+      "en": "Gyarados ex",
+      "fr": "Léviator-ex"
+    },
     "image": "cPK_10_002320_00_GYARADOSex_RR.webp",
     "packs": [
       "Mew"
@@ -183,7 +237,10 @@
     "set": "A1a",
     "number": 19,
     "rarity": "R",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_10_002330_00_SHOWERS_R.webp",
     "packs": [
       "Mew"
@@ -193,7 +250,10 @@
     "set": "A1a",
     "number": 20,
     "rarity": "C",
-    "name": "Finneon",
+    "name": {
+      "en": "Finneon",
+      "fr": "Écayon"
+    },
     "image": "cPK_10_002340_00_KEIKOUO_C.webp",
     "packs": [
       "Mew"
@@ -203,7 +263,10 @@
     "set": "A1a",
     "number": 21,
     "rarity": "U",
-    "name": "Lumineon",
+    "name": {
+      "en": "Lumineon",
+      "fr": "Luminéon"
+    },
     "image": "cPK_10_002350_00_NEOLANT_U.webp",
     "packs": [
       "Mew"
@@ -213,7 +276,10 @@
     "set": "A1a",
     "number": 22,
     "rarity": "C",
-    "name": "Chewtle",
+    "name": {
+      "en": "Chewtle",
+      "fr": "Khélocrok"
+    },
     "image": "cPK_10_002360_00_KAMUKAME_C.webp",
     "packs": [
       "Mew"
@@ -223,7 +289,10 @@
     "set": "A1a",
     "number": 23,
     "rarity": "U",
-    "name": "Drednaw",
+    "name": {
+      "en": "Drednaw",
+      "fr": "Torgamord"
+    },
     "image": "cPK_10_002370_00_KAJIRIGAME_U.webp",
     "packs": [
       "Mew"
@@ -233,7 +302,10 @@
     "set": "A1a",
     "number": 24,
     "rarity": "C",
-    "name": "Cramorant",
+    "name": {
+      "en": "Cramorant",
+      "fr": "Nigosier"
+    },
     "image": "cPK_10_002380_00_UU_C.webp",
     "packs": [
       "Mew"
@@ -243,7 +315,10 @@
     "set": "A1a",
     "number": 25,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_10_002390_00_PIKACHU_C.webp",
     "packs": [
       "Mew"
@@ -253,7 +328,10 @@
     "set": "A1a",
     "number": 26,
     "rarity": "R",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "image": "cPK_10_002400_00_RAICHU_R.webp",
     "packs": [
       "Mew"
@@ -263,7 +341,10 @@
     "set": "A1a",
     "number": 27,
     "rarity": "U",
-    "name": "Electabuzz",
+    "name": {
+      "en": "Electabuzz",
+      "fr": "Élektek"
+    },
     "image": "cPK_10_002410_00_ELEBOO_U.webp",
     "packs": [
       "Mew"
@@ -273,7 +354,10 @@
     "set": "A1a",
     "number": 28,
     "rarity": "C",
-    "name": "Joltik",
+    "name": {
+      "en": "Joltik",
+      "fr": "Statitik"
+    },
     "image": "cPK_10_002420_00_BACHURU_C.webp",
     "packs": [
       "Mew"
@@ -283,7 +367,10 @@
     "set": "A1a",
     "number": 29,
     "rarity": "U",
-    "name": "Galvantula",
+    "name": {
+      "en": "Galvantula",
+      "fr": "Mygavolt"
+    },
     "image": "cPK_10_002430_00_DENTULA_U.webp",
     "packs": [
       "Mew"
@@ -293,7 +380,10 @@
     "set": "A1a",
     "number": 30,
     "rarity": "C",
-    "name": "Dedenne",
+    "name": {
+      "en": "Dedenne",
+      "fr": "Dedenne"
+    },
     "image": "cPK_10_002440_00_DEDENNE_C.webp",
     "packs": [
       "Mew"
@@ -303,7 +393,10 @@
     "set": "A1a",
     "number": 31,
     "rarity": "R",
-    "name": "Mew",
+    "name": {
+      "en": "Mew",
+      "fr": "Mew"
+    },
     "image": "cPK_10_002140_00_MEW_R.webp",
     "packs": [
       "Mew"
@@ -313,7 +406,10 @@
     "set": "A1a",
     "number": 32,
     "rarity": "RR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_10_002450_00_MEWex_RR.webp",
     "packs": [
       "Mew"
@@ -323,7 +419,10 @@
     "set": "A1a",
     "number": 33,
     "rarity": "U",
-    "name": "Sigilyph",
+    "name": {
+      "en": "Sigilyph",
+      "fr": "Cryptéro"
+    },
     "image": "cPK_10_002460_00_SYMBOLER_U.webp",
     "packs": [
       "Mew"
@@ -333,7 +432,10 @@
     "set": "A1a",
     "number": 34,
     "rarity": "C",
-    "name": "Elgyem",
+    "name": {
+      "en": "Elgyem",
+      "fr": "Lewsor"
+    },
     "image": "cPK_10_002470_00_LIGRAY_C.webp",
     "packs": [
       "Mew"
@@ -343,7 +445,10 @@
     "set": "A1a",
     "number": 35,
     "rarity": "U",
-    "name": "Beheeyem",
+    "name": {
+      "en": "Beheeyem",
+      "fr": "Neitram"
+    },
     "image": "cPK_10_002500_00_OHBEM_U.webp",
     "packs": [
       "Mew"
@@ -353,7 +458,10 @@
     "set": "A1a",
     "number": 36,
     "rarity": "C",
-    "name": "Flabébé",
+    "name": {
+      "en": "Flabébé",
+      "fr": "Flabébé"
+    },
     "image": "cPK_10_002510_00_FLABEBE_C.webp",
     "packs": [
       "Mew"
@@ -363,7 +471,10 @@
     "set": "A1a",
     "number": 37,
     "rarity": "C",
-    "name": "Floette",
+    "name": {
+      "en": "Floette",
+      "fr": "Floette"
+    },
     "image": "cPK_10_002520_00_FLOETTE_C.webp",
     "packs": [
       "Mew"
@@ -373,7 +484,10 @@
     "set": "A1a",
     "number": 38,
     "rarity": "U",
-    "name": "Florges",
+    "name": {
+      "en": "Florges",
+      "fr": "Florges"
+    },
     "image": "cPK_10_002480_00_FLORGES_U.webp",
     "packs": [
       "Mew"
@@ -383,7 +497,10 @@
     "set": "A1a",
     "number": 39,
     "rarity": "C",
-    "name": "Swirlix",
+    "name": {
+      "en": "Swirlix",
+      "fr": "Sucroquin"
+    },
     "image": "cPK_10_002490_00_PEROPPAFU_C.webp",
     "packs": [
       "Mew"
@@ -393,7 +510,10 @@
     "set": "A1a",
     "number": 40,
     "rarity": "C",
-    "name": "Slurpuff",
+    "name": {
+      "en": "Slurpuff",
+      "fr": "Cupcanaille"
+    },
     "image": "cPK_10_002530_00_PEROREAM_C.webp",
     "packs": [
       "Mew"
@@ -403,7 +523,10 @@
     "set": "A1a",
     "number": 41,
     "rarity": "C",
-    "name": "Mankey",
+    "name": {
+      "en": "Mankey",
+      "fr": "Férosinge"
+    },
     "image": "cPK_10_002540_00_MANKEY_C.webp",
     "packs": [
       "Mew"
@@ -413,7 +536,10 @@
     "set": "A1a",
     "number": 42,
     "rarity": "C",
-    "name": "Primeape",
+    "name": {
+      "en": "Primeape",
+      "fr": "Colossinge"
+    },
     "image": "cPK_10_002550_00_OKORIZARU_C.webp",
     "packs": [
       "Mew"
@@ -423,7 +549,10 @@
     "set": "A1a",
     "number": 43,
     "rarity": "C",
-    "name": "Geodude",
+    "name": {
+      "en": "Geodude",
+      "fr": "Racaillou"
+    },
     "image": "cPK_10_002560_00_ISITSUBUTE_C.webp",
     "packs": [
       "Mew"
@@ -433,7 +562,10 @@
     "set": "A1a",
     "number": 44,
     "rarity": "U",
-    "name": "Graveler",
+    "name": {
+      "en": "Graveler",
+      "fr": "Gravalanch"
+    },
     "image": "cPK_10_002570_00_GOLONE_U.webp",
     "packs": [
       "Mew"
@@ -443,7 +575,10 @@
     "set": "A1a",
     "number": 45,
     "rarity": "R",
-    "name": "Golem",
+    "name": {
+      "en": "Golem",
+      "fr": "Grolem"
+    },
     "image": "cPK_10_002580_00_GOLONYA_R.webp",
     "packs": [
       "Mew"
@@ -453,7 +588,10 @@
     "set": "A1a",
     "number": 46,
     "rarity": "RR",
-    "name": "Aerodactyl ex",
+    "name": {
+      "en": "Aerodactyl ex",
+      "fr": "Ptéra-ex"
+    },
     "image": "cPK_10_002590_00_PTERAex_RR.webp",
     "packs": [
       "Mew"
@@ -463,7 +601,10 @@
     "set": "A1a",
     "number": 47,
     "rarity": "R",
-    "name": "Marshadow",
+    "name": {
+      "en": "Marshadow",
+      "fr": "Marshadow"
+    },
     "image": "cPK_10_002600_00_MARSHADOW_R.webp",
     "packs": [
       "Mew"
@@ -473,7 +614,10 @@
     "set": "A1a",
     "number": 48,
     "rarity": "U",
-    "name": "Stonjourner",
+    "name": {
+      "en": "Stonjourner",
+      "fr": "Dolman"
+    },
     "image": "cPK_10_002610_00_ISHIHENGIN_U.webp",
     "packs": [
       "Mew"
@@ -483,7 +627,10 @@
     "set": "A1a",
     "number": 49,
     "rarity": "C",
-    "name": "Koffing",
+    "name": {
+      "en": "Koffing",
+      "fr": "Smogo"
+    },
     "image": "cPK_10_002620_00_DOGARS_C.webp",
     "packs": [
       "Mew"
@@ -493,7 +640,10 @@
     "set": "A1a",
     "number": 50,
     "rarity": "U",
-    "name": "Weezing",
+    "name": {
+      "en": "Weezing",
+      "fr": "Smogogo"
+    },
     "image": "cPK_10_002630_00_MATADOGAS_U.webp",
     "packs": [
       "Mew"
@@ -503,7 +653,10 @@
     "set": "A1a",
     "number": 51,
     "rarity": "C",
-    "name": "Purrloin",
+    "name": {
+      "en": "Purrloin",
+      "fr": "Chacripan"
+    },
     "image": "cPK_10_002640_00_CHORONEKO_C.webp",
     "packs": [
       "Mew"
@@ -513,7 +666,10 @@
     "set": "A1a",
     "number": 52,
     "rarity": "C",
-    "name": "Liepard",
+    "name": {
+      "en": "Liepard",
+      "fr": "Léopardus"
+    },
     "image": "cPK_10_002650_00_LEPARDAS_C.webp",
     "packs": [
       "Mew"
@@ -523,7 +679,10 @@
     "set": "A1a",
     "number": 53,
     "rarity": "C",
-    "name": "Venipede",
+    "name": {
+      "en": "Venipede",
+      "fr": "Venipatte"
+    },
     "image": "cPK_10_002660_00_FUSHIDE_C.webp",
     "packs": [
       "Mew"
@@ -533,7 +692,10 @@
     "set": "A1a",
     "number": 54,
     "rarity": "C",
-    "name": "Whirlipede",
+    "name": {
+      "en": "Whirlipede",
+      "fr": "Scobolide"
+    },
     "image": "cPK_10_002670_00_WHEEGA_C.webp",
     "packs": [
       "Mew"
@@ -543,7 +705,10 @@
     "set": "A1a",
     "number": 55,
     "rarity": "U",
-    "name": "Scolipede",
+    "name": {
+      "en": "Scolipede",
+      "fr": "Brutapode"
+    },
     "image": "cPK_10_002680_00_PENDROR_U.webp",
     "packs": [
       "Mew"
@@ -553,7 +718,10 @@
     "set": "A1a",
     "number": 56,
     "rarity": "U",
-    "name": "Druddigon",
+    "name": {
+      "en": "Druddigon",
+      "fr": "Drakkarmin"
+    },
     "image": "cPK_10_002690_00_CRIMGAN_U.webp",
     "packs": [
       "Mew"
@@ -563,7 +731,10 @@
     "set": "A1a",
     "number": 57,
     "rarity": "C",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_10_002700_00_POPPO_C.webp",
     "packs": [
       "Mew"
@@ -573,7 +744,10 @@
     "set": "A1a",
     "number": 58,
     "rarity": "C",
-    "name": "Pidgeotto",
+    "name": {
+      "en": "Pidgeotto",
+      "fr": "Roucoups"
+    },
     "image": "cPK_10_002710_00_PIGEON_C.webp",
     "packs": [
       "Mew"
@@ -583,7 +757,10 @@
     "set": "A1a",
     "number": 59,
     "rarity": "RR",
-    "name": "Pidgeot ex",
+    "name": {
+      "en": "Pidgeot ex",
+      "fr": "Roucarnage-ex"
+    },
     "image": "cPK_10_002720_00_PIGEOTex_RR.webp",
     "packs": [
       "Mew"
@@ -593,7 +770,10 @@
     "set": "A1a",
     "number": 60,
     "rarity": "R",
-    "name": "Tauros",
+    "name": {
+      "en": "Tauros",
+      "fr": "Tauros"
+    },
     "image": "cPK_10_002730_00_KENTAUROS_R.webp",
     "packs": [
       "Mew"
@@ -603,7 +783,10 @@
     "set": "A1a",
     "number": 61,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_002740_00_EIEVUI_C.webp",
     "packs": [
       "Mew"
@@ -613,7 +796,10 @@
     "set": "A1a",
     "number": 62,
     "rarity": "C",
-    "name": "Chatot",
+    "name": {
+      "en": "Chatot",
+      "fr": "Pijako"
+    },
     "image": "cPK_10_002750_00_PERAP_C.webp",
     "packs": [
       "Mew"
@@ -623,7 +809,10 @@
     "set": "A1a",
     "number": 63,
     "rarity": "C",
-    "name": "Old Amber",
+    "name": {
+      "en": "Old Amber",
+      "fr": "Vieil Ambre"
+    },
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
     "packs": [
       "Mew"
@@ -633,7 +822,10 @@
     "set": "A1a",
     "number": 64,
     "rarity": "U",
-    "name": "Pokémon Flute",
+    "name": {
+      "en": "Pokémon Flute",
+      "fr": "Flûte Pokémon"
+    },
     "image": "cTR_10_000200_00_POKEMONNOFUE_U.webp",
     "packs": [
       "Mew"
@@ -643,7 +835,10 @@
     "set": "A1a",
     "number": 65,
     "rarity": "U",
-    "name": "Mythical Slab",
+    "name": {
+      "en": "Mythical Slab",
+      "fr": "Dalle Fabuleuse"
+    },
     "image": "cTR_10_000190_00_MABOROSHINOSEKIBAN_U.webp",
     "packs": [
       "Mew"
@@ -653,7 +848,10 @@
     "set": "A1a",
     "number": 66,
     "rarity": "U",
-    "name": "Budding Expeditioner",
+    "name": {
+      "en": "Budding Expeditioner",
+      "fr": "Jeune Explorateur"
+    },
     "image": "cTR_10_000220_00_KAKEDASHICHOSAIN_U.webp",
     "packs": [
       "Mew"
@@ -663,7 +861,10 @@
     "set": "A1a",
     "number": 67,
     "rarity": "U",
-    "name": "Blue",
+    "name": {
+      "en": "Blue",
+      "fr": "Blue"
+    },
     "image": "cTR_10_000210_00_GREEN_U.webp",
     "packs": [
       "Mew"
@@ -673,7 +874,10 @@
     "set": "A1a",
     "number": 68,
     "rarity": "U",
-    "name": "Leaf",
+    "name": {
+      "en": "Leaf",
+      "fr": "Leaf"
+    },
     "image": "cTR_10_000230_00_LEAF_U.webp",
     "packs": [
       "Mew"
@@ -683,7 +887,10 @@
     "set": "A1a",
     "number": 69,
     "rarity": "AR",
-    "name": "Exeggutor",
+    "name": {
+      "en": "Exeggutor",
+      "fr": "Noadkoko"
+    },
     "image": "cPK_20_002160_00_NASSY_AR.webp",
     "packs": [
       "Mew"
@@ -693,7 +900,10 @@
     "set": "A1a",
     "number": 70,
     "rarity": "AR",
-    "name": "Serperior",
+    "name": {
+      "en": "Serperior",
+      "fr": "Majaspic"
+    },
     "image": "cPK_20_002200_00_JALORDA_AR.webp",
     "packs": [
       "Mew"
@@ -703,7 +913,10 @@
     "set": "A1a",
     "number": 71,
     "rarity": "AR",
-    "name": "Salandit",
+    "name": {
+      "en": "Salandit",
+      "fr": "Tritox"
+    },
     "image": "cPK_20_002290_00_YATOUMORI_AR.webp",
     "packs": [
       "Mew"
@@ -713,7 +926,10 @@
     "set": "A1a",
     "number": 72,
     "rarity": "AR",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_20_002330_00_SHOWERS_AR.webp",
     "packs": [
       "Mew"
@@ -723,7 +939,10 @@
     "set": "A1a",
     "number": 73,
     "rarity": "AR",
-    "name": "Dedenne",
+    "name": {
+      "en": "Dedenne",
+      "fr": "Dedenne"
+    },
     "image": "cPK_20_002440_00_DEDENNE_AR.webp",
     "packs": [
       "Mew"
@@ -733,7 +952,10 @@
     "set": "A1a",
     "number": 74,
     "rarity": "AR",
-    "name": "Marshadow",
+    "name": {
+      "en": "Marshadow",
+      "fr": "Marshadow"
+    },
     "image": "cPK_20_002600_00_MARSHADOW_AR.webp",
     "packs": [
       "Mew"
@@ -743,7 +965,10 @@
     "set": "A1a",
     "number": 75,
     "rarity": "SR",
-    "name": "Celebi ex",
+    "name": {
+      "en": "Celebi ex",
+      "fr": "Celebi-ex"
+    },
     "image": "cPK_20_002170_00_CELEBIex_SR.webp",
     "packs": [
       "Mew"
@@ -753,7 +978,10 @@
     "set": "A1a",
     "number": 76,
     "rarity": "SR",
-    "name": "Gyarados ex",
+    "name": {
+      "en": "Gyarados ex",
+      "fr": "Léviator-ex"
+    },
     "image": "cPK_20_002320_00_GYARADOSex_SR.webp",
     "packs": [
       "Mew"
@@ -763,7 +991,10 @@
     "set": "A1a",
     "number": 77,
     "rarity": "SR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_20_002450_00_MEWex_SR.webp",
     "packs": [
       "Mew"
@@ -773,7 +1004,10 @@
     "set": "A1a",
     "number": 78,
     "rarity": "SR",
-    "name": "Aerodactyl ex",
+    "name": {
+      "en": "Aerodactyl ex",
+      "fr": "Ptéra-ex"
+    },
     "image": "cPK_20_002590_00_PTERAex_SR.webp",
     "packs": [
       "Mew"
@@ -783,7 +1017,10 @@
     "set": "A1a",
     "number": 79,
     "rarity": "SR",
-    "name": "Pidgeot ex",
+    "name": {
+      "en": "Pidgeot ex",
+      "fr": "Roucarnage-ex"
+    },
     "image": "cPK_20_002720_00_PIGEOTex_SR.webp",
     "packs": [
       "Mew"
@@ -793,7 +1030,10 @@
     "set": "A1a",
     "number": 80,
     "rarity": "SR",
-    "name": "Budding Expeditioner",
+    "name": {
+      "en": "Budding Expeditioner",
+      "fr": "Jeune Explorateur"
+    },
     "image": "cTR_20_000220_00_KAKEDASHICHOSAIN_SR.webp",
     "packs": [
       "Mew"
@@ -803,7 +1043,10 @@
     "set": "A1a",
     "number": 81,
     "rarity": "SR",
-    "name": "Blue",
+    "name": {
+      "en": "Blue",
+      "fr": "Blue"
+    },
     "image": "cTR_20_000210_00_GREEN_SR.webp",
     "packs": [
       "Mew"
@@ -813,7 +1056,10 @@
     "set": "A1a",
     "number": 82,
     "rarity": "SR",
-    "name": "Leaf",
+    "name": {
+      "en": "Leaf",
+      "fr": "Leaf"
+    },
     "image": "cTR_20_000230_00_LEAF_SR.webp",
     "packs": [
       "Mew"
@@ -823,7 +1069,10 @@
     "set": "A1a",
     "number": 83,
     "rarity": "SAR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_20_002450_01_MEWex_SAR.webp",
     "packs": [
       "Mew"
@@ -833,7 +1082,10 @@
     "set": "A1a",
     "number": 84,
     "rarity": "SAR",
-    "name": "Aerodactyl ex",
+    "name": {
+      "en": "Aerodactyl ex",
+      "fr": "Ptéra-ex"
+    },
     "image": "cPK_20_002590_01_PTERAex_SAR.webp",
     "packs": [
       "Mew"
@@ -843,7 +1095,10 @@
     "set": "A1a",
     "number": 85,
     "rarity": "IM",
-    "name": "Celebi ex",
+    "name": {
+      "en": "Celebi ex",
+      "fr": "Celebi-ex"
+    },
     "image": "cPK_20_002170_01_CELEBIex_IM.webp",
     "packs": [
       "Mew"
@@ -853,7 +1108,10 @@
     "set": "A1a",
     "number": 86,
     "rarity": "UR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_20_002450_02_MEWex_UR.webp",
     "packs": [
       "Mew"

--- a/dist/cards/A2.json
+++ b/dist/cards/A2.json
@@ -3,7 +3,10 @@
     "set": "A2",
     "number": 1,
     "rarity": "C",
-    "name": "Oddish",
+    "name": {
+      "en": "Oddish",
+      "fr": "Mystherbe"
+    },
     "image": "cPK_10_002820_00_NAZONOKUSA_C.webp",
     "packs": [
       "Dialga",
@@ -14,7 +17,10 @@
     "set": "A2",
     "number": 2,
     "rarity": "C",
-    "name": "Gloom",
+    "name": {
+      "en": "Gloom",
+      "fr": "Ortide"
+    },
     "image": "cPK_10_002830_00_KUSAIHANA_C.webp",
     "packs": [
       "Dialga",
@@ -25,7 +31,10 @@
     "set": "A2",
     "number": 3,
     "rarity": "U",
-    "name": "Bellossom",
+    "name": {
+      "en": "Bellossom",
+      "fr": "Joliflor"
+    },
     "image": "cPK_10_002840_00_KIREIHANA_U.webp",
     "packs": [
       "Dialga",
@@ -36,7 +45,10 @@
     "set": "A2",
     "number": 4,
     "rarity": "C",
-    "name": "Tangela",
+    "name": {
+      "en": "Tangela",
+      "fr": "Saquedeneu"
+    },
     "image": "cPK_10_002850_00_MONJARA_C.webp",
     "packs": [
       "Dialga"
@@ -46,7 +58,10 @@
     "set": "A2",
     "number": 5,
     "rarity": "U",
-    "name": "Tangrowth",
+    "name": {
+      "en": "Tangrowth",
+      "fr": "Bouldeneu"
+    },
     "image": "cPK_10_002860_00_MOJUMBO_U.webp",
     "packs": [
       "Dialga"
@@ -56,7 +71,10 @@
     "set": "A2",
     "number": 6,
     "rarity": "C",
-    "name": "Yanma",
+    "name": {
+      "en": "Yanma",
+      "fr": "Yanma"
+    },
     "image": "cPK_10_002870_00_YANYANMA_C.webp",
     "packs": [
       "Dialga"
@@ -66,7 +84,10 @@
     "set": "A2",
     "number": 7,
     "rarity": "RR",
-    "name": "Yanmega ex",
+    "name": {
+      "en": "Yanmega ex",
+      "fr": "Yanmega-ex"
+    },
     "image": "cPK_10_002880_00_MEGAYANMAex_RR.webp",
     "packs": [
       "Dialga"
@@ -76,7 +97,10 @@
     "set": "A2",
     "number": 8,
     "rarity": "C",
-    "name": "Roselia",
+    "name": {
+      "en": "Roselia",
+      "fr": "Rosélia"
+    },
     "image": "cPK_10_002890_00_ROSELIA_C.webp",
     "packs": [
       "Dialga",
@@ -87,7 +111,10 @@
     "set": "A2",
     "number": 9,
     "rarity": "U",
-    "name": "Roserade",
+    "name": {
+      "en": "Roserade",
+      "fr": "Roserade"
+    },
     "image": "cPK_10_002900_00_ROSERADE_U.webp",
     "packs": [
       "Dialga",
@@ -98,7 +125,10 @@
     "set": "A2",
     "number": 10,
     "rarity": "C",
-    "name": "Turtwig",
+    "name": {
+      "en": "Turtwig",
+      "fr": "Tortipouss"
+    },
     "image": "cPK_10_002910_00_NAETLE_C.webp",
     "packs": [
       "Palkia"
@@ -108,7 +138,10 @@
     "set": "A2",
     "number": 11,
     "rarity": "U",
-    "name": "Grotle",
+    "name": {
+      "en": "Grotle",
+      "fr": "Boskara"
+    },
     "image": "cPK_10_002920_00_HAYASHIGAME_U.webp",
     "packs": [
       "Palkia"
@@ -118,7 +151,10 @@
     "set": "A2",
     "number": 12,
     "rarity": "R",
-    "name": "Torterra",
+    "name": {
+      "en": "Torterra",
+      "fr": "Torterra"
+    },
     "image": "cPK_10_002930_00_DODAITOSE_R.webp",
     "packs": [
       "Palkia"
@@ -128,7 +164,10 @@
     "set": "A2",
     "number": 13,
     "rarity": "C",
-    "name": "Kricketot",
+    "name": {
+      "en": "Kricketot",
+      "fr": "Crikzik"
+    },
     "image": "cPK_10_002940_00_KOROBOHSHI_C.webp",
     "packs": [
       "Palkia"
@@ -138,7 +177,10 @@
     "set": "A2",
     "number": 14,
     "rarity": "C",
-    "name": "Kricketune",
+    "name": {
+      "en": "Kricketune",
+      "fr": "Mélokrik"
+    },
     "image": "cPK_10_002950_00_KOROTOCK_C.webp",
     "packs": [
       "Palkia"
@@ -148,7 +190,10 @@
     "set": "A2",
     "number": 15,
     "rarity": "C",
-    "name": "Burmy",
+    "name": {
+      "en": "Burmy",
+      "fr": "Cheniti"
+    },
     "image": "cPK_10_002960_00_MINOMUCCHI_C.webp",
     "packs": [
       "Dialga",
@@ -159,7 +204,10 @@
     "set": "A2",
     "number": 16,
     "rarity": "C",
-    "name": "Wormadam",
+    "name": {
+      "en": "Wormadam",
+      "fr": "Cheniselle"
+    },
     "image": "cPK_10_002970_00_MINOMADAMKUSAKINOMINO_C.webp",
     "packs": [
       "Dialga",
@@ -170,7 +218,10 @@
     "set": "A2",
     "number": 17,
     "rarity": "C",
-    "name": "Combee",
+    "name": {
+      "en": "Combee",
+      "fr": "Apitrini"
+    },
     "image": "cPK_10_002980_00_MITSUHONEY_C.webp",
     "packs": [
       "Dialga"
@@ -180,7 +231,10 @@
     "set": "A2",
     "number": 18,
     "rarity": "U",
-    "name": "Vespiquen",
+    "name": {
+      "en": "Vespiquen",
+      "fr": "Apireine"
+    },
     "image": "cPK_10_002990_00_BEEQUEN_U.webp",
     "packs": [
       "Dialga"
@@ -190,7 +244,10 @@
     "set": "A2",
     "number": 19,
     "rarity": "U",
-    "name": "Carnivine",
+    "name": {
+      "en": "Carnivine",
+      "fr": "Vortente"
+    },
     "image": "cPK_10_003000_00_MUSKIPPA_U.webp",
     "packs": [
       "Palkia"
@@ -200,7 +257,10 @@
     "set": "A2",
     "number": 20,
     "rarity": "R",
-    "name": "Leafeon",
+    "name": {
+      "en": "Leafeon",
+      "fr": "Phyllali"
+    },
     "image": "cPK_10_003010_00_LEAFIA_R.webp",
     "packs": [
       "Dialga"
@@ -210,7 +270,10 @@
     "set": "A2",
     "number": 21,
     "rarity": "C",
-    "name": "Mow Rotom",
+    "name": {
+      "en": "Mow Rotom",
+      "fr": "Motisma Tonte"
+    },
     "image": "cPK_10_003020_00_CUT ROTOM_C.webp",
     "packs": [
       "Dialga",
@@ -221,7 +284,10 @@
     "set": "A2",
     "number": 22,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_10_003030_00_SHAYMIN_R.webp",
     "packs": [
       "Dialga"
@@ -231,7 +297,10 @@
     "set": "A2",
     "number": 23,
     "rarity": "C",
-    "name": "Magmar",
+    "name": {
+      "en": "Magmar",
+      "fr": "Magmar"
+    },
     "image": "cPK_10_003040_00_BOOBER_C.webp",
     "packs": [
       "Palkia"
@@ -241,7 +310,10 @@
     "set": "A2",
     "number": 24,
     "rarity": "R",
-    "name": "Magmortar",
+    "name": {
+      "en": "Magmortar",
+      "fr": "Maganon"
+    },
     "image": "cPK_10_003050_00_BOOBURN_R.webp",
     "packs": [
       "Palkia"
@@ -251,7 +323,10 @@
     "set": "A2",
     "number": 25,
     "rarity": "C",
-    "name": "Slugma",
+    "name": {
+      "en": "Slugma",
+      "fr": "Limagma"
+    },
     "image": "cPK_10_003060_00_MAGMAG_C.webp",
     "packs": [
       "Dialga",
@@ -262,7 +337,10 @@
     "set": "A2",
     "number": 26,
     "rarity": "U",
-    "name": "Magcargo",
+    "name": {
+      "en": "Magcargo",
+      "fr": "Volcaropod"
+    },
     "image": "cPK_10_003070_00_MAGCARGOT_U.webp",
     "packs": [
       "Dialga",
@@ -273,7 +351,10 @@
     "set": "A2",
     "number": 27,
     "rarity": "C",
-    "name": "Chimchar",
+    "name": {
+      "en": "Chimchar",
+      "fr": "Ouisticram"
+    },
     "image": "cPK_10_003080_00_HIKOZARU_C.webp",
     "packs": [
       "Palkia"
@@ -283,7 +364,10 @@
     "set": "A2",
     "number": 28,
     "rarity": "U",
-    "name": "Monferno",
+    "name": {
+      "en": "Monferno",
+      "fr": "Chimpenfeu"
+    },
     "image": "cPK_10_003090_00_MOUKAZARU_U.webp",
     "packs": [
       "Palkia"
@@ -293,7 +377,10 @@
     "set": "A2",
     "number": 29,
     "rarity": "RR",
-    "name": "Infernape ex",
+    "name": {
+      "en": "Infernape ex",
+      "fr": "Simiabraz-ex"
+    },
     "image": "cPK_10_003100_00_GOUKAZARUex_RR.webp",
     "packs": [
       "Palkia"
@@ -303,7 +390,10 @@
     "set": "A2",
     "number": 30,
     "rarity": "C",
-    "name": "Heat Rotom",
+    "name": {
+      "en": "Heat Rotom",
+      "fr": "Motisma Chaleur"
+    },
     "image": "cPK_10_003110_00_HEAT ROTOM_C.webp",
     "packs": [
       "Dialga",
@@ -314,7 +404,10 @@
     "set": "A2",
     "number": 31,
     "rarity": "C",
-    "name": "Swinub",
+    "name": {
+      "en": "Swinub",
+      "fr": "Marcacrin"
+    },
     "image": "cPK_10_003120_00_URIMOO_C.webp",
     "packs": [
       "Dialga"
@@ -324,7 +417,10 @@
     "set": "A2",
     "number": 32,
     "rarity": "U",
-    "name": "Piloswine",
+    "name": {
+      "en": "Piloswine",
+      "fr": "Cochignon"
+    },
     "image": "cPK_10_003130_00_INOMOO_U.webp",
     "packs": [
       "Dialga"
@@ -334,7 +430,10 @@
     "set": "A2",
     "number": 33,
     "rarity": "R",
-    "name": "Mamoswine",
+    "name": {
+      "en": "Mamoswine",
+      "fr": "Mammochon"
+    },
     "image": "cPK_10_003140_00_MAMMOO_R.webp",
     "packs": [
       "Dialga"
@@ -344,7 +443,10 @@
     "set": "A2",
     "number": 34,
     "rarity": "U",
-    "name": "Regice",
+    "name": {
+      "en": "Regice",
+      "fr": "Regice"
+    },
     "image": "cPK_10_003150_00_REGICE_U.webp",
     "packs": [
       "Palkia"
@@ -354,7 +456,10 @@
     "set": "A2",
     "number": 35,
     "rarity": "C",
-    "name": "Piplup",
+    "name": {
+      "en": "Piplup",
+      "fr": "Tiplouf"
+    },
     "image": "cPK_10_003160_00_POCHAMA_C.webp",
     "packs": [
       "Palkia"
@@ -364,7 +469,10 @@
     "set": "A2",
     "number": 36,
     "rarity": "U",
-    "name": "Prinplup",
+    "name": {
+      "en": "Prinplup",
+      "fr": "Prinplouf"
+    },
     "image": "cPK_10_003170_00_POTTAISHI_U.webp",
     "packs": [
       "Palkia"
@@ -374,7 +482,10 @@
     "set": "A2",
     "number": 37,
     "rarity": "R",
-    "name": "Empoleon",
+    "name": {
+      "en": "Empoleon",
+      "fr": "Pingoléon"
+    },
     "image": "cPK_10_003180_00_EMPERTE_R.webp",
     "packs": [
       "Palkia"
@@ -384,7 +495,10 @@
     "set": "A2",
     "number": 38,
     "rarity": "C",
-    "name": "Buizel",
+    "name": {
+      "en": "Buizel",
+      "fr": "Mustébouée"
+    },
     "image": "cPK_10_003190_00_BUOYSEL_C.webp",
     "packs": [
       "Dialga",
@@ -395,7 +509,10 @@
     "set": "A2",
     "number": 39,
     "rarity": "U",
-    "name": "Floatzel",
+    "name": {
+      "en": "Floatzel",
+      "fr": "Mustéflott"
+    },
     "image": "cPK_10_003200_00_FLOAZEL_U.webp",
     "packs": [
       "Dialga",
@@ -406,7 +523,10 @@
     "set": "A2",
     "number": 40,
     "rarity": "C",
-    "name": "Shellos",
+    "name": {
+      "en": "Shellos",
+      "fr": "Sancoki"
+    },
     "image": "cPK_10_003210_00_KARANAKUSHI_C.webp",
     "packs": [
       "Palkia"
@@ -416,7 +536,10 @@
     "set": "A2",
     "number": 41,
     "rarity": "U",
-    "name": "Gastrodon",
+    "name": {
+      "en": "Gastrodon",
+      "fr": "Tritosor"
+    },
     "image": "cPK_10_003220_00_TRITODON_U.webp",
     "packs": [
       "Palkia"
@@ -426,7 +549,10 @@
     "set": "A2",
     "number": 42,
     "rarity": "C",
-    "name": "Finneon",
+    "name": {
+      "en": "Finneon",
+      "fr": "Écayon"
+    },
     "image": "cPK_10_003230_00_KEIKOUO_C.webp",
     "packs": [
       "Dialga",
@@ -437,7 +563,10 @@
     "set": "A2",
     "number": 43,
     "rarity": "U",
-    "name": "Lumineon",
+    "name": {
+      "en": "Lumineon",
+      "fr": "Luminéon"
+    },
     "image": "cPK_10_003240_00_NEOLANT_U.webp",
     "packs": [
       "Dialga",
@@ -448,7 +577,10 @@
     "set": "A2",
     "number": 44,
     "rarity": "C",
-    "name": "Snover",
+    "name": {
+      "en": "Snover",
+      "fr": "Blizzi"
+    },
     "image": "cPK_10_003250_00_YUKIKABURI_C.webp",
     "packs": [
       "Dialga",
@@ -459,7 +591,10 @@
     "set": "A2",
     "number": 45,
     "rarity": "U",
-    "name": "Abomasnow",
+    "name": {
+      "en": "Abomasnow",
+      "fr": "Blizzaroi"
+    },
     "image": "cPK_10_003260_00_YUKINOOH_U.webp",
     "packs": [
       "Dialga",
@@ -470,7 +605,10 @@
     "set": "A2",
     "number": 46,
     "rarity": "R",
-    "name": "Glaceon",
+    "name": {
+      "en": "Glaceon",
+      "fr": "Givrali"
+    },
     "image": "cPK_10_003270_00_GLACIA_R.webp",
     "packs": [
       "Palkia"
@@ -480,7 +618,10 @@
     "set": "A2",
     "number": 47,
     "rarity": "C",
-    "name": "Wash Rotom",
+    "name": {
+      "en": "Wash Rotom",
+      "fr": "Motisma Lavage"
+    },
     "image": "cPK_10_003280_00_WASH ROTOM_C.webp",
     "packs": [
       "Dialga",
@@ -491,7 +632,10 @@
     "set": "A2",
     "number": 48,
     "rarity": "C",
-    "name": "Frost Rotom",
+    "name": {
+      "en": "Frost Rotom",
+      "fr": "Motisma Froid"
+    },
     "image": "cPK_10_003290_00_FROST ROTOM_C.webp",
     "packs": [
       "Dialga",
@@ -502,7 +646,10 @@
     "set": "A2",
     "number": 49,
     "rarity": "RR",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_10_003300_00_PALKIAex_RR.webp",
     "packs": [
       "Palkia"
@@ -512,7 +659,10 @@
     "set": "A2",
     "number": 50,
     "rarity": "U",
-    "name": "Manaphy",
+    "name": {
+      "en": "Manaphy",
+      "fr": "Manaphy"
+    },
     "image": "cPK_10_003310_00_MANAPHY_U.webp",
     "packs": [
       "Palkia"
@@ -522,7 +672,10 @@
     "set": "A2",
     "number": 51,
     "rarity": "C",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_10_003320_00_COIL_C.webp",
     "packs": [
       "Dialga",
@@ -533,7 +686,10 @@
     "set": "A2",
     "number": 52,
     "rarity": "U",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "image": "cPK_10_003330_00_RARECOIL_U.webp",
     "packs": [
       "Dialga",
@@ -544,7 +700,10 @@
     "set": "A2",
     "number": 53,
     "rarity": "R",
-    "name": "Magnezone",
+    "name": {
+      "en": "Magnezone",
+      "fr": "Magnézone"
+    },
     "image": "cPK_10_003340_00_JIBACOIL_R.webp",
     "packs": [
       "Dialga",
@@ -555,7 +714,10 @@
     "set": "A2",
     "number": 54,
     "rarity": "C",
-    "name": "Voltorb",
+    "name": {
+      "en": "Voltorb",
+      "fr": "Voltorbe"
+    },
     "image": "cPK_10_003350_00_BIRIRIDAMA_C.webp",
     "packs": [
       "Dialga",
@@ -566,7 +728,10 @@
     "set": "A2",
     "number": 55,
     "rarity": "U",
-    "name": "Electrode",
+    "name": {
+      "en": "Electrode",
+      "fr": "Électrode"
+    },
     "image": "cPK_10_003360_00_MARUMINE_U.webp",
     "packs": [
       "Dialga",
@@ -577,7 +742,10 @@
     "set": "A2",
     "number": 56,
     "rarity": "C",
-    "name": "Electabuzz",
+    "name": {
+      "en": "Electabuzz",
+      "fr": "Élektek"
+    },
     "image": "cPK_10_003370_00_ELEBOO_C.webp",
     "packs": [
       "Dialga"
@@ -587,7 +755,10 @@
     "set": "A2",
     "number": 57,
     "rarity": "R",
-    "name": "Electivire",
+    "name": {
+      "en": "Electivire",
+      "fr": "Élekable"
+    },
     "image": "cPK_10_003380_00_ELEKIBLE_R.webp",
     "packs": [
       "Dialga"
@@ -597,7 +768,10 @@
     "set": "A2",
     "number": 58,
     "rarity": "C",
-    "name": "Shinx",
+    "name": {
+      "en": "Shinx",
+      "fr": "Lixy"
+    },
     "image": "cPK_10_003390_00_KOLINK_C.webp",
     "packs": [
       "Dialga"
@@ -607,7 +781,10 @@
     "set": "A2",
     "number": 59,
     "rarity": "U",
-    "name": "Luxio",
+    "name": {
+      "en": "Luxio",
+      "fr": "Luxio"
+    },
     "image": "cPK_10_003400_00_LUXIO_U.webp",
     "packs": [
       "Dialga"
@@ -617,7 +794,10 @@
     "set": "A2",
     "number": 60,
     "rarity": "R",
-    "name": "Luxray",
+    "name": {
+      "en": "Luxray",
+      "fr": "Luxray"
+    },
     "image": "cPK_10_003410_00_RENTORAR_R.webp",
     "packs": [
       "Dialga"
@@ -627,7 +807,10 @@
     "set": "A2",
     "number": 61,
     "rarity": "RR",
-    "name": "Pachirisu ex",
+    "name": {
+      "en": "Pachirisu ex",
+      "fr": "Pachirisu-ex"
+    },
     "image": "cPK_10_003420_00_PACHIRISUex_RR.webp",
     "packs": [
       "Dialga"
@@ -637,7 +820,10 @@
     "set": "A2",
     "number": 62,
     "rarity": "C",
-    "name": "Rotom",
+    "name": {
+      "en": "Rotom",
+      "fr": "Motisma"
+    },
     "image": "cPK_10_003430_00_ROTOM_C.webp",
     "packs": [
       "Palkia"
@@ -647,7 +833,10 @@
     "set": "A2",
     "number": 63,
     "rarity": "C",
-    "name": "Togepi",
+    "name": {
+      "en": "Togepi",
+      "fr": "Togepi"
+    },
     "image": "cPK_10_003440_00_TOGEPY_C.webp",
     "packs": [
       "Dialga",
@@ -658,7 +847,10 @@
     "set": "A2",
     "number": 64,
     "rarity": "U",
-    "name": "Togetic",
+    "name": {
+      "en": "Togetic",
+      "fr": "Togetic"
+    },
     "image": "cPK_10_003450_00_TOGECHICK_U.webp",
     "packs": [
       "Dialga",
@@ -669,7 +861,10 @@
     "set": "A2",
     "number": 65,
     "rarity": "R",
-    "name": "Togekiss",
+    "name": {
+      "en": "Togekiss",
+      "fr": "Togekiss"
+    },
     "image": "cPK_10_003460_00_TOGEKISS_R.webp",
     "packs": [
       "Dialga",
@@ -680,7 +875,10 @@
     "set": "A2",
     "number": 66,
     "rarity": "C",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_10_003470_00_MUMA_C.webp",
     "packs": [
       "Palkia"
@@ -690,7 +888,10 @@
     "set": "A2",
     "number": 67,
     "rarity": "RR",
-    "name": "Mismagius ex",
+    "name": {
+      "en": "Mismagius ex",
+      "fr": "Magirêve-ex"
+    },
     "image": "cPK_10_003480_00_MUMARGIex_RR.webp",
     "packs": [
       "Palkia"
@@ -700,7 +901,10 @@
     "set": "A2",
     "number": 68,
     "rarity": "C",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "image": "cPK_10_003490_00_RALTS_C.webp",
     "packs": [
       "Dialga"
@@ -710,7 +914,10 @@
     "set": "A2",
     "number": 69,
     "rarity": "C",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "image": "cPK_10_003500_00_KIRLIA_C.webp",
     "packs": [
       "Dialga"
@@ -720,7 +927,10 @@
     "set": "A2",
     "number": 70,
     "rarity": "C",
-    "name": "Duskull",
+    "name": {
+      "en": "Duskull",
+      "fr": "Skelénox"
+    },
     "image": "cPK_10_003510_00_YOMAWARU_C.webp",
     "packs": [
       "Dialga"
@@ -730,7 +940,10 @@
     "set": "A2",
     "number": 71,
     "rarity": "U",
-    "name": "Dusclops",
+    "name": {
+      "en": "Dusclops",
+      "fr": "Téraclope"
+    },
     "image": "cPK_10_003520_00_SAMAYOURU_U.webp",
     "packs": [
       "Dialga"
@@ -740,7 +953,10 @@
     "set": "A2",
     "number": 72,
     "rarity": "R",
-    "name": "Dusknoir",
+    "name": {
+      "en": "Dusknoir",
+      "fr": "Noctunoir"
+    },
     "image": "cPK_10_003530_00_YONOIR_R.webp",
     "packs": [
       "Dialga"
@@ -750,7 +966,10 @@
     "set": "A2",
     "number": 73,
     "rarity": "C",
-    "name": "Drifloon",
+    "name": {
+      "en": "Drifloon",
+      "fr": "Baudrive"
+    },
     "image": "cPK_10_003540_00_FUWANTE_C.webp",
     "packs": [
       "Dialga"
@@ -760,7 +979,10 @@
     "set": "A2",
     "number": 74,
     "rarity": "U",
-    "name": "Drifblim",
+    "name": {
+      "en": "Drifblim",
+      "fr": "Grodrive"
+    },
     "image": "cPK_10_003550_00_FUWARIDE_U.webp",
     "packs": [
       "Dialga"
@@ -770,7 +992,10 @@
     "set": "A2",
     "number": 75,
     "rarity": "U",
-    "name": "Uxie",
+    "name": {
+      "en": "Uxie",
+      "fr": "Créhelf"
+    },
     "image": "cPK_10_003560_00_YUXIE_U.webp",
     "packs": [
       "Dialga",
@@ -781,7 +1006,10 @@
     "set": "A2",
     "number": 76,
     "rarity": "R",
-    "name": "Mesprit",
+    "name": {
+      "en": "Mesprit",
+      "fr": "Créfollet"
+    },
     "image": "cPK_10_003570_00_EMRIT_R.webp",
     "packs": [
       "Dialga",
@@ -792,7 +1020,10 @@
     "set": "A2",
     "number": 77,
     "rarity": "U",
-    "name": "Azelf",
+    "name": {
+      "en": "Azelf",
+      "fr": "Créfadet"
+    },
     "image": "cPK_10_003580_00_AGNOME_U.webp",
     "packs": [
       "Dialga",
@@ -803,7 +1034,10 @@
     "set": "A2",
     "number": 78,
     "rarity": "R",
-    "name": "Giratina",
+    "name": {
+      "en": "Giratina",
+      "fr": "Giratina"
+    },
     "image": "cPK_10_003590_00_ORIGINGIRATINA_R.webp",
     "packs": [
       "Palkia"
@@ -813,7 +1047,10 @@
     "set": "A2",
     "number": 79,
     "rarity": "R",
-    "name": "Cresselia",
+    "name": {
+      "en": "Cresselia",
+      "fr": "Cresselia"
+    },
     "image": "cPK_10_003600_00_CRESSELIA_R.webp",
     "packs": [
       "Palkia"
@@ -823,7 +1060,10 @@
     "set": "A2",
     "number": 80,
     "rarity": "C",
-    "name": "Rhyhorn",
+    "name": {
+      "en": "Rhyhorn",
+      "fr": "Rhinocorne"
+    },
     "image": "cPK_10_003610_00_SIHORN_C.webp",
     "packs": [
       "Palkia"
@@ -833,7 +1073,10 @@
     "set": "A2",
     "number": 81,
     "rarity": "U",
-    "name": "Rhydon",
+    "name": {
+      "en": "Rhydon",
+      "fr": "Rhinoféros"
+    },
     "image": "cPK_10_003620_00_SIDON_U.webp",
     "packs": [
       "Palkia"
@@ -843,7 +1086,10 @@
     "set": "A2",
     "number": 82,
     "rarity": "R",
-    "name": "Rhyperior",
+    "name": {
+      "en": "Rhyperior",
+      "fr": "Rhinastoc"
+    },
     "image": "cPK_10_003630_00_DOSIDON_R.webp",
     "packs": [
       "Palkia"
@@ -853,7 +1099,10 @@
     "set": "A2",
     "number": 83,
     "rarity": "C",
-    "name": "Gligar",
+    "name": {
+      "en": "Gligar",
+      "fr": "Scorplane"
+    },
     "image": "cPK_10_003640_00_GLIGER_C.webp",
     "packs": [
       "Dialga"
@@ -863,7 +1112,10 @@
     "set": "A2",
     "number": 84,
     "rarity": "U",
-    "name": "Gliscor",
+    "name": {
+      "en": "Gliscor",
+      "fr": "Scorvol"
+    },
     "image": "cPK_10_003650_00_GLION_U.webp",
     "packs": [
       "Dialga"
@@ -873,7 +1125,10 @@
     "set": "A2",
     "number": 85,
     "rarity": "C",
-    "name": "Hitmontop",
+    "name": {
+      "en": "Hitmontop",
+      "fr": "Kapoera"
+    },
     "image": "cPK_10_003660_00_KAPOERER_C.webp",
     "packs": [
       "Dialga"
@@ -883,7 +1138,10 @@
     "set": "A2",
     "number": 86,
     "rarity": "C",
-    "name": "Nosepass",
+    "name": {
+      "en": "Nosepass",
+      "fr": "Tarinor"
+    },
     "image": "cPK_10_003670_00_NOSEPASS_C.webp",
     "packs": [
       "Dialga",
@@ -894,7 +1152,10 @@
     "set": "A2",
     "number": 87,
     "rarity": "U",
-    "name": "Regirock",
+    "name": {
+      "en": "Regirock",
+      "fr": "Regirock"
+    },
     "image": "cPK_10_003680_00_REGIROCK_U.webp",
     "packs": [
       "Dialga",
@@ -905,7 +1166,10 @@
     "set": "A2",
     "number": 88,
     "rarity": "U",
-    "name": "Cranidos",
+    "name": {
+      "en": "Cranidos",
+      "fr": "Kranidos"
+    },
     "image": "cPK_10_003690_00_ZUGAIDOS_U.webp",
     "packs": [
       "Dialga"
@@ -915,7 +1179,10 @@
     "set": "A2",
     "number": 89,
     "rarity": "R",
-    "name": "Rampardos",
+    "name": {
+      "en": "Rampardos",
+      "fr": "Charkos"
+    },
     "image": "cPK_10_003700_00_RAMPALD_R.webp",
     "packs": [
       "Dialga"
@@ -925,7 +1192,10 @@
     "set": "A2",
     "number": 90,
     "rarity": "C",
-    "name": "Wormadam",
+    "name": {
+      "en": "Wormadam",
+      "fr": "Cheniselle"
+    },
     "image": "cPK_10_003710_00_MINOMADAMSUNACHINOMINO_C.webp",
     "packs": [
       "Dialga"
@@ -935,7 +1205,10 @@
     "set": "A2",
     "number": 91,
     "rarity": "C",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "image": "cPK_10_003720_00_RIOLU_C.webp",
     "packs": [
       "Dialga"
@@ -945,7 +1218,10 @@
     "set": "A2",
     "number": 92,
     "rarity": "R",
-    "name": "Lucario",
+    "name": {
+      "en": "Lucario",
+      "fr": "Lucario"
+    },
     "image": "cPK_10_003730_00_LUCARIO_R.webp",
     "packs": [
       "Dialga"
@@ -955,7 +1231,10 @@
     "set": "A2",
     "number": 93,
     "rarity": "C",
-    "name": "Hippopotas",
+    "name": {
+      "en": "Hippopotas",
+      "fr": "Hippopotas"
+    },
     "image": "cPK_10_003740_00_HIPPOPOTAS_C.webp",
     "packs": [
       "Palkia"
@@ -965,7 +1244,10 @@
     "set": "A2",
     "number": 94,
     "rarity": "U",
-    "name": "Hippowdon",
+    "name": {
+      "en": "Hippowdon",
+      "fr": "Hippodocus"
+    },
     "image": "cPK_10_003750_00_KABALDON_U.webp",
     "packs": [
       "Palkia"
@@ -975,7 +1257,10 @@
     "set": "A2",
     "number": 95,
     "rarity": "RR",
-    "name": "Gallade ex",
+    "name": {
+      "en": "Gallade ex",
+      "fr": "Gallame-ex"
+    },
     "image": "cPK_10_003760_00_ERUREIDOex_RR.webp",
     "packs": [
       "Dialga"
@@ -985,7 +1270,10 @@
     "set": "A2",
     "number": 96,
     "rarity": "C",
-    "name": "Murkrow",
+    "name": {
+      "en": "Murkrow",
+      "fr": "Cornèbre"
+    },
     "image": "cPK_10_003770_00_YAMIKARASU_C.webp",
     "packs": [
       "Dialga"
@@ -995,7 +1283,10 @@
     "set": "A2",
     "number": 97,
     "rarity": "U",
-    "name": "Honchkrow",
+    "name": {
+      "en": "Honchkrow",
+      "fr": "Corboss"
+    },
     "image": "cPK_10_003780_00_DONGKARASU_U.webp",
     "packs": [
       "Dialga"
@@ -1005,7 +1296,10 @@
     "set": "A2",
     "number": 98,
     "rarity": "C",
-    "name": "Sneasel",
+    "name": {
+      "en": "Sneasel",
+      "fr": "Farfuret"
+    },
     "image": "cPK_10_003790_00_NYULA_C.webp",
     "packs": [
       "Palkia"
@@ -1015,7 +1309,10 @@
     "set": "A2",
     "number": 99,
     "rarity": "RR",
-    "name": "Weavile ex",
+    "name": {
+      "en": "Weavile ex",
+      "fr": "Dimoret-ex"
+    },
     "image": "cPK_10_003800_00_MANYULAex_RR.webp",
     "packs": [
       "Palkia"
@@ -1025,7 +1322,10 @@
     "set": "A2",
     "number": 100,
     "rarity": "C",
-    "name": "Poochyena",
+    "name": {
+      "en": "Poochyena",
+      "fr": "Medhyèna"
+    },
     "image": "cPK_10_003810_00_POCHIENA_C.webp",
     "packs": [
       "Dialga",
@@ -1036,7 +1336,10 @@
     "set": "A2",
     "number": 101,
     "rarity": "U",
-    "name": "Mightyena",
+    "name": {
+      "en": "Mightyena",
+      "fr": "Grahyèna"
+    },
     "image": "cPK_10_003820_00_GRAENA_U.webp",
     "packs": [
       "Dialga",
@@ -1047,7 +1350,10 @@
     "set": "A2",
     "number": 102,
     "rarity": "C",
-    "name": "Stunky",
+    "name": {
+      "en": "Stunky",
+      "fr": "Moufouette"
+    },
     "image": "cPK_10_003830_00_SKUNPUU_C.webp",
     "packs": [
       "Dialga"
@@ -1057,7 +1363,10 @@
     "set": "A2",
     "number": 103,
     "rarity": "U",
-    "name": "Skuntank",
+    "name": {
+      "en": "Skuntank",
+      "fr": "Moufflair"
+    },
     "image": "cPK_10_003840_00_SKUTANK_U.webp",
     "packs": [
       "Dialga"
@@ -1067,7 +1376,10 @@
     "set": "A2",
     "number": 104,
     "rarity": "U",
-    "name": "Spiritomb",
+    "name": {
+      "en": "Spiritomb",
+      "fr": "Spiritomb"
+    },
     "image": "cPK_10_003850_00_MIKARUGE_U.webp",
     "packs": [
       "Palkia"
@@ -1077,7 +1389,10 @@
     "set": "A2",
     "number": 105,
     "rarity": "C",
-    "name": "Skorupi",
+    "name": {
+      "en": "Skorupi",
+      "fr": "Rapion"
+    },
     "image": "cPK_10_003860_00_SCORUPI_C.webp",
     "packs": [
       "Dialga",
@@ -1088,7 +1403,10 @@
     "set": "A2",
     "number": 106,
     "rarity": "U",
-    "name": "Drapion",
+    "name": {
+      "en": "Drapion",
+      "fr": "Drascore"
+    },
     "image": "cPK_10_003870_00_DORAPION_U.webp",
     "packs": [
       "Dialga",
@@ -1099,7 +1417,10 @@
     "set": "A2",
     "number": 107,
     "rarity": "C",
-    "name": "Croagunk",
+    "name": {
+      "en": "Croagunk",
+      "fr": "Cradopaud"
+    },
     "image": "cPK_10_003880_00_GUREGGRU_C.webp",
     "packs": [
       "Dialga"
@@ -1109,7 +1430,10 @@
     "set": "A2",
     "number": 108,
     "rarity": "U",
-    "name": "Toxicroak",
+    "name": {
+      "en": "Toxicroak",
+      "fr": "Coatox"
+    },
     "image": "cPK_10_003890_00_DOKUROG_U.webp",
     "packs": [
       "Dialga"
@@ -1119,7 +1443,10 @@
     "set": "A2",
     "number": 109,
     "rarity": "R",
-    "name": "Darkrai",
+    "name": {
+      "en": "Darkrai",
+      "fr": "Darkrai"
+    },
     "image": "cPK_10_003900_00_DARKRAI_R.webp",
     "packs": [
       "Dialga"
@@ -1129,7 +1456,10 @@
     "set": "A2",
     "number": 110,
     "rarity": "RR",
-    "name": "Darkrai ex",
+    "name": {
+      "en": "Darkrai ex",
+      "fr": "Darkrai-ex"
+    },
     "image": "cPK_10_003910_00_DARKRAIex_RR.webp",
     "packs": [
       "Dialga"
@@ -1139,7 +1469,10 @@
     "set": "A2",
     "number": 111,
     "rarity": "U",
-    "name": "Skarmory",
+    "name": {
+      "en": "Skarmory",
+      "fr": "Airmure"
+    },
     "image": "cPK_10_003920_00_AIRMD_U.webp",
     "packs": [
       "Dialga",
@@ -1150,7 +1483,10 @@
     "set": "A2",
     "number": 112,
     "rarity": "U",
-    "name": "Registeel",
+    "name": {
+      "en": "Registeel",
+      "fr": "Registeel"
+    },
     "image": "cPK_10_003930_00_REGISTEEL_U.webp",
     "packs": [
       "Dialga"
@@ -1160,7 +1496,10 @@
     "set": "A2",
     "number": 113,
     "rarity": "U",
-    "name": "Shieldon",
+    "name": {
+      "en": "Shieldon",
+      "fr": "Dinoclier"
+    },
     "image": "cPK_10_003940_00_TATETOPS_U.webp",
     "packs": [
       "Palkia"
@@ -1170,7 +1509,10 @@
     "set": "A2",
     "number": 114,
     "rarity": "R",
-    "name": "Bastiodon",
+    "name": {
+      "en": "Bastiodon",
+      "fr": "Bastiodon"
+    },
     "image": "cPK_10_003950_00_TORIDEPS_R.webp",
     "packs": [
       "Palkia"
@@ -1180,7 +1522,10 @@
     "set": "A2",
     "number": 115,
     "rarity": "C",
-    "name": "Wormadam",
+    "name": {
+      "en": "Wormadam",
+      "fr": "Cheniselle"
+    },
     "image": "cPK_10_003960_00_MINOMADAMGOMINOMINO_C.webp",
     "packs": [
       "Palkia"
@@ -1190,7 +1535,10 @@
     "set": "A2",
     "number": 116,
     "rarity": "C",
-    "name": "Bronzor",
+    "name": {
+      "en": "Bronzor",
+      "fr": "Archéomire"
+    },
     "image": "cPK_10_003970_00_DOHMIRROR_C.webp",
     "packs": [
       "Dialga"
@@ -1200,7 +1548,10 @@
     "set": "A2",
     "number": 117,
     "rarity": "U",
-    "name": "Bronzong",
+    "name": {
+      "en": "Bronzong",
+      "fr": "Archéodong"
+    },
     "image": "cPK_10_003980_00_DOHTAKUN_U.webp",
     "packs": [
       "Dialga"
@@ -1210,7 +1561,10 @@
     "set": "A2",
     "number": 118,
     "rarity": "U",
-    "name": "Probopass",
+    "name": {
+      "en": "Probopass",
+      "fr": "Tarinorme"
+    },
     "image": "cPK_10_003990_00_DAINOSE_U.webp",
     "packs": [
       "Dialga",
@@ -1221,7 +1575,10 @@
     "set": "A2",
     "number": 119,
     "rarity": "RR",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_10_004000_00_DIALGAex_RR.webp",
     "packs": [
       "Dialga"
@@ -1231,7 +1588,10 @@
     "set": "A2",
     "number": 120,
     "rarity": "R",
-    "name": "Heatran",
+    "name": {
+      "en": "Heatran",
+      "fr": "Heatran"
+    },
     "image": "cPK_10_004010_00_HEATRAN_R.webp",
     "packs": [
       "Dialga"
@@ -1241,7 +1601,10 @@
     "set": "A2",
     "number": 121,
     "rarity": "C",
-    "name": "Gible",
+    "name": {
+      "en": "Gible",
+      "fr": "Griknot"
+    },
     "image": "cPK_10_004020_00_FUKAMARU_C.webp",
     "packs": [
       "Palkia"
@@ -1251,7 +1614,10 @@
     "set": "A2",
     "number": 122,
     "rarity": "U",
-    "name": "Gabite",
+    "name": {
+      "en": "Gabite",
+      "fr": "Carmache"
+    },
     "image": "cPK_10_004030_00_GABITE_U.webp",
     "packs": [
       "Palkia"
@@ -1261,7 +1627,10 @@
     "set": "A2",
     "number": 123,
     "rarity": "R",
-    "name": "Garchomp",
+    "name": {
+      "en": "Garchomp",
+      "fr": "Carchacrok"
+    },
     "image": "cPK_10_004040_00_GABURIAS_R.webp",
     "packs": [
       "Palkia"
@@ -1271,7 +1640,10 @@
     "set": "A2",
     "number": 124,
     "rarity": "C",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_10_004050_00_BERORINGA_C.webp",
     "packs": [
       "Palkia"
@@ -1281,7 +1653,10 @@
     "set": "A2",
     "number": 125,
     "rarity": "RR",
-    "name": "Lickilicky ex",
+    "name": {
+      "en": "Lickilicky ex",
+      "fr": "Coudlangue-ex"
+    },
     "image": "cPK_10_004060_00_BEROBELTex_RR.webp",
     "packs": [
       "Palkia"
@@ -1291,7 +1666,10 @@
     "set": "A2",
     "number": 126,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_004070_00_EIEVUI_C.webp",
     "packs": [
       "Dialga",
@@ -1302,7 +1680,10 @@
     "set": "A2",
     "number": 127,
     "rarity": "C",
-    "name": "Porygon",
+    "name": {
+      "en": "Porygon",
+      "fr": "Porygon"
+    },
     "image": "cPK_10_004080_00_PORYGON_C.webp",
     "packs": [
       "Palkia"
@@ -1312,7 +1693,10 @@
     "set": "A2",
     "number": 128,
     "rarity": "U",
-    "name": "Porygon2",
+    "name": {
+      "en": "Porygon2",
+      "fr": "Porygon2"
+    },
     "image": "cPK_10_004090_00_PORYGON2_U.webp",
     "packs": [
       "Palkia"
@@ -1322,7 +1706,10 @@
     "set": "A2",
     "number": 129,
     "rarity": "R",
-    "name": "Porygon-Z",
+    "name": {
+      "en": "Porygon-Z",
+      "fr": "Porygon-Z"
+    },
     "image": "cPK_10_004100_00_PORYGON-Z_R.webp",
     "packs": [
       "Palkia"
@@ -1332,7 +1719,10 @@
     "set": "A2",
     "number": 130,
     "rarity": "C",
-    "name": "Aipom",
+    "name": {
+      "en": "Aipom",
+      "fr": "Capumain"
+    },
     "image": "cPK_10_004110_00_EIPAM_C.webp",
     "packs": [
       "Dialga",
@@ -1343,7 +1733,10 @@
     "set": "A2",
     "number": 131,
     "rarity": "C",
-    "name": "Ambipom",
+    "name": {
+      "en": "Ambipom",
+      "fr": "Capidextre"
+    },
     "image": "cPK_10_004120_00_ETEBOTH_C.webp",
     "packs": [
       "Dialga",
@@ -1354,7 +1747,10 @@
     "set": "A2",
     "number": 132,
     "rarity": "C",
-    "name": "Starly",
+    "name": {
+      "en": "Starly",
+      "fr": "Étourmi"
+    },
     "image": "cPK_10_004130_00_MUKKURU_C.webp",
     "packs": [
       "Palkia"
@@ -1364,7 +1760,10 @@
     "set": "A2",
     "number": 133,
     "rarity": "C",
-    "name": "Staravia",
+    "name": {
+      "en": "Staravia",
+      "fr": "Étourvol"
+    },
     "image": "cPK_10_004140_00_MUKUBIRD_C.webp",
     "packs": [
       "Palkia"
@@ -1374,7 +1773,10 @@
     "set": "A2",
     "number": 134,
     "rarity": "U",
-    "name": "Staraptor",
+    "name": {
+      "en": "Staraptor",
+      "fr": "Étouraptor"
+    },
     "image": "cPK_10_004150_00_MUKUHAWK_U.webp",
     "packs": [
       "Palkia"
@@ -1384,7 +1786,10 @@
     "set": "A2",
     "number": 135,
     "rarity": "C",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_10_004160_00_BIPPA_C.webp",
     "packs": [
       "Dialga"
@@ -1394,7 +1799,10 @@
     "set": "A2",
     "number": 136,
     "rarity": "C",
-    "name": "Bibarel",
+    "name": {
+      "en": "Bibarel",
+      "fr": "Castorno"
+    },
     "image": "cPK_10_004170_00_BEADARU_C.webp",
     "packs": [
       "Dialga"
@@ -1404,7 +1812,10 @@
     "set": "A2",
     "number": 137,
     "rarity": "C",
-    "name": "Buneary",
+    "name": {
+      "en": "Buneary",
+      "fr": "Laporeille"
+    },
     "image": "cPK_10_004180_00_MIMIROL_C.webp",
     "packs": [
       "Dialga"
@@ -1414,7 +1825,10 @@
     "set": "A2",
     "number": 138,
     "rarity": "C",
-    "name": "Lopunny",
+    "name": {
+      "en": "Lopunny",
+      "fr": "Lockpin"
+    },
     "image": "cPK_10_004190_00_MIMILOP_C.webp",
     "packs": [
       "Dialga"
@@ -1424,7 +1838,10 @@
     "set": "A2",
     "number": 139,
     "rarity": "C",
-    "name": "Glameow",
+    "name": {
+      "en": "Glameow",
+      "fr": "Chaglam"
+    },
     "image": "cPK_10_004200_00_NYARMAR_C.webp",
     "packs": [
       "Palkia"
@@ -1434,7 +1851,10 @@
     "set": "A2",
     "number": 140,
     "rarity": "U",
-    "name": "Purugly",
+    "name": {
+      "en": "Purugly",
+      "fr": "Chaffreux"
+    },
     "image": "cPK_10_004210_00_BUNYATTO_U.webp",
     "packs": [
       "Palkia"
@@ -1444,7 +1864,10 @@
     "set": "A2",
     "number": 141,
     "rarity": "C",
-    "name": "Chatot",
+    "name": {
+      "en": "Chatot",
+      "fr": "Pijako"
+    },
     "image": "cPK_10_004220_00_PERAP_C.webp",
     "packs": [
       "Palkia"
@@ -1454,7 +1877,10 @@
     "set": "A2",
     "number": 142,
     "rarity": "C",
-    "name": "Fan Rotom",
+    "name": {
+      "en": "Fan Rotom",
+      "fr": "Motisma Hélice"
+    },
     "image": "cPK_10_004230_00_SPIN ROTOM_C.webp",
     "packs": [
       "Dialga",
@@ -1465,7 +1891,10 @@
     "set": "A2",
     "number": 143,
     "rarity": "R",
-    "name": "Regigigas",
+    "name": {
+      "en": "Regigigas",
+      "fr": "Regigigas"
+    },
     "image": "cPK_10_004240_00_REGIGIGAS_R.webp",
     "packs": [
       "Dialga",
@@ -1476,7 +1905,10 @@
     "set": "A2",
     "number": 144,
     "rarity": "C",
-    "name": "Skull Fossil",
+    "name": {
+      "en": "Skull Fossil",
+      "fr": "Fossile Crâne"
+    },
     "image": "cTR_10_000260_00_ZUGAINOKASEKI_C.webp",
     "packs": [
       "Dialga"
@@ -1486,7 +1918,10 @@
     "set": "A2",
     "number": 145,
     "rarity": "C",
-    "name": "Armor Fossil",
+    "name": {
+      "en": "Armor Fossil",
+      "fr": "Fossile Armure"
+    },
     "image": "cTR_10_000270_00_TATENOKASEKI_C.webp",
     "packs": [
       "Palkia"
@@ -1496,7 +1931,10 @@
     "set": "A2",
     "number": 146,
     "rarity": "U",
-    "name": "Pokémon Communication",
+    "name": {
+      "en": "Pokémon Communication",
+      "fr": "Communication Pokémon"
+    },
     "image": "cTR_10_000280_00_POKEMONTSUUSHIN_U.webp",
     "packs": [
       "Dialga"
@@ -1506,7 +1944,10 @@
     "set": "A2",
     "number": 147,
     "rarity": "U",
-    "name": "Giant Cape",
+    "name": {
+      "en": "Giant Cape",
+      "fr": "Cape Géante"
+    },
     "image": "cTR_10_000290_00_OOKINAMANTO_U.webp",
     "packs": [
       "Dialga"
@@ -1516,7 +1957,10 @@
     "set": "A2",
     "number": 148,
     "rarity": "U",
-    "name": "Rocky Helmet",
+    "name": {
+      "en": "Rocky Helmet",
+      "fr": "Casque Brut"
+    },
     "image": "cTR_10_000300_00_GOTSUGOTSUMETTO_U.webp",
     "packs": [
       "Palkia"
@@ -1526,7 +1970,10 @@
     "set": "A2",
     "number": 149,
     "rarity": "U",
-    "name": "Lum Berry",
+    "name": {
+      "en": "Lum Berry",
+      "fr": "Baie Prine"
+    },
     "image": "cTR_10_000310_00_RAMUNOMI_U.webp",
     "packs": [
       "Palkia"
@@ -1536,7 +1983,10 @@
     "set": "A2",
     "number": 150,
     "rarity": "U",
-    "name": "Cyrus",
+    "name": {
+      "en": "Cyrus",
+      "fr": "Hélio"
+    },
     "image": "cTR_10_000320_00_AKAGI_U.webp",
     "packs": [
       "Palkia"
@@ -1546,7 +1996,10 @@
     "set": "A2",
     "number": 151,
     "rarity": "U",
-    "name": "Team Galactic Grunt",
+    "name": {
+      "en": "Team Galactic Grunt",
+      "fr": "Sbire de la Team Galaxie"
+    },
     "image": "cTR_10_000330_00_GINGADANNOSHITAPPA_U.webp",
     "packs": [
       "Dialga"
@@ -1556,7 +2009,10 @@
     "set": "A2",
     "number": 152,
     "rarity": "U",
-    "name": "Cynthia",
+    "name": {
+      "en": "Cynthia",
+      "fr": "Cynthia"
+    },
     "image": "cTR_10_000340_00_SHIRONA_U.webp",
     "packs": [
       "Palkia"
@@ -1566,7 +2022,10 @@
     "set": "A2",
     "number": 153,
     "rarity": "U",
-    "name": "Volkner",
+    "name": {
+      "en": "Volkner",
+      "fr": "Tanguy"
+    },
     "image": "cTR_10_000350_00_DENZI_U.webp",
     "packs": [
       "Dialga"
@@ -1576,7 +2035,10 @@
     "set": "A2",
     "number": 154,
     "rarity": "U",
-    "name": "Dawn",
+    "name": {
+      "en": "Dawn",
+      "fr": "Aurore"
+    },
     "image": "cTR_10_000360_00_HIKARI_U.webp",
     "packs": [
       "Dialga"
@@ -1586,7 +2048,10 @@
     "set": "A2",
     "number": 155,
     "rarity": "U",
-    "name": "Mars",
+    "name": {
+      "en": "Mars",
+      "fr": "Mars"
+    },
     "image": "cTR_10_000370_00_MARS_U.webp",
     "packs": [
       "Palkia"
@@ -1596,7 +2061,10 @@
     "set": "A2",
     "number": 156,
     "rarity": "AR",
-    "name": "Tangrowth",
+    "name": {
+      "en": "Tangrowth",
+      "fr": "Bouldeneu"
+    },
     "image": "cPK_20_002860_00_MOJUMBO_AR.webp",
     "packs": [
       "Dialga"
@@ -1606,7 +2074,10 @@
     "set": "A2",
     "number": 157,
     "rarity": "AR",
-    "name": "Combee",
+    "name": {
+      "en": "Combee",
+      "fr": "Apitrini"
+    },
     "image": "cPK_20_002980_00_MITSUHONEY_AR.webp",
     "packs": [
       "Dialga"
@@ -1616,7 +2087,10 @@
     "set": "A2",
     "number": 158,
     "rarity": "AR",
-    "name": "Carnivine",
+    "name": {
+      "en": "Carnivine",
+      "fr": "Vortente"
+    },
     "image": "cPK_20_003000_00_MUSKIPPA_AR.webp",
     "packs": [
       "Palkia"
@@ -1626,7 +2100,10 @@
     "set": "A2",
     "number": 159,
     "rarity": "AR",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_20_003030_00_SHAYMIN_AR.webp",
     "packs": [
       "Dialga"
@@ -1636,7 +2113,10 @@
     "set": "A2",
     "number": 160,
     "rarity": "AR",
-    "name": "Mamoswine",
+    "name": {
+      "en": "Mamoswine",
+      "fr": "Mammochon"
+    },
     "image": "cPK_20_003140_00_MAMMOO_AR.webp",
     "packs": [
       "Dialga"
@@ -1646,7 +2126,10 @@
     "set": "A2",
     "number": 161,
     "rarity": "AR",
-    "name": "Gastrodon",
+    "name": {
+      "en": "Gastrodon",
+      "fr": "Tritosor"
+    },
     "image": "cPK_20_003220_00_TRITODON_AR.webp",
     "packs": [
       "Palkia"
@@ -1656,7 +2139,10 @@
     "set": "A2",
     "number": 162,
     "rarity": "AR",
-    "name": "Manaphy",
+    "name": {
+      "en": "Manaphy",
+      "fr": "Manaphy"
+    },
     "image": "cPK_20_003310_00_MANAPHY_AR.webp",
     "packs": [
       "Palkia"
@@ -1666,7 +2152,10 @@
     "set": "A2",
     "number": 163,
     "rarity": "AR",
-    "name": "Shinx",
+    "name": {
+      "en": "Shinx",
+      "fr": "Lixy"
+    },
     "image": "cPK_20_003390_00_KOLINK_AR.webp",
     "packs": [
       "Dialga"
@@ -1676,7 +2165,10 @@
     "set": "A2",
     "number": 164,
     "rarity": "AR",
-    "name": "Rotom",
+    "name": {
+      "en": "Rotom",
+      "fr": "Motisma"
+    },
     "image": "cPK_20_003430_00_ROTOM_AR.webp",
     "packs": [
       "Palkia"
@@ -1686,7 +2178,10 @@
     "set": "A2",
     "number": 165,
     "rarity": "AR",
-    "name": "Drifloon",
+    "name": {
+      "en": "Drifloon",
+      "fr": "Baudrive"
+    },
     "image": "cPK_20_003540_00_FUWANTE_AR.webp",
     "packs": [
       "Dialga"
@@ -1696,7 +2191,10 @@
     "set": "A2",
     "number": 166,
     "rarity": "AR",
-    "name": "Mesprit",
+    "name": {
+      "en": "Mesprit",
+      "fr": "Créfollet"
+    },
     "image": "cPK_20_003570_00_EMRIT_AR.webp",
     "packs": [
       "Dialga"
@@ -1706,7 +2204,10 @@
     "set": "A2",
     "number": 167,
     "rarity": "AR",
-    "name": "Giratina",
+    "name": {
+      "en": "Giratina",
+      "fr": "Giratina"
+    },
     "image": "cPK_20_003590_00_ORIGINGIRATINA_AR.webp",
     "packs": [
       "Palkia"
@@ -1716,7 +2217,10 @@
     "set": "A2",
     "number": 168,
     "rarity": "AR",
-    "name": "Cresselia",
+    "name": {
+      "en": "Cresselia",
+      "fr": "Cresselia"
+    },
     "image": "cPK_20_003600_00_CRESSELIA_AR.webp",
     "packs": [
       "Palkia"
@@ -1726,7 +2230,10 @@
     "set": "A2",
     "number": 169,
     "rarity": "AR",
-    "name": "Rhyperior",
+    "name": {
+      "en": "Rhyperior",
+      "fr": "Rhinastoc"
+    },
     "image": "cPK_20_003630_00_DOSIDON_AR.webp",
     "packs": [
       "Palkia"
@@ -1736,7 +2243,10 @@
     "set": "A2",
     "number": 170,
     "rarity": "AR",
-    "name": "Lucario",
+    "name": {
+      "en": "Lucario",
+      "fr": "Lucario"
+    },
     "image": "cPK_20_003730_00_LUCARIO_AR.webp",
     "packs": [
       "Dialga"
@@ -1746,7 +2256,10 @@
     "set": "A2",
     "number": 171,
     "rarity": "AR",
-    "name": "Hippopotas",
+    "name": {
+      "en": "Hippopotas",
+      "fr": "Hippopotas"
+    },
     "image": "cPK_20_003740_00_HIPPOPOTAS_AR.webp",
     "packs": [
       "Palkia"
@@ -1756,7 +2269,10 @@
     "set": "A2",
     "number": 172,
     "rarity": "AR",
-    "name": "Spiritomb",
+    "name": {
+      "en": "Spiritomb",
+      "fr": "Spiritomb"
+    },
     "image": "cPK_20_003850_00_MIKARUGE_AR.webp",
     "packs": [
       "Palkia"
@@ -1766,7 +2282,10 @@
     "set": "A2",
     "number": 173,
     "rarity": "AR",
-    "name": "Croagunk",
+    "name": {
+      "en": "Croagunk",
+      "fr": "Cradopaud"
+    },
     "image": "cPK_20_003880_00_GUREGGRU_AR.webp",
     "packs": [
       "Dialga"
@@ -1776,7 +2295,10 @@
     "set": "A2",
     "number": 174,
     "rarity": "AR",
-    "name": "Heatran",
+    "name": {
+      "en": "Heatran",
+      "fr": "Heatran"
+    },
     "image": "cPK_20_004010_00_HEATRAN_AR.webp",
     "packs": [
       "Dialga"
@@ -1786,7 +2308,10 @@
     "set": "A2",
     "number": 175,
     "rarity": "AR",
-    "name": "Garchomp",
+    "name": {
+      "en": "Garchomp",
+      "fr": "Carchacrok"
+    },
     "image": "cPK_20_004040_00_GABURIAS_AR.webp",
     "packs": [
       "Palkia"
@@ -1796,7 +2321,10 @@
     "set": "A2",
     "number": 176,
     "rarity": "AR",
-    "name": "Staraptor",
+    "name": {
+      "en": "Staraptor",
+      "fr": "Étouraptor"
+    },
     "image": "cPK_20_004150_00_MUKUHAWK_AR.webp",
     "packs": [
       "Palkia"
@@ -1806,7 +2334,10 @@
     "set": "A2",
     "number": 177,
     "rarity": "AR",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_20_004160_00_BIPPA_AR.webp",
     "packs": [
       "Dialga"
@@ -1816,7 +2347,10 @@
     "set": "A2",
     "number": 178,
     "rarity": "AR",
-    "name": "Glameow",
+    "name": {
+      "en": "Glameow",
+      "fr": "Chaglam"
+    },
     "image": "cPK_20_004200_00_NYARMAR_AR.webp",
     "packs": [
       "Palkia"
@@ -1826,7 +2360,10 @@
     "set": "A2",
     "number": 179,
     "rarity": "AR",
-    "name": "Regigigas",
+    "name": {
+      "en": "Regigigas",
+      "fr": "Regigigas"
+    },
     "image": "cPK_20_004240_00_REGIGIGAS_AR.webp",
     "packs": [
       "Dialga"
@@ -1836,7 +2373,10 @@
     "set": "A2",
     "number": 180,
     "rarity": "SR",
-    "name": "Yanmega ex",
+    "name": {
+      "en": "Yanmega ex",
+      "fr": "Yanmega-ex"
+    },
     "image": "cPK_20_002880_00_MEGAYANMAex_SR.webp",
     "packs": [
       "Dialga"
@@ -1846,7 +2386,10 @@
     "set": "A2",
     "number": 181,
     "rarity": "SR",
-    "name": "Infernape ex",
+    "name": {
+      "en": "Infernape ex",
+      "fr": "Simiabraz-ex"
+    },
     "image": "cPK_20_003100_00_GOUKAZARUex_SR.webp",
     "packs": [
       "Palkia"
@@ -1856,7 +2399,10 @@
     "set": "A2",
     "number": 182,
     "rarity": "SR",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_20_003300_00_PALKIAex_SR.webp",
     "packs": [
       "Palkia"
@@ -1866,7 +2412,10 @@
     "set": "A2",
     "number": 183,
     "rarity": "SR",
-    "name": "Pachirisu ex",
+    "name": {
+      "en": "Pachirisu ex",
+      "fr": "Pachirisu-ex"
+    },
     "image": "cPK_20_003420_00_PACHIRISUex_SR.webp",
     "packs": [
       "Dialga"
@@ -1876,7 +2425,10 @@
     "set": "A2",
     "number": 184,
     "rarity": "SR",
-    "name": "Mismagius ex",
+    "name": {
+      "en": "Mismagius ex",
+      "fr": "Magirêve-ex"
+    },
     "image": "cPK_20_003480_00_MUMARGIex_SR.webp",
     "packs": [
       "Palkia"
@@ -1886,7 +2438,10 @@
     "set": "A2",
     "number": 185,
     "rarity": "SR",
-    "name": "Gallade ex",
+    "name": {
+      "en": "Gallade ex",
+      "fr": "Gallame-ex"
+    },
     "image": "cPK_20_003760_00_ERUREIDOex_SR.webp",
     "packs": [
       "Dialga"
@@ -1896,7 +2451,10 @@
     "set": "A2",
     "number": 186,
     "rarity": "SR",
-    "name": "Weavile ex",
+    "name": {
+      "en": "Weavile ex",
+      "fr": "Dimoret-ex"
+    },
     "image": "cPK_20_003800_00_MANYULAex_SR.webp",
     "packs": [
       "Palkia"
@@ -1906,7 +2464,10 @@
     "set": "A2",
     "number": 187,
     "rarity": "SR",
-    "name": "Darkrai ex",
+    "name": {
+      "en": "Darkrai ex",
+      "fr": "Darkrai-ex"
+    },
     "image": "cPK_20_003910_00_DARKRAIex_SR.webp",
     "packs": [
       "Dialga"
@@ -1916,7 +2477,10 @@
     "set": "A2",
     "number": 188,
     "rarity": "SR",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_20_004000_00_DIALGAex_SR.webp",
     "packs": [
       "Dialga"
@@ -1926,7 +2490,10 @@
     "set": "A2",
     "number": 189,
     "rarity": "SR",
-    "name": "Lickilicky ex",
+    "name": {
+      "en": "Lickilicky ex",
+      "fr": "Coudlangue-ex"
+    },
     "image": "cPK_20_004060_00_BEROBELTex_SR.webp",
     "packs": [
       "Palkia"
@@ -1936,7 +2503,10 @@
     "set": "A2",
     "number": 190,
     "rarity": "SR",
-    "name": "Cyrus",
+    "name": {
+      "en": "Cyrus",
+      "fr": "Hélio"
+    },
     "image": "cTR_20_000320_00_AKAGI_SR.webp",
     "packs": [
       "Palkia"
@@ -1946,7 +2516,10 @@
     "set": "A2",
     "number": 191,
     "rarity": "SR",
-    "name": "Team Galactic Grunt",
+    "name": {
+      "en": "Team Galactic Grunt",
+      "fr": "Sbire de la Team Galaxie"
+    },
     "image": "cTR_20_000330_00_GINGADANNOSHITAPPA_SR.webp",
     "packs": [
       "Dialga"
@@ -1956,7 +2529,10 @@
     "set": "A2",
     "number": 192,
     "rarity": "SR",
-    "name": "Cynthia",
+    "name": {
+      "en": "Cynthia",
+      "fr": "Cynthia"
+    },
     "image": "cTR_20_000340_00_SHIRONA_SR.webp",
     "packs": [
       "Palkia"
@@ -1966,7 +2542,10 @@
     "set": "A2",
     "number": 193,
     "rarity": "SR",
-    "name": "Volkner",
+    "name": {
+      "en": "Volkner",
+      "fr": "Tanguy"
+    },
     "image": "cTR_20_000350_00_DENZI_SR.webp",
     "packs": [
       "Dialga"
@@ -1976,7 +2555,10 @@
     "set": "A2",
     "number": 194,
     "rarity": "SR",
-    "name": "Dawn",
+    "name": {
+      "en": "Dawn",
+      "fr": "Aurore"
+    },
     "image": "cTR_20_000360_00_HIKARI_SR.webp",
     "packs": [
       "Dialga"
@@ -1986,7 +2568,10 @@
     "set": "A2",
     "number": 195,
     "rarity": "SR",
-    "name": "Mars",
+    "name": {
+      "en": "Mars",
+      "fr": "Mars"
+    },
     "image": "cTR_20_000370_00_MARS_SR.webp",
     "packs": [
       "Palkia"
@@ -1996,7 +2581,10 @@
     "set": "A2",
     "number": 196,
     "rarity": "SAR",
-    "name": "Yanmega ex",
+    "name": {
+      "en": "Yanmega ex",
+      "fr": "Yanmega-ex"
+    },
     "image": "cPK_20_002880_01_MEGAYANMAex_SAR.webp",
     "packs": [
       "Dialga"
@@ -2006,7 +2594,10 @@
     "set": "A2",
     "number": 197,
     "rarity": "SAR",
-    "name": "Infernape ex",
+    "name": {
+      "en": "Infernape ex",
+      "fr": "Simiabraz-ex"
+    },
     "image": "cPK_20_003100_01_GOUKAZARUex_SAR.webp",
     "packs": [
       "Palkia"
@@ -2016,7 +2607,10 @@
     "set": "A2",
     "number": 198,
     "rarity": "SAR",
-    "name": "Pachirisu ex",
+    "name": {
+      "en": "Pachirisu ex",
+      "fr": "Pachirisu-ex"
+    },
     "image": "cPK_20_003420_01_PACHIRISUex_SAR.webp",
     "packs": [
       "Dialga"
@@ -2026,7 +2620,10 @@
     "set": "A2",
     "number": 199,
     "rarity": "SAR",
-    "name": "Mismagius ex",
+    "name": {
+      "en": "Mismagius ex",
+      "fr": "Magirêve-ex"
+    },
     "image": "cPK_20_003480_01_MUMARGIex_SAR.webp",
     "packs": [
       "Palkia"
@@ -2036,7 +2633,10 @@
     "set": "A2",
     "number": 200,
     "rarity": "SAR",
-    "name": "Gallade ex",
+    "name": {
+      "en": "Gallade ex",
+      "fr": "Gallame-ex"
+    },
     "image": "cPK_20_003760_01_ERUREIDOex_SAR.webp",
     "packs": [
       "Dialga"
@@ -2046,7 +2646,10 @@
     "set": "A2",
     "number": 201,
     "rarity": "SAR",
-    "name": "Weavile ex",
+    "name": {
+      "en": "Weavile ex",
+      "fr": "Dimoret-ex"
+    },
     "image": "cPK_20_003800_01_MANYULAex_SAR.webp",
     "packs": [
       "Palkia"
@@ -2056,7 +2659,10 @@
     "set": "A2",
     "number": 202,
     "rarity": "SAR",
-    "name": "Darkrai ex",
+    "name": {
+      "en": "Darkrai ex",
+      "fr": "Darkrai-ex"
+    },
     "image": "cPK_20_003910_01_DARKRAIex_SAR.webp",
     "packs": [
       "Dialga"
@@ -2066,7 +2672,10 @@
     "set": "A2",
     "number": 203,
     "rarity": "SAR",
-    "name": "Lickilicky ex",
+    "name": {
+      "en": "Lickilicky ex",
+      "fr": "Coudlangue-ex"
+    },
     "image": "cPK_20_004060_01_BEROBELTex_SAR.webp",
     "packs": [
       "Palkia"
@@ -2076,7 +2685,10 @@
     "set": "A2",
     "number": 204,
     "rarity": "IM",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_20_003300_01_PALKIAex_IM.webp",
     "packs": [
       "Palkia"
@@ -2086,7 +2698,10 @@
     "set": "A2",
     "number": 205,
     "rarity": "IM",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_20_004000_01_DIALGAex_IM.webp",
     "packs": [
       "Dialga"
@@ -2096,7 +2711,10 @@
     "set": "A2",
     "number": 206,
     "rarity": "UR",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_20_003300_02_PALKIAex_UR.webp",
     "packs": [
       "Dialga",
@@ -2107,7 +2725,10 @@
     "set": "A2",
     "number": 207,
     "rarity": "UR",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_20_004000_02_DIALGAex_UR.webp",
     "packs": [
       "Dialga",

--- a/dist/cards/A2a.json
+++ b/dist/cards/A2a.json
@@ -3,7 +3,10 @@
     "set": "A2a",
     "number": 1,
     "rarity": "U",
-    "name": "Heracross",
+    "name": {
+      "en": "Heracross",
+      "fr": "Scarhino"
+    },
     "image": "cPK_10_004250_00_HERACROS_U.webp",
     "packs": [
       "Arceus"
@@ -13,7 +16,10 @@
     "set": "A2a",
     "number": 2,
     "rarity": "C",
-    "name": "Burmy",
+    "name": {
+      "en": "Burmy",
+      "fr": "Cheniti"
+    },
     "image": "cPK_10_004260_00_MINOMUCCHI_C.webp",
     "packs": [
       "Arceus"
@@ -23,7 +29,10 @@
     "set": "A2a",
     "number": 3,
     "rarity": "U",
-    "name": "Mothim",
+    "name": {
+      "en": "Mothim",
+      "fr": "Papilord"
+    },
     "image": "cPK_10_004270_00_GAMALE_U.webp",
     "packs": [
       "Arceus"
@@ -33,7 +42,10 @@
     "set": "A2a",
     "number": 4,
     "rarity": "C",
-    "name": "Combee",
+    "name": {
+      "en": "Combee",
+      "fr": "Apitrini"
+    },
     "image": "cPK_10_004280_00_MITSUHONEY_C.webp",
     "packs": [
       "Arceus"
@@ -43,7 +55,10 @@
     "set": "A2a",
     "number": 5,
     "rarity": "U",
-    "name": "Vespiquen",
+    "name": {
+      "en": "Vespiquen",
+      "fr": "Apireine"
+    },
     "image": "cPK_10_004290_00_BEEQUEN_U.webp",
     "packs": [
       "Arceus"
@@ -53,7 +68,10 @@
     "set": "A2a",
     "number": 6,
     "rarity": "C",
-    "name": "Cherubi",
+    "name": {
+      "en": "Cherubi",
+      "fr": "Ceribou"
+    },
     "image": "cPK_10_004300_00_CHERINBO_C.webp",
     "packs": [
       "Arceus"
@@ -63,7 +81,10 @@
     "set": "A2a",
     "number": 7,
     "rarity": "U",
-    "name": "Cherrim",
+    "name": {
+      "en": "Cherrim",
+      "fr": "Ceriflor"
+    },
     "image": "cPK_10_004310_00_CHERRIM_U.webp",
     "packs": [
       "Arceus"
@@ -73,7 +94,10 @@
     "set": "A2a",
     "number": 8,
     "rarity": "U",
-    "name": "Cherrim",
+    "name": {
+      "en": "Cherrim",
+      "fr": "Ceriflor"
+    },
     "image": "cPK_10_004320_00_CHERRIM_U.webp",
     "packs": [
       "Arceus"
@@ -83,7 +107,10 @@
     "set": "A2a",
     "number": 9,
     "rarity": "R",
-    "name": "Carnivine",
+    "name": {
+      "en": "Carnivine",
+      "fr": "Vortente"
+    },
     "image": "cPK_10_004330_00_MUSKIPPA_R.webp",
     "packs": [
       "Arceus"
@@ -93,7 +120,10 @@
     "set": "A2a",
     "number": 10,
     "rarity": "RR",
-    "name": "Leafeon ex",
+    "name": {
+      "en": "Leafeon ex",
+      "fr": "Phyllali-ex"
+    },
     "image": "cPK_10_004340_00_LEAFIAex_RR.webp",
     "packs": [
       "Arceus"
@@ -103,7 +133,10 @@
     "set": "A2a",
     "number": 11,
     "rarity": "C",
-    "name": "Houndour",
+    "name": {
+      "en": "Houndour",
+      "fr": "Malosse"
+    },
     "image": "cPK_10_004350_00_DELVIL_C.webp",
     "packs": [
       "Arceus"
@@ -113,7 +146,10 @@
     "set": "A2a",
     "number": 12,
     "rarity": "U",
-    "name": "Houndoom",
+    "name": {
+      "en": "Houndoom",
+      "fr": "Démolosse"
+    },
     "image": "cPK_10_004360_00_HELLGAR_U.webp",
     "packs": [
       "Arceus"
@@ -123,7 +159,10 @@
     "set": "A2a",
     "number": 13,
     "rarity": "R",
-    "name": "Heatran",
+    "name": {
+      "en": "Heatran",
+      "fr": "Heatran"
+    },
     "image": "cPK_10_004370_00_HEATRAN_R.webp",
     "packs": [
       "Arceus"
@@ -133,7 +172,10 @@
     "set": "A2a",
     "number": 14,
     "rarity": "C",
-    "name": "Marill",
+    "name": {
+      "en": "Marill",
+      "fr": "Marill"
+    },
     "image": "cPK_10_004380_00_MARIL_C.webp",
     "packs": [
       "Arceus"
@@ -143,7 +185,10 @@
     "set": "A2a",
     "number": 15,
     "rarity": "C",
-    "name": "Azumarill",
+    "name": {
+      "en": "Azumarill",
+      "fr": "Azumarill"
+    },
     "image": "cPK_10_004390_00_MARILLI_C.webp",
     "packs": [
       "Arceus"
@@ -153,7 +198,10 @@
     "set": "A2a",
     "number": 16,
     "rarity": "C",
-    "name": "Barboach",
+    "name": {
+      "en": "Barboach",
+      "fr": "Barloche"
+    },
     "image": "cPK_10_004400_00_DOJOACH_C.webp",
     "packs": [
       "Arceus"
@@ -163,7 +211,10 @@
     "set": "A2a",
     "number": 17,
     "rarity": "U",
-    "name": "Whiscash",
+    "name": {
+      "en": "Whiscash",
+      "fr": "Barbicha"
+    },
     "image": "cPK_10_004410_00_NAMAZUN_U.webp",
     "packs": [
       "Arceus"
@@ -173,7 +224,10 @@
     "set": "A2a",
     "number": 18,
     "rarity": "C",
-    "name": "Snorunt",
+    "name": {
+      "en": "Snorunt",
+      "fr": "Stalgamin"
+    },
     "image": "cPK_10_004420_00_YUKIWARASHI_C.webp",
     "packs": [
       "Arceus"
@@ -183,7 +237,10 @@
     "set": "A2a",
     "number": 19,
     "rarity": "U",
-    "name": "Froslass",
+    "name": {
+      "en": "Froslass",
+      "fr": "Momartik"
+    },
     "image": "cPK_10_004430_00_YUKIMENOKO_U.webp",
     "packs": [
       "Arceus"
@@ -193,7 +250,10 @@
     "set": "A2a",
     "number": 20,
     "rarity": "C",
-    "name": "Snover",
+    "name": {
+      "en": "Snover",
+      "fr": "Blizzi"
+    },
     "image": "cPK_10_004440_00_YUKIKABURI_C.webp",
     "packs": [
       "Arceus"
@@ -203,7 +263,10 @@
     "set": "A2a",
     "number": 21,
     "rarity": "R",
-    "name": "Abomasnow",
+    "name": {
+      "en": "Abomasnow",
+      "fr": "Blizzaroi"
+    },
     "image": "cPK_10_004450_00_YUKINOOH_R.webp",
     "packs": [
       "Arceus"
@@ -213,7 +276,10 @@
     "set": "A2a",
     "number": 22,
     "rarity": "RR",
-    "name": "Glaceon ex",
+    "name": {
+      "en": "Glaceon ex",
+      "fr": "Givrali-ex"
+    },
     "image": "cPK_10_004460_00_GLACIAex_RR.webp",
     "packs": [
       "Arceus"
@@ -223,7 +289,10 @@
     "set": "A2a",
     "number": 23,
     "rarity": "R",
-    "name": "Palkia",
+    "name": {
+      "en": "Origin Forme Palkia",
+      "fr": "Palkia Forme Originelle"
+    },
     "image": "cPK_10_004470_00_ORIGINPALKIA_R.webp",
     "packs": [
       "Arceus"
@@ -233,7 +302,10 @@
     "set": "A2a",
     "number": 24,
     "rarity": "U",
-    "name": "Phione",
+    "name": {
+      "en": "Phione",
+      "fr": "Phione"
+    },
     "image": "cPK_10_004480_00_PHIONE_U.webp",
     "packs": [
       "Arceus"
@@ -243,7 +315,10 @@
     "set": "A2a",
     "number": 25,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_10_004490_00_PIKACHU_C.webp",
     "packs": [
       "Arceus"
@@ -253,7 +328,10 @@
     "set": "A2a",
     "number": 26,
     "rarity": "R",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "image": "cPK_10_004500_00_RAICHU_R.webp",
     "packs": [
       "Arceus"
@@ -263,7 +341,10 @@
     "set": "A2a",
     "number": 27,
     "rarity": "C",
-    "name": "Electrike",
+    "name": {
+      "en": "Electrike",
+      "fr": "Dynavolt"
+    },
     "image": "cPK_10_004510_00_RAKURAI_C.webp",
     "packs": [
       "Arceus"
@@ -273,7 +354,10 @@
     "set": "A2a",
     "number": 28,
     "rarity": "U",
-    "name": "Manectric",
+    "name": {
+      "en": "Manectric",
+      "fr": "Élecsprint"
+    },
     "image": "cPK_10_004520_00_LIVOLT_U.webp",
     "packs": [
       "Arceus"
@@ -283,7 +367,10 @@
     "set": "A2a",
     "number": 29,
     "rarity": "C",
-    "name": "Clefairy",
+    "name": {
+      "en": "Clefairy",
+      "fr": "Mélofée"
+    },
     "image": "cPK_10_004530_00_PIPPI_C.webp",
     "packs": [
       "Arceus"
@@ -293,7 +380,10 @@
     "set": "A2a",
     "number": 30,
     "rarity": "U",
-    "name": "Clefable",
+    "name": {
+      "en": "Clefable",
+      "fr": "Mélodelfe"
+    },
     "image": "cPK_10_004540_00_PIXY_U.webp",
     "packs": [
       "Arceus"
@@ -303,7 +393,10 @@
     "set": "A2a",
     "number": 31,
     "rarity": "C",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "image": "cPK_10_004550_00_GHOS_C.webp",
     "packs": [
       "Arceus"
@@ -313,7 +406,10 @@
     "set": "A2a",
     "number": 32,
     "rarity": "C",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "image": "cPK_10_004560_00_GHOST_C.webp",
     "packs": [
       "Arceus"
@@ -323,7 +419,10 @@
     "set": "A2a",
     "number": 33,
     "rarity": "U",
-    "name": "Gengar",
+    "name": {
+      "en": "Gengar",
+      "fr": "Ectoplasma"
+    },
     "image": "cPK_10_004570_00_GANGAR_U.webp",
     "packs": [
       "Arceus"
@@ -333,7 +432,10 @@
     "set": "A2a",
     "number": 34,
     "rarity": "U",
-    "name": "Unown",
+    "name": {
+      "en": "Unown",
+      "fr": "Zarbi"
+    },
     "image": "cPK_10_004580_00_UNKNOWN_U.webp",
     "packs": [
       "Arceus"
@@ -343,7 +445,10 @@
     "set": "A2a",
     "number": 35,
     "rarity": "R",
-    "name": "Rotom",
+    "name": {
+      "en": "Rotom",
+      "fr": "Motisma"
+    },
     "image": "cPK_10_004590_00_ROTOM_R.webp",
     "packs": [
       "Arceus"
@@ -353,7 +458,10 @@
     "set": "A2a",
     "number": 36,
     "rarity": "U",
-    "name": "Sudowoodo",
+    "name": {
+      "en": "Sudowoodo",
+      "fr": "Simularbre"
+    },
     "image": "cPK_10_004600_00_USOKKIE_U.webp",
     "packs": [
       "Arceus"
@@ -363,7 +471,10 @@
     "set": "A2a",
     "number": 37,
     "rarity": "C",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_10_004610_00_GOMAZOU_C.webp",
     "packs": [
       "Arceus"
@@ -373,7 +484,10 @@
     "set": "A2a",
     "number": 38,
     "rarity": "U",
-    "name": "Donphan",
+    "name": {
+      "en": "Donphan",
+      "fr": "Donphan"
+    },
     "image": "cPK_10_004620_00_DONFAN_U.webp",
     "packs": [
       "Arceus"
@@ -383,7 +497,10 @@
     "set": "A2a",
     "number": 39,
     "rarity": "C",
-    "name": "Larvitar",
+    "name": {
+      "en": "Larvitar",
+      "fr": "Embrylex"
+    },
     "image": "cPK_10_004630_00_YOGIRAS_C.webp",
     "packs": [
       "Arceus"
@@ -393,7 +510,10 @@
     "set": "A2a",
     "number": 40,
     "rarity": "U",
-    "name": "Pupitar",
+    "name": {
+      "en": "Pupitar",
+      "fr": "Ymphect"
+    },
     "image": "cPK_10_004640_00_SANAGIRAS_U.webp",
     "packs": [
       "Arceus"
@@ -403,7 +523,10 @@
     "set": "A2a",
     "number": 41,
     "rarity": "R",
-    "name": "Tyranitar",
+    "name": {
+      "en": "Tyranitar",
+      "fr": "Tyranocif"
+    },
     "image": "cPK_10_004650_00_BANGIRAS_R.webp",
     "packs": [
       "Arceus"
@@ -413,7 +536,10 @@
     "set": "A2a",
     "number": 42,
     "rarity": "C",
-    "name": "Nosepass",
+    "name": {
+      "en": "Nosepass",
+      "fr": "Tarinor"
+    },
     "image": "cPK_10_004660_00_NOSEPASS_C.webp",
     "packs": [
       "Arceus"
@@ -423,7 +549,10 @@
     "set": "A2a",
     "number": 43,
     "rarity": "C",
-    "name": "Meditite",
+    "name": {
+      "en": "Meditite",
+      "fr": "Méditikka"
+    },
     "image": "cPK_10_004670_00_ASANAN_C.webp",
     "packs": [
       "Arceus"
@@ -433,7 +562,10 @@
     "set": "A2a",
     "number": 44,
     "rarity": "U",
-    "name": "Medicham",
+    "name": {
+      "en": "Medicham",
+      "fr": "Charmina"
+    },
     "image": "cPK_10_004680_00_CHAREM_U.webp",
     "packs": [
       "Arceus"
@@ -443,7 +575,10 @@
     "set": "A2a",
     "number": 45,
     "rarity": "C",
-    "name": "Gible",
+    "name": {
+      "en": "Gible",
+      "fr": "Griknot"
+    },
     "image": "cPK_10_004690_00_FUKAMARU_C.webp",
     "packs": [
       "Arceus"
@@ -453,7 +588,10 @@
     "set": "A2a",
     "number": 46,
     "rarity": "C",
-    "name": "Gabite",
+    "name": {
+      "en": "Gabite",
+      "fr": "Carmache"
+    },
     "image": "cPK_10_004700_00_GABITE_C.webp",
     "packs": [
       "Arceus"
@@ -463,7 +601,10 @@
     "set": "A2a",
     "number": 47,
     "rarity": "RR",
-    "name": "Garchomp ex",
+    "name": {
+      "en": "Garchomp ex",
+      "fr": "Carchacrok-ex"
+    },
     "image": "cPK_10_004710_00_GABURIASex_RR.webp",
     "packs": [
       "Arceus"
@@ -473,7 +614,10 @@
     "set": "A2a",
     "number": 48,
     "rarity": "C",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "image": "cPK_10_004720_00_ZUBAT_C.webp",
     "packs": [
       "Arceus"
@@ -483,7 +627,10 @@
     "set": "A2a",
     "number": 49,
     "rarity": "C",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "image": "cPK_10_004730_00_GOLBAT_C.webp",
     "packs": [
       "Arceus"
@@ -493,7 +640,10 @@
     "set": "A2a",
     "number": 50,
     "rarity": "R",
-    "name": "Crobat",
+    "name": {
+      "en": "Crobat",
+      "fr": "Nostenfer"
+    },
     "image": "cPK_10_004740_00_CROBAT_R.webp",
     "packs": [
       "Arceus"
@@ -503,7 +653,10 @@
     "set": "A2a",
     "number": 51,
     "rarity": "C",
-    "name": "Croagunk",
+    "name": {
+      "en": "Croagunk",
+      "fr": "Cradopaud"
+    },
     "image": "cPK_10_004750_00_GUREGGRU_C.webp",
     "packs": [
       "Arceus"
@@ -513,7 +666,10 @@
     "set": "A2a",
     "number": 52,
     "rarity": "U",
-    "name": "Toxicroak",
+    "name": {
+      "en": "Toxicroak",
+      "fr": "Coatox"
+    },
     "image": "cPK_10_004760_00_DOKUROG_U.webp",
     "packs": [
       "Arceus"
@@ -523,7 +679,10 @@
     "set": "A2a",
     "number": 53,
     "rarity": "C",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_10_004770_00_COIL_C.webp",
     "packs": [
       "Arceus"
@@ -533,7 +692,10 @@
     "set": "A2a",
     "number": 54,
     "rarity": "C",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "image": "cPK_10_004780_00_RARECOIL_C.webp",
     "packs": [
       "Arceus"
@@ -543,7 +705,10 @@
     "set": "A2a",
     "number": 55,
     "rarity": "R",
-    "name": "Magnezone",
+    "name": {
+      "en": "Magnezone",
+      "fr": "Magnézone"
+    },
     "image": "cPK_10_004790_00_JIBACOIL_R.webp",
     "packs": [
       "Arceus"
@@ -553,7 +718,10 @@
     "set": "A2a",
     "number": 56,
     "rarity": "C",
-    "name": "Mawile",
+    "name": {
+      "en": "Mawile",
+      "fr": "Mysdibule"
+    },
     "image": "cPK_10_004800_00_KUCHEAT_C.webp",
     "packs": [
       "Arceus"
@@ -563,7 +731,10 @@
     "set": "A2a",
     "number": 57,
     "rarity": "RR",
-    "name": "Probopass ex",
+    "name": {
+      "en": "Probopass ex",
+      "fr": "Tarinorme-ex"
+    },
     "image": "cPK_10_004810_00_DAINOSEex_RR.webp",
     "packs": [
       "Arceus"
@@ -573,7 +744,10 @@
     "set": "A2a",
     "number": 58,
     "rarity": "C",
-    "name": "Bronzor",
+    "name": {
+      "en": "Bronzor",
+      "fr": "Archéomire"
+    },
     "image": "cPK_10_004820_00_DOHMIRROR_C.webp",
     "packs": [
       "Arceus"
@@ -583,7 +757,10 @@
     "set": "A2a",
     "number": 59,
     "rarity": "U",
-    "name": "Bronzong",
+    "name": {
+      "en": "Bronzong",
+      "fr": "Archéodong"
+    },
     "image": "cPK_10_004830_00_DOHTAKUN_U.webp",
     "packs": [
       "Arceus"
@@ -593,7 +770,10 @@
     "set": "A2a",
     "number": 60,
     "rarity": "R",
-    "name": "Dialga",
+    "name": {
+      "en": "Origin Forme Dialga",
+      "fr": "Dialga Forme Originelle"
+    },
     "image": "cPK_10_004840_00_ORIGINDIALGA_R.webp",
     "packs": [
       "Arceus"
@@ -603,7 +783,10 @@
     "set": "A2a",
     "number": 61,
     "rarity": "R",
-    "name": "Giratina",
+    "name": {
+      "en": "Giratina",
+      "fr": "Giratina"
+    },
     "image": "cPK_10_004850_00_GIRATINA_R.webp",
     "packs": [
       "Arceus"
@@ -613,7 +796,10 @@
     "set": "A2a",
     "number": 62,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_004860_00_EIEVUI_C.webp",
     "packs": [
       "Arceus"
@@ -623,7 +809,10 @@
     "set": "A2a",
     "number": 63,
     "rarity": "U",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "image": "cPK_10_004870_00_KABIGON_U.webp",
     "packs": [
       "Arceus"
@@ -633,7 +822,10 @@
     "set": "A2a",
     "number": 64,
     "rarity": "C",
-    "name": "Hoothoot",
+    "name": {
+      "en": "Hoothoot",
+      "fr": "Hoothoot"
+    },
     "image": "cPK_10_004880_00_HOHO_C.webp",
     "packs": [
       "Arceus"
@@ -643,7 +835,10 @@
     "set": "A2a",
     "number": 65,
     "rarity": "U",
-    "name": "Noctowl",
+    "name": {
+      "en": "Noctowl",
+      "fr": "Noarfang"
+    },
     "image": "cPK_10_004890_00_YORUNOZUKU_U.webp",
     "packs": [
       "Arceus"
@@ -653,7 +848,10 @@
     "set": "A2a",
     "number": 66,
     "rarity": "C",
-    "name": "Starly",
+    "name": {
+      "en": "Starly",
+      "fr": "Étourmi"
+    },
     "image": "cPK_10_004900_00_MUKKURU_C.webp",
     "packs": [
       "Arceus"
@@ -663,7 +861,10 @@
     "set": "A2a",
     "number": 67,
     "rarity": "C",
-    "name": "Staravia",
+    "name": {
+      "en": "Staravia",
+      "fr": "Étourvol"
+    },
     "image": "cPK_10_004910_00_MUKUBIRD_C.webp",
     "packs": [
       "Arceus"
@@ -673,7 +874,10 @@
     "set": "A2a",
     "number": 68,
     "rarity": "U",
-    "name": "Staraptor",
+    "name": {
+      "en": "Staraptor",
+      "fr": "Étouraptor"
+    },
     "image": "cPK_10_004920_00_MUKUHAWK_U.webp",
     "packs": [
       "Arceus"
@@ -683,7 +887,10 @@
     "set": "A2a",
     "number": 69,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_10_004930_00_SHAYMIN_R.webp",
     "packs": [
       "Arceus"
@@ -693,7 +900,10 @@
     "set": "A2a",
     "number": 70,
     "rarity": "R",
-    "name": "Arceus",
+    "name": {
+      "en": "Arceus",
+      "fr": "Arceus"
+    },
     "image": "cPK_10_004940_00_ARCEUS_R.webp",
     "packs": [
       "Arceus"
@@ -703,7 +913,10 @@
     "set": "A2a",
     "number": 71,
     "rarity": "RR",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_10_004950_00_ARCEUSex_RR.webp",
     "packs": [
       "Arceus"
@@ -713,7 +926,10 @@
     "set": "A2a",
     "number": 72,
     "rarity": "U",
-    "name": "Irida",
+    "name": {
+      "en": "Irida",
+      "fr": "Nacchara"
+    },
     "image": "cTR_10_000380_00_KAI_U.webp",
     "packs": [
       "Arceus"
@@ -723,7 +939,10 @@
     "set": "A2a",
     "number": 73,
     "rarity": "U",
-    "name": "Celestic Town Elder",
+    "name": {
+      "en": "Celestic Town Elder",
+      "fr": "Doyenne de Célestia"
+    },
     "image": "cTR_10_000390_00_KANNAGITOWNNOTYOUROU_U.webp",
     "packs": [
       "Arceus"
@@ -733,7 +952,10 @@
     "set": "A2a",
     "number": 74,
     "rarity": "U",
-    "name": "Barry",
+    "name": {
+      "en": "Barry",
+      "fr": "René"
+    },
     "image": "cTR_10_000400_00_JUN_U.webp",
     "packs": [
       "Arceus"
@@ -743,7 +965,10 @@
     "set": "A2a",
     "number": 75,
     "rarity": "U",
-    "name": "Adaman",
+    "name": {
+      "en": "Adaman",
+      "fr": "Adamantin"
+    },
     "image": "cTR_10_000410_00_SEKI_U.webp",
     "packs": [
       "Arceus"
@@ -753,7 +978,10 @@
     "set": "A2a",
     "number": 76,
     "rarity": "AR",
-    "name": "Houndoom",
+    "name": {
+      "en": "Houndoom",
+      "fr": "Démolosse"
+    },
     "image": "cPK_20_004360_00_HELLGAR_AR.webp",
     "packs": [
       "Arceus"
@@ -763,7 +991,10 @@
     "set": "A2a",
     "number": 77,
     "rarity": "AR",
-    "name": "Marill",
+    "name": {
+      "en": "Marill",
+      "fr": "Marill"
+    },
     "image": "cPK_20_004380_00_MARIL_AR.webp",
     "packs": [
       "Arceus"
@@ -773,7 +1004,10 @@
     "set": "A2a",
     "number": 78,
     "rarity": "AR",
-    "name": "Unown",
+    "name": {
+      "en": "Unown",
+      "fr": "Zarbi"
+    },
     "image": "cPK_20_004580_00_UNKNOWN_AR.webp",
     "packs": [
       "Arceus"
@@ -783,7 +1017,10 @@
     "set": "A2a",
     "number": 79,
     "rarity": "AR",
-    "name": "Sudowoodo",
+    "name": {
+      "en": "Sudowoodo",
+      "fr": "Simularbre"
+    },
     "image": "cPK_20_004600_00_USOKKIE_AR.webp",
     "packs": [
       "Arceus"
@@ -793,7 +1030,10 @@
     "set": "A2a",
     "number": 80,
     "rarity": "AR",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_20_004770_00_COIL_AR.webp",
     "packs": [
       "Arceus"
@@ -803,7 +1043,10 @@
     "set": "A2a",
     "number": 81,
     "rarity": "AR",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_20_004930_00_SHAYMIN_AR.webp",
     "packs": [
       "Arceus"
@@ -813,7 +1056,10 @@
     "set": "A2a",
     "number": 82,
     "rarity": "SR",
-    "name": "Leafeon ex",
+    "name": {
+      "en": "Leafeon ex",
+      "fr": "Phyllali-ex"
+    },
     "image": "cPK_20_004340_00_LEAFIAex_SR.webp",
     "packs": [
       "Arceus"
@@ -823,7 +1069,10 @@
     "set": "A2a",
     "number": 83,
     "rarity": "SR",
-    "name": "Glaceon ex",
+    "name": {
+      "en": "Glaceon ex",
+      "fr": "Givrali-ex"
+    },
     "image": "cPK_20_004460_00_GLACIAex_SR.webp",
     "packs": [
       "Arceus"
@@ -833,7 +1082,10 @@
     "set": "A2a",
     "number": 84,
     "rarity": "SR",
-    "name": "Garchomp ex",
+    "name": {
+      "en": "Garchomp ex",
+      "fr": "Carchacrok-ex"
+    },
     "image": "cPK_20_004710_00_GABURIASex_SR.webp",
     "packs": [
       "Arceus"
@@ -843,7 +1095,10 @@
     "set": "A2a",
     "number": 85,
     "rarity": "SR",
-    "name": "Probopass ex",
+    "name": {
+      "en": "Probopass ex",
+      "fr": "Tarinorme-ex"
+    },
     "image": "cPK_20_004810_00_DAINOSEex_SR.webp",
     "packs": [
       "Arceus"
@@ -853,7 +1108,10 @@
     "set": "A2a",
     "number": 86,
     "rarity": "SR",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_20_004950_00_ARCEUSex_SR.webp",
     "packs": [
       "Arceus"
@@ -863,7 +1121,10 @@
     "set": "A2a",
     "number": 87,
     "rarity": "SR",
-    "name": "Irida",
+    "name": {
+      "en": "Irida",
+      "fr": "Nacchara"
+    },
     "image": "cTR_20_000380_00_KAI_SR.webp",
     "packs": [
       "Arceus"
@@ -873,7 +1134,10 @@
     "set": "A2a",
     "number": 88,
     "rarity": "SR",
-    "name": "Celestic Town Elder",
+    "name": {
+      "en": "Celestic Town Elder",
+      "fr": "Doyenne de Célestia"
+    },
     "image": "cTR_20_000390_00_KANNAGITOWNNOTYOUROU_SR.webp",
     "packs": [
       "Arceus"
@@ -883,7 +1147,10 @@
     "set": "A2a",
     "number": 89,
     "rarity": "SR",
-    "name": "Barry",
+    "name": {
+      "en": "Barry",
+      "fr": "René"
+    },
     "image": "cTR_20_000400_00_JUN_SR.webp",
     "packs": [
       "Arceus"
@@ -893,7 +1160,10 @@
     "set": "A2a",
     "number": 90,
     "rarity": "SR",
-    "name": "Adaman",
+    "name": {
+      "en": "Adaman",
+      "fr": "Adamantin"
+    },
     "image": "cTR_20_000410_00_SEKI_SR.webp",
     "packs": [
       "Arceus"
@@ -903,7 +1173,10 @@
     "set": "A2a",
     "number": 91,
     "rarity": "SAR",
-    "name": "Leafeon ex",
+    "name": {
+      "en": "Leafeon ex",
+      "fr": "Phyllali-ex"
+    },
     "image": "cPK_20_004340_01_LEAFIAex_SAR.webp",
     "packs": [
       "Arceus"
@@ -913,7 +1186,10 @@
     "set": "A2a",
     "number": 92,
     "rarity": "SAR",
-    "name": "Glaceon ex",
+    "name": {
+      "en": "Glaceon ex",
+      "fr": "Givrali-ex"
+    },
     "image": "cPK_20_004460_01_GLACIAex_SAR.webp",
     "packs": [
       "Arceus"
@@ -923,7 +1199,10 @@
     "set": "A2a",
     "number": 93,
     "rarity": "SAR",
-    "name": "Garchomp ex",
+    "name": {
+      "en": "Garchomp ex",
+      "fr": "Carchacrok-ex"
+    },
     "image": "cPK_20_004710_01_GABURIASex_SAR.webp",
     "packs": [
       "Arceus"
@@ -933,7 +1212,10 @@
     "set": "A2a",
     "number": 94,
     "rarity": "SAR",
-    "name": "Probopass ex",
+    "name": {
+      "en": "Probopass ex",
+      "fr": "Tarinorme-ex"
+    },
     "image": "cPK_20_004810_01_DAINOSEex_SAR.webp",
     "packs": [
       "Arceus"
@@ -943,7 +1225,10 @@
     "set": "A2a",
     "number": 95,
     "rarity": "IM",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_20_004950_01_ARCEUSex_IM.webp",
     "packs": [
       "Arceus"
@@ -953,7 +1238,10 @@
     "set": "A2a",
     "number": 96,
     "rarity": "UR",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_20_004950_02_ARCEUSex_UR.webp",
     "packs": [
       "Arceus"

--- a/dist/cards/A2b.json
+++ b/dist/cards/A2b.json
@@ -3,7 +3,10 @@
     "set": "A2b",
     "number": 1,
     "rarity": "C",
-    "name": "Weedle",
+    "name": {
+      "en": "Weedle",
+      "fr": "Aspicot"
+    },
     "image": "cPK_10_005210_00_BEEDLE_C.webp",
     "packs": [
       "Shining"
@@ -13,7 +16,10 @@
     "set": "A2b",
     "number": 2,
     "rarity": "U",
-    "name": "Kakuna",
+    "name": {
+      "en": "Kakuna",
+      "fr": "Coconfort"
+    },
     "image": "cPK_10_005220_00_COCOON_U.webp",
     "packs": [
       "Shining"
@@ -23,7 +29,10 @@
     "set": "A2b",
     "number": 3,
     "rarity": "RR",
-    "name": "Beedrill ex",
+    "name": {
+      "en": "Beedrill ex",
+      "fr": "Dardargnan-ex"
+    },
     "image": "cPK_10_005230_00_SPEARex_RR.webp",
     "packs": [
       "Shining"
@@ -33,7 +42,10 @@
     "set": "A2b",
     "number": 4,
     "rarity": "C",
-    "name": "Pinsir",
+    "name": {
+      "en": "Pinsir",
+      "fr": "Scarabrute"
+    },
     "image": "cPK_10_005240_00_KAILIOS_C.webp",
     "packs": [
       "Shining"
@@ -43,7 +55,10 @@
     "set": "A2b",
     "number": 5,
     "rarity": "C",
-    "name": "Sprigatito",
+    "name": {
+      "en": "Sprigatito",
+      "fr": "Poussacha"
+    },
     "image": "cPK_10_005080_00_NYAHOJA_C.webp",
     "packs": [
       "Shining"
@@ -53,7 +68,10 @@
     "set": "A2b",
     "number": 6,
     "rarity": "U",
-    "name": "Floragato",
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    },
     "image": "cPK_10_005250_00_NYAROTE_U.webp",
     "packs": [
       "Shining"
@@ -63,7 +81,10 @@
     "set": "A2b",
     "number": 7,
     "rarity": "R",
-    "name": "Meowscarada",
+    "name": {
+      "en": "Meowscarada",
+      "fr": "Miascarade"
+    },
     "image": "cPK_10_005260_00_MASQUERNYA_R.webp",
     "packs": [
       "Shining"
@@ -73,7 +94,10 @@
     "set": "A2b",
     "number": 8,
     "rarity": "C",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_10_005270_00_HITOKAGE_C.webp",
     "packs": [
       "Shining"
@@ -83,7 +107,10 @@
     "set": "A2b",
     "number": 9,
     "rarity": "U",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "image": "cPK_10_005280_00_LIZARDO_U.webp",
     "packs": [
       "Shining"
@@ -93,7 +120,10 @@
     "set": "A2b",
     "number": 10,
     "rarity": "RR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_10_005290_00_LIZARDONex_RR.webp",
     "packs": [
       "Shining"
@@ -103,7 +133,10 @@
     "set": "A2b",
     "number": 11,
     "rarity": "C",
-    "name": "Magmar",
+    "name": {
+      "en": "Magmar",
+      "fr": "Magmar"
+    },
     "image": "cPK_10_005300_00_BOOBER_C.webp",
     "packs": [
       "Shining"
@@ -113,7 +146,10 @@
     "set": "A2b",
     "number": 12,
     "rarity": "R",
-    "name": "Magmortar",
+    "name": {
+      "en": "Magmortar",
+      "fr": "Maganon"
+    },
     "image": "cPK_10_005310_00_BOOBURN_R.webp",
     "packs": [
       "Shining"
@@ -123,7 +159,10 @@
     "set": "A2b",
     "number": 13,
     "rarity": "U",
-    "name": "Paldean Tauros",
+    "name": {
+      "en": "Paldean Tauros",
+      "fr": "Tauros de Paldea"
+    },
     "image": "cPK_10_005320_00_PALDEAKENTAUROS_U.webp",
     "packs": [
       "Shining"
@@ -133,7 +172,10 @@
     "set": "A2b",
     "number": 14,
     "rarity": "C",
-    "name": "Tentacool",
+    "name": {
+      "en": "Tentacool",
+      "fr": "Tentacool"
+    },
     "image": "cPK_10_005330_00_MENOKURAGE_C.webp",
     "packs": [
       "Shining"
@@ -143,7 +185,10 @@
     "set": "A2b",
     "number": 15,
     "rarity": "U",
-    "name": "Tentacruel",
+    "name": {
+      "en": "Tentacruel",
+      "fr": "Tentacruel"
+    },
     "image": "cPK_10_005340_00_DOKUKURAGE_U.webp",
     "packs": [
       "Shining"
@@ -153,7 +198,10 @@
     "set": "A2b",
     "number": 16,
     "rarity": "C",
-    "name": "Buizel",
+    "name": {
+      "en": "Buizel",
+      "fr": "Mustébouée"
+    },
     "image": "cPK_10_005350_00_BUOYSEL_C.webp",
     "packs": [
       "Shining"
@@ -163,7 +211,10 @@
     "set": "A2b",
     "number": 17,
     "rarity": "U",
-    "name": "Floatzel",
+    "name": {
+      "en": "Floatzel",
+      "fr": "Mustéflott"
+    },
     "image": "cPK_10_005360_00_FLOAZEL_U.webp",
     "packs": [
       "Shining"
@@ -173,7 +224,10 @@
     "set": "A2b",
     "number": 18,
     "rarity": "C",
-    "name": "Wiglett",
+    "name": {
+      "en": "Wiglett",
+      "fr": "Taupikeau"
+    },
     "image": "cPK_10_005370_00_UMIDIGDA_C.webp",
     "packs": [
       "Shining"
@@ -183,7 +237,10 @@
     "set": "A2b",
     "number": 19,
     "rarity": "RR",
-    "name": "Wugtrio ex",
+    "name": {
+      "en": "Wugtrio ex",
+      "fr": "Triopikeau-ex"
+    },
     "image": "cPK_10_005380_00_UMITRIOex_RR.webp",
     "packs": [
       "Shining"
@@ -193,7 +250,10 @@
     "set": "A2b",
     "number": 20,
     "rarity": "R",
-    "name": "Dondozo",
+    "name": {
+      "en": "Dondozo",
+      "fr": "Oyacata"
+    },
     "image": "cPK_10_005390_00_HEYRUSHER_R.webp",
     "packs": [
       "Shining"
@@ -203,7 +263,10 @@
     "set": "A2b",
     "number": 21,
     "rarity": "U",
-    "name": "Tatsugiri",
+    "name": {
+      "en": "Tatsugiri",
+      "fr": "Nigirigon"
+    },
     "image": "cPK_10_005400_00_SYARITATSU_U.webp",
     "packs": [
       "Shining"
@@ -213,7 +276,10 @@
     "set": "A2b",
     "number": 22,
     "rarity": "RR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_10_005410_00_PIKACHUex_RR.webp",
     "packs": [
       "Shining"
@@ -223,7 +289,10 @@
     "set": "A2b",
     "number": 23,
     "rarity": "C",
-    "name": "Voltorb",
+    "name": {
+      "en": "Voltorb",
+      "fr": "Voltorbe"
+    },
     "image": "cPK_10_005420_00_BIRIRIDAMA_C.webp",
     "packs": [
       "Shining"
@@ -233,7 +302,10 @@
     "set": "A2b",
     "number": 24,
     "rarity": "U",
-    "name": "Electrode",
+    "name": {
+      "en": "Electrode",
+      "fr": "Électrode"
+    },
     "image": "cPK_10_005430_00_MARUMINE_U.webp",
     "packs": [
       "Shining"
@@ -243,7 +315,10 @@
     "set": "A2b",
     "number": 25,
     "rarity": "U",
-    "name": "Pachirisu",
+    "name": {
+      "en": "Pachirisu",
+      "fr": "Pachirisu"
+    },
     "image": "cPK_10_005060_00_PACHIRISU_U.webp",
     "packs": [
       "Shining"
@@ -253,7 +328,10 @@
     "set": "A2b",
     "number": 26,
     "rarity": "C",
-    "name": "Pawmi",
+    "name": {
+      "en": "Pawmi",
+      "fr": "Pohm"
+    },
     "image": "cPK_10_005440_00_PAMO_C.webp",
     "packs": [
       "Shining"
@@ -263,7 +341,10 @@
     "set": "A2b",
     "number": 27,
     "rarity": "U",
-    "name": "Pawmo",
+    "name": {
+      "en": "Pawmo",
+      "fr": "Pohmotte"
+    },
     "image": "cPK_10_005450_00_PAMOT_U.webp",
     "packs": [
       "Shining"
@@ -273,7 +354,10 @@
     "set": "A2b",
     "number": 28,
     "rarity": "R",
-    "name": "Pawmot",
+    "name": {
+      "en": "Pawmot",
+      "fr": "Pohmarmotte"
+    },
     "image": "cPK_10_005010_00_PARMOT_R.webp",
     "packs": [
       "Shining"
@@ -283,7 +367,10 @@
     "set": "A2b",
     "number": 29,
     "rarity": "C",
-    "name": "Abra",
+    "name": {
+      "en": "Abra",
+      "fr": "Abra"
+    },
     "image": "cPK_10_005460_00_CASEY_C.webp",
     "packs": [
       "Shining"
@@ -293,7 +380,10 @@
     "set": "A2b",
     "number": 30,
     "rarity": "U",
-    "name": "Kadabra",
+    "name": {
+      "en": "Kadabra",
+      "fr": "Kadabra"
+    },
     "image": "cPK_10_005470_00_YUNGERER_U.webp",
     "packs": [
       "Shining"
@@ -303,7 +393,10 @@
     "set": "A2b",
     "number": 31,
     "rarity": "R",
-    "name": "Alakazam",
+    "name": {
+      "en": "Alakazam",
+      "fr": "Alakazam"
+    },
     "image": "cPK_10_005480_00_FOODIN_R.webp",
     "packs": [
       "Shining"
@@ -313,7 +406,10 @@
     "set": "A2b",
     "number": 32,
     "rarity": "C",
-    "name": "Mr. Mime",
+    "name": {
+      "en": "Mr. Mime",
+      "fr": "M. Mime"
+    },
     "image": "cPK_10_005490_00_BARRIERD_C.webp",
     "packs": [
       "Shining"
@@ -323,7 +419,10 @@
     "set": "A2b",
     "number": 33,
     "rarity": "C",
-    "name": "Drifloon",
+    "name": {
+      "en": "Drifloon",
+      "fr": "Baudrive"
+    },
     "image": "cPK_10_005500_00_FUWANTE_C.webp",
     "packs": [
       "Shining"
@@ -333,7 +432,10 @@
     "set": "A2b",
     "number": 34,
     "rarity": "U",
-    "name": "Drifblim",
+    "name": {
+      "en": "Drifblim",
+      "fr": "Grodrive"
+    },
     "image": "cPK_10_005510_00_FUWARIDE_U.webp",
     "packs": [
       "Shining"
@@ -343,7 +445,10 @@
     "set": "A2b",
     "number": 35,
     "rarity": "RR",
-    "name": "Giratina ex",
+    "name": {
+      "en": "Giratina ex",
+      "fr": "Giratina-ex"
+    },
     "image": "cPK_10_005520_00_GIRATINAex_RR.webp",
     "packs": [
       "Shining"
@@ -353,7 +458,10 @@
     "set": "A2b",
     "number": 36,
     "rarity": "C",
-    "name": "Gimmighoul",
+    "name": {
+      "en": "Gimmighoul",
+      "fr": "Mordudor"
+    },
     "image": "cPK_10_005530_00_COLLECUREI_C.webp",
     "packs": [
       "Shining"
@@ -363,7 +471,10 @@
     "set": "A2b",
     "number": 37,
     "rarity": "C",
-    "name": "Machop",
+    "name": {
+      "en": "Machop",
+      "fr": "Machoc"
+    },
     "image": "cPK_10_005540_00_WANRIKY_C.webp",
     "packs": [
       "Shining"
@@ -373,7 +484,10 @@
     "set": "A2b",
     "number": 38,
     "rarity": "C",
-    "name": "Machoke",
+    "name": {
+      "en": "Machoke",
+      "fr": "Machopeur"
+    },
     "image": "cPK_10_005550_00_GORIKY_C.webp",
     "packs": [
       "Shining"
@@ -383,7 +497,10 @@
     "set": "A2b",
     "number": 39,
     "rarity": "R",
-    "name": "Machamp",
+    "name": {
+      "en": "Machamp",
+      "fr": "Mackogneur"
+    },
     "image": "cPK_10_005020_00_KAIRIKY_R.webp",
     "packs": [
       "Shining"
@@ -393,7 +510,10 @@
     "set": "A2b",
     "number": 40,
     "rarity": "C",
-    "name": "Hitmonlee",
+    "name": {
+      "en": "Hitmonlee",
+      "fr": "Kicklee"
+    },
     "image": "cPK_10_005560_00_SAWAMULAR_C.webp",
     "packs": [
       "Shining"
@@ -403,7 +523,10 @@
     "set": "A2b",
     "number": 41,
     "rarity": "C",
-    "name": "Hitmonchan",
+    "name": {
+      "en": "Hitmonchan",
+      "fr": "Tygnon"
+    },
     "image": "cPK_10_005570_00_EBIWALAR_C.webp",
     "packs": [
       "Shining"
@@ -413,7 +536,10 @@
     "set": "A2b",
     "number": 42,
     "rarity": "C",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "image": "cPK_10_005070_00_RIOLU_C.webp",
     "packs": [
       "Shining"
@@ -423,7 +549,10 @@
     "set": "A2b",
     "number": 43,
     "rarity": "RR",
-    "name": "Lucario ex",
+    "name": {
+      "en": "Lucario ex",
+      "fr": "Lucario-ex"
+    },
     "image": "cPK_10_005580_00_LUCARIOex_RR.webp",
     "packs": [
       "Shining"
@@ -433,7 +562,10 @@
     "set": "A2b",
     "number": 44,
     "rarity": "U",
-    "name": "Flamigo",
+    "name": {
+      "en": "Flamigo",
+      "fr": "Flamenroule"
+    },
     "image": "cPK_10_005590_00_KARAMINGO_U.webp",
     "packs": [
       "Shining"
@@ -443,7 +575,10 @@
     "set": "A2b",
     "number": 45,
     "rarity": "C",
-    "name": "Ekans",
+    "name": {
+      "en": "Ekans",
+      "fr": "Abo"
+    },
     "image": "cPK_10_005600_00_ARBO_C.webp",
     "packs": [
       "Shining"
@@ -453,7 +588,10 @@
     "set": "A2b",
     "number": 46,
     "rarity": "U",
-    "name": "Arbok",
+    "name": {
+      "en": "Arbok",
+      "fr": "Arbok"
+    },
     "image": "cPK_10_005610_00_ARBOK_U.webp",
     "packs": [
       "Shining"
@@ -463,7 +601,10 @@
     "set": "A2b",
     "number": 47,
     "rarity": "C",
-    "name": "Paldean Wooper",
+    "name": {
+      "en": "Paldean Wooper",
+      "fr": "Axoloto de Paldea"
+    },
     "image": "cPK_10_005620_00_PALDEAUPAH_C.webp",
     "packs": [
       "Shining"
@@ -473,7 +614,10 @@
     "set": "A2b",
     "number": 48,
     "rarity": "RR",
-    "name": "Paldean Clodsire ex",
+    "name": {
+      "en": "Paldean Clodsire ex",
+      "fr": "Terraiste de Paldea-ex"
+    },
     "image": "cPK_10_005630_00_PALDEADOOHex_RR.webp",
     "packs": [
       "Shining"
@@ -483,7 +627,10 @@
     "set": "A2b",
     "number": 49,
     "rarity": "U",
-    "name": "Spiritomb",
+    "name": {
+      "en": "Spiritomb",
+      "fr": "Spiritomb"
+    },
     "image": "cPK_10_005640_00_MIKARUGE_U.webp",
     "packs": [
       "Shining"
@@ -493,7 +640,10 @@
     "set": "A2b",
     "number": 50,
     "rarity": "C",
-    "name": "Shroodle",
+    "name": {
+      "en": "Shroodle",
+      "fr": "Gribouraigne"
+    },
     "image": "cPK_10_005650_00_SHIRUSHREW_C.webp",
     "packs": [
       "Shining"
@@ -503,7 +653,10 @@
     "set": "A2b",
     "number": 51,
     "rarity": "R",
-    "name": "Grafaiai",
+    "name": {
+      "en": "Grafaiai",
+      "fr": "Tag-Tag"
+    },
     "image": "cPK_10_005660_00_TAGGINGRU_R.webp",
     "packs": [
       "Shining"
@@ -513,7 +666,10 @@
     "set": "A2b",
     "number": 52,
     "rarity": "C",
-    "name": "Tinkatink",
+    "name": {
+      "en": "Tinkatink",
+      "fr": "Forgerette"
+    },
     "image": "cPK_10_005670_00_KANUCHAN_C.webp",
     "packs": [
       "Shining"
@@ -523,7 +679,10 @@
     "set": "A2b",
     "number": 53,
     "rarity": "U",
-    "name": "Tinkatuff",
+    "name": {
+      "en": "Tinkatuff",
+      "fr": "Forgella"
+    },
     "image": "cPK_10_005680_00_NAKANUCHAN_U.webp",
     "packs": [
       "Shining"
@@ -533,7 +692,10 @@
     "set": "A2b",
     "number": 54,
     "rarity": "RR",
-    "name": "Tinkaton ex",
+    "name": {
+      "en": "Tinkaton ex",
+      "fr": "Forgelina-ex"
+    },
     "image": "cPK_10_005690_00_DEKANUCHANex_RR.webp",
     "packs": [
       "Shining"
@@ -543,7 +705,10 @@
     "set": "A2b",
     "number": 55,
     "rarity": "C",
-    "name": "Varoom",
+    "name": {
+      "en": "Varoom",
+      "fr": "Vrombi"
+    },
     "image": "cPK_10_005700_00_BURORON_C.webp",
     "packs": [
       "Shining"
@@ -553,7 +718,10 @@
     "set": "A2b",
     "number": 56,
     "rarity": "U",
-    "name": "Revavroom",
+    "name": {
+      "en": "Revavroom",
+      "fr": "Vrombotor"
+    },
     "image": "cPK_10_005710_00_BUROROROOM_U.webp",
     "packs": [
       "Shining"
@@ -563,7 +731,10 @@
     "set": "A2b",
     "number": 57,
     "rarity": "R",
-    "name": "Gholdengo",
+    "name": {
+      "en": "Gholdengo",
+      "fr": "Gromago"
+    },
     "image": "cPK_10_005720_00_SURFUGO_R.webp",
     "packs": [
       "Shining"
@@ -573,7 +744,10 @@
     "set": "A2b",
     "number": 58,
     "rarity": "C",
-    "name": "Rattata",
+    "name": {
+      "en": "Rattata",
+      "fr": "Rattata"
+    },
     "image": "cPK_10_005730_00_KORATTA_C.webp",
     "packs": [
       "Shining"
@@ -583,7 +757,10 @@
     "set": "A2b",
     "number": 59,
     "rarity": "C",
-    "name": "Raticate",
+    "name": {
+      "en": "Raticate",
+      "fr": "Rattatac"
+    },
     "image": "cPK_10_005740_00_RATTA_C.webp",
     "packs": [
       "Shining"
@@ -593,7 +770,10 @@
     "set": "A2b",
     "number": 60,
     "rarity": "C",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "image": "cPK_10_005750_00_PURIN_C.webp",
     "packs": [
       "Shining"
@@ -603,7 +783,10 @@
     "set": "A2b",
     "number": 61,
     "rarity": "R",
-    "name": "Wigglytuff",
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    },
     "image": "cPK_10_005760_00_PUKURIN_R.webp",
     "packs": [
       "Shining"
@@ -613,7 +796,10 @@
     "set": "A2b",
     "number": 62,
     "rarity": "C",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_10_005770_00_BERORINGA_C.webp",
     "packs": [
       "Shining"
@@ -623,7 +809,10 @@
     "set": "A2b",
     "number": 63,
     "rarity": "C",
-    "name": "Lickilicky",
+    "name": {
+      "en": "Lickilicky",
+      "fr": "Coudlangue"
+    },
     "image": "cPK_10_005780_00_BEROBELT_C.webp",
     "packs": [
       "Shining"
@@ -633,7 +822,10 @@
     "set": "A2b",
     "number": 64,
     "rarity": "C",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_10_005040_00_BIPPA_C.webp",
     "packs": [
       "Shining"
@@ -643,7 +835,10 @@
     "set": "A2b",
     "number": 65,
     "rarity": "RR",
-    "name": "Bibarel ex",
+    "name": {
+      "en": "Bibarel ex",
+      "fr": "Castorno-ex"
+    },
     "image": "cPK_10_005790_00_BEADARUex_RR.webp",
     "packs": [
       "Shining"
@@ -653,7 +848,10 @@
     "set": "A2b",
     "number": 66,
     "rarity": "C",
-    "name": "Buneary",
+    "name": {
+      "en": "Buneary",
+      "fr": "Laporeille"
+    },
     "image": "cPK_10_005800_00_MIMIROL_C.webp",
     "packs": [
       "Shining"
@@ -663,7 +861,10 @@
     "set": "A2b",
     "number": 67,
     "rarity": "C",
-    "name": "Lopunny",
+    "name": {
+      "en": "Lopunny",
+      "fr": "Lockpin"
+    },
     "image": "cPK_10_005810_00_MIMILOP_C.webp",
     "packs": [
       "Shining"
@@ -673,7 +874,10 @@
     "set": "A2b",
     "number": 68,
     "rarity": "U",
-    "name": "Cyclizar",
+    "name": {
+      "en": "Cyclizar",
+      "fr": "Motorizard"
+    },
     "image": "cPK_10_005090_00_MOTOTOKAGE_U.webp",
     "packs": [
       "Shining"
@@ -683,7 +887,10 @@
     "set": "A2b",
     "number": 69,
     "rarity": "U",
-    "name": "Iono",
+    "name": {
+      "en": "Iono",
+      "fr": "Mashynn"
+    },
     "image": "cTR_10_000420_00_NANJYAMO_U.webp",
     "packs": [
       "Shining"
@@ -693,7 +900,10 @@
     "set": "A2b",
     "number": 70,
     "rarity": "U",
-    "name": "Pokémon Center Lady",
+    "name": {
+      "en": "Pokémon Center Lady",
+      "fr": "Dame du Centre Pokémon"
+    },
     "image": "cTR_10_000430_00_POKEMONCENTERNOONEESAN_U.webp",
     "packs": [
       "Shining"
@@ -703,7 +913,10 @@
     "set": "A2b",
     "number": 71,
     "rarity": "U",
-    "name": "Red",
+    "name": {
+      "en": "Red",
+      "fr": "Red"
+    },
     "image": "cTR_10_000440_00_RED_U.webp",
     "packs": [
       "Shining"
@@ -713,7 +926,10 @@
     "set": "A2b",
     "number": 72,
     "rarity": "U",
-    "name": "Team Rocket Grunt",
+    "name": {
+      "en": "Team Rocket Grunt",
+      "fr": "Sbire de la Team Rocket"
+    },
     "image": "cTR_10_000450_00_ROCKETDANNOSHITAPPA_U.webp",
     "packs": [
       "Shining"
@@ -723,7 +939,10 @@
     "set": "A2b",
     "number": 73,
     "rarity": "AR",
-    "name": "Meowscarada",
+    "name": {
+      "en": "Meowscarada",
+      "fr": "Miascarade"
+    },
     "image": "cPK_20_005260_00_MASQUERNYA_AR.webp",
     "packs": [
       "Shining"
@@ -733,7 +952,10 @@
     "set": "A2b",
     "number": 74,
     "rarity": "AR",
-    "name": "Buizel",
+    "name": {
+      "en": "Buizel",
+      "fr": "Mustébouée"
+    },
     "image": "cPK_20_005350_00_BUOYSEL_AR.webp",
     "packs": [
       "Shining"
@@ -743,7 +965,10 @@
     "set": "A2b",
     "number": 75,
     "rarity": "AR",
-    "name": "Tatsugiri",
+    "name": {
+      "en": "Tatsugiri",
+      "fr": "Nigirigon"
+    },
     "image": "cPK_20_005400_00_SYARITATSU_AR.webp",
     "packs": [
       "Shining"
@@ -753,7 +978,10 @@
     "set": "A2b",
     "number": 76,
     "rarity": "AR",
-    "name": "Grafaiai",
+    "name": {
+      "en": "Grafaiai",
+      "fr": "Tag-Tag"
+    },
     "image": "cPK_20_005660_00_TAGGINGRU_AR.webp",
     "packs": [
       "Shining"
@@ -763,7 +991,10 @@
     "set": "A2b",
     "number": 77,
     "rarity": "AR",
-    "name": "Gholdengo",
+    "name": {
+      "en": "Gholdengo",
+      "fr": "Gromago"
+    },
     "image": "cPK_20_005720_00_SURFUGO_AR.webp",
     "packs": [
       "Shining"
@@ -773,7 +1004,10 @@
     "set": "A2b",
     "number": 78,
     "rarity": "AR",
-    "name": "Wigglytuff",
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    },
     "image": "cPK_20_005760_00_PUKURIN_AR.webp",
     "packs": [
       "Shining"
@@ -783,7 +1017,10 @@
     "set": "A2b",
     "number": 79,
     "rarity": "SR",
-    "name": "Beedrill ex",
+    "name": {
+      "en": "Beedrill ex",
+      "fr": "Dardargnan-ex"
+    },
     "image": "cPK_20_005230_00_SPEARex_SR.webp",
     "packs": [
       "Shining"
@@ -793,7 +1030,10 @@
     "set": "A2b",
     "number": 80,
     "rarity": "SR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_20_005290_00_LIZARDONex_SR.webp",
     "packs": [
       "Shining"
@@ -803,7 +1043,10 @@
     "set": "A2b",
     "number": 81,
     "rarity": "SR",
-    "name": "Wugtrio ex",
+    "name": {
+      "en": "Wugtrio ex",
+      "fr": "Triopikeau-ex"
+    },
     "image": "cPK_20_005380_00_UMITRIOex_SR.webp",
     "packs": [
       "Shining"
@@ -813,7 +1056,10 @@
     "set": "A2b",
     "number": 82,
     "rarity": "SR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_005410_00_PIKACHUex_SR.webp",
     "packs": [
       "Shining"
@@ -823,7 +1069,10 @@
     "set": "A2b",
     "number": 83,
     "rarity": "SR",
-    "name": "Giratina ex",
+    "name": {
+      "en": "Giratina ex",
+      "fr": "Giratina-ex"
+    },
     "image": "cPK_20_005520_00_GIRATINAex_SR.webp",
     "packs": [
       "Shining"
@@ -833,7 +1082,10 @@
     "set": "A2b",
     "number": 84,
     "rarity": "SR",
-    "name": "Lucario ex",
+    "name": {
+      "en": "Lucario ex",
+      "fr": "Lucario-ex"
+    },
     "image": "cPK_20_005580_00_LUCARIOex_SR.webp",
     "packs": [
       "Shining"
@@ -843,7 +1095,10 @@
     "set": "A2b",
     "number": 85,
     "rarity": "SR",
-    "name": "Paldean Clodsire ex",
+    "name": {
+      "en": "Paldean Clodsire ex",
+      "fr": "Terraiste de Paldea-ex"
+    },
     "image": "cPK_20_005630_00_PALDEADOOHex_SR.webp",
     "packs": [
       "Shining"
@@ -853,7 +1108,10 @@
     "set": "A2b",
     "number": 86,
     "rarity": "SR",
-    "name": "Tinkaton ex",
+    "name": {
+      "en": "Tinkaton ex",
+      "fr": "Forgelina-ex"
+    },
     "image": "cPK_20_005690_00_DEKANUCHANex_SR.webp",
     "packs": [
       "Shining"
@@ -863,7 +1121,10 @@
     "set": "A2b",
     "number": 87,
     "rarity": "SR",
-    "name": "Bibarel ex",
+    "name": {
+      "en": "Bibarel ex",
+      "fr": "Castorno-ex"
+    },
     "image": "cPK_20_005790_00_BEADARUex_SR.webp",
     "packs": [
       "Shining"
@@ -873,7 +1134,10 @@
     "set": "A2b",
     "number": 88,
     "rarity": "SR",
-    "name": "Iono",
+    "name": {
+      "en": "Iono",
+      "fr": "Mashynn"
+    },
     "image": "cTR_20_000420_00_NANJYAMO_SR.webp",
     "packs": [
       "Shining"
@@ -883,7 +1147,10 @@
     "set": "A2b",
     "number": 89,
     "rarity": "SR",
-    "name": "Pokémon Center Lady",
+    "name": {
+      "en": "Pokémon Center Lady",
+      "fr": "Dame du Centre Pokémon"
+    },
     "image": "cTR_20_000430_00_POKEMONCENTERNOONEESAN_SR.webp",
     "packs": [
       "Shining"
@@ -893,7 +1160,10 @@
     "set": "A2b",
     "number": 90,
     "rarity": "SR",
-    "name": "Red",
+    "name": {
+      "en": "Red",
+      "fr": "Red"
+    },
     "image": "cTR_20_000440_00_RED_SR.webp",
     "packs": [
       "Shining"
@@ -903,7 +1173,10 @@
     "set": "A2b",
     "number": 91,
     "rarity": "SR",
-    "name": "Team Rocket Grunt",
+    "name": {
+      "en": "Team Rocket Grunt",
+      "fr": "Sbire de la Team Rocket"
+    },
     "image": "cTR_20_000450_00_ROCKETDANNOSHITAPPA_SR.webp",
     "packs": [
       "Shining"
@@ -913,7 +1186,10 @@
     "set": "A2b",
     "number": 92,
     "rarity": "SAR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_005410_01_PIKACHUex_SAR.webp",
     "packs": [
       "Shining"
@@ -923,7 +1199,10 @@
     "set": "A2b",
     "number": 93,
     "rarity": "SAR",
-    "name": "Paldean Clodsire ex",
+    "name": {
+      "en": "Paldean Clodsire ex",
+      "fr": "Terraiste de Paldea-ex"
+    },
     "image": "cPK_20_005630_01_PALDEADOOHex_SAR.webp",
     "packs": [
       "Shining"
@@ -933,7 +1212,10 @@
     "set": "A2b",
     "number": 94,
     "rarity": "SAR",
-    "name": "Tinkaton ex",
+    "name": {
+      "en": "Tinkaton ex",
+      "fr": "Forgelina-ex"
+    },
     "image": "cPK_20_005690_01_DEKANUCHANex_SAR.webp",
     "packs": [
       "Shining"
@@ -943,7 +1225,10 @@
     "set": "A2b",
     "number": 95,
     "rarity": "SAR",
-    "name": "Bibarel ex",
+    "name": {
+      "en": "Bibarel ex",
+      "fr": "Castorno-ex"
+    },
     "image": "cPK_20_005790_01_BEADARUex_SAR.webp",
     "packs": [
       "Shining"
@@ -953,7 +1238,10 @@
     "set": "A2b",
     "number": 96,
     "rarity": "IM",
-    "name": "Giratina ex",
+    "name": {
+      "en": "Giratina ex",
+      "fr": "Giratina-ex"
+    },
     "image": "cPK_20_005520_01_GIRATINAex_IM.webp",
     "packs": [
       "Shining"
@@ -963,7 +1251,10 @@
     "set": "A2b",
     "number": 97,
     "rarity": "S",
-    "name": "Weedle",
+    "name": {
+      "en": "Weedle",
+      "fr": "Aspicot"
+    },
     "image": "cPK_20_005210_00_BEEDLE_S.webp",
     "packs": [
       "Shining"
@@ -973,7 +1264,10 @@
     "set": "A2b",
     "number": 98,
     "rarity": "S",
-    "name": "Kakuna",
+    "name": {
+      "en": "Kakuna",
+      "fr": "Coconfort"
+    },
     "image": "cPK_20_005220_00_COCOON_S.webp",
     "packs": [
       "Shining"
@@ -983,7 +1277,10 @@
     "set": "A2b",
     "number": 99,
     "rarity": "S",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_20_005270_00_HITOKAGE_S.webp",
     "packs": [
       "Shining"
@@ -993,7 +1290,10 @@
     "set": "A2b",
     "number": 100,
     "rarity": "S",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "image": "cPK_20_005280_00_LIZARDO_S.webp",
     "packs": [
       "Shining"
@@ -1003,7 +1303,10 @@
     "set": "A2b",
     "number": 101,
     "rarity": "S",
-    "name": "Wiglett",
+    "name": {
+      "en": "Wiglett",
+      "fr": "Taupikeau"
+    },
     "image": "cPK_20_005370_00_UMIDIGDA_S.webp",
     "packs": [
       "Shining"
@@ -1013,7 +1316,10 @@
     "set": "A2b",
     "number": 102,
     "rarity": "S",
-    "name": "Dondozo",
+    "name": {
+      "en": "Dondozo",
+      "fr": "Oyacata"
+    },
     "image": "cPK_20_005390_00_HEYRUSHER_S.webp",
     "packs": [
       "Shining"
@@ -1023,7 +1329,10 @@
     "set": "A2b",
     "number": 103,
     "rarity": "S",
-    "name": "Pachirisu",
+    "name": {
+      "en": "Pachirisu",
+      "fr": "Pachirisu"
+    },
     "image": "cPK_20_005060_00_PACHIRISU_S.webp",
     "packs": [
       "Shining"
@@ -1033,7 +1342,10 @@
     "set": "A2b",
     "number": 104,
     "rarity": "S",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "image": "cPK_20_005070_00_RIOLU_S.webp",
     "packs": [
       "Shining"
@@ -1043,7 +1355,10 @@
     "set": "A2b",
     "number": 105,
     "rarity": "S",
-    "name": "Varoom",
+    "name": {
+      "en": "Varoom",
+      "fr": "Vrombi"
+    },
     "image": "cPK_20_005700_00_BURORON_S.webp",
     "packs": [
       "Shining"
@@ -1053,7 +1368,10 @@
     "set": "A2b",
     "number": 106,
     "rarity": "S",
-    "name": "Revavroom",
+    "name": {
+      "en": "Revavroom",
+      "fr": "Vrombotor"
+    },
     "image": "cPK_20_005710_00_BUROROROOM_S.webp",
     "packs": [
       "Shining"
@@ -1063,7 +1381,10 @@
     "set": "A2b",
     "number": 107,
     "rarity": "SSR",
-    "name": "Beedrill ex",
+    "name": {
+      "en": "Beedrill ex",
+      "fr": "Dardargnan-ex"
+    },
     "image": "cPK_20_005230_01_SPEARex_SSR.webp",
     "packs": [
       "Shining"
@@ -1073,7 +1394,10 @@
     "set": "A2b",
     "number": 108,
     "rarity": "SSR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_20_005290_01_LIZARDONex_SSR.webp",
     "packs": [
       "Shining"
@@ -1083,7 +1407,10 @@
     "set": "A2b",
     "number": 109,
     "rarity": "SSR",
-    "name": "Wugtrio ex",
+    "name": {
+      "en": "Wugtrio ex",
+      "fr": "Triopikeau-ex"
+    },
     "image": "cPK_20_005380_01_UMITRIOex_SSR.webp",
     "packs": [
       "Shining"
@@ -1093,7 +1420,10 @@
     "set": "A2b",
     "number": 110,
     "rarity": "SSR",
-    "name": "Lucario ex",
+    "name": {
+      "en": "Lucario ex",
+      "fr": "Lucario-ex"
+    },
     "image": "cPK_20_005580_01_LUCARIOex_SSR.webp",
     "packs": [
       "Shining"
@@ -1103,7 +1433,10 @@
     "set": "A2b",
     "number": 111,
     "rarity": "UR",
-    "name": "Poké Ball",
+    "name": {
+      "en": "Poké Ball",
+      "fr": "Poké Ball"
+    },
     "image": "cTR_20_000030_00_MONSTERBALL_UR.webp",
     "packs": [
       "Shining"

--- a/dist/cards/A3.json
+++ b/dist/cards/A3.json
@@ -3,7 +3,10 @@
     "set": "A3",
     "number": 1,
     "rarity": "C",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_10_005820_00_TAMATAMA_C.webp",
     "packs": [
       "Lunala"
@@ -13,7 +16,10 @@
     "set": "A3",
     "number": 2,
     "rarity": "R",
-    "name": "Alolan Exeggutor",
+    "name": {
+      "en": "Alolan Exeggutor",
+      "fr": "Noadkoko d'Alola"
+    },
     "image": "cPK_10_005830_00_ALOLANASSY_R.webp",
     "packs": [
       "Lunala"
@@ -23,7 +29,10 @@
     "set": "A3",
     "number": 3,
     "rarity": "C",
-    "name": "Surskit",
+    "name": {
+      "en": "Surskit",
+      "fr": "Arakdo"
+    },
     "image": "cPK_10_005840_00_AMETAMA_C.webp",
     "packs": [
       "Solgaleo",
@@ -34,7 +43,10 @@
     "set": "A3",
     "number": 4,
     "rarity": "U",
-    "name": "Masquerain",
+    "name": {
+      "en": "Masquerain",
+      "fr": "Maskadra"
+    },
     "image": "cPK_10_005850_00_AMEMOTH_U.webp",
     "packs": [
       "Solgaleo",
@@ -45,7 +57,10 @@
     "set": "A3",
     "number": 5,
     "rarity": "C",
-    "name": "Maractus",
+    "name": {
+      "en": "Maractus",
+      "fr": "Maracachi"
+    },
     "image": "cPK_10_005860_00_MARACACCHI_C.webp",
     "packs": [
       "Lunala"
@@ -55,7 +70,10 @@
     "set": "A3",
     "number": 6,
     "rarity": "C",
-    "name": "Karrablast",
+    "name": {
+      "en": "Karrablast",
+      "fr": "Carabing"
+    },
     "image": "cPK_10_005870_00_KABURUMO_C.webp",
     "packs": [
       "Solgaleo",
@@ -66,7 +84,10 @@
     "set": "A3",
     "number": 7,
     "rarity": "C",
-    "name": "Phantump",
+    "name": {
+      "en": "Phantump",
+      "fr": "Brocélôme"
+    },
     "image": "cPK_10_005880_00_BOKUREI_C.webp",
     "packs": [
       "Solgaleo"
@@ -76,7 +97,10 @@
     "set": "A3",
     "number": 8,
     "rarity": "U",
-    "name": "Trevenant",
+    "name": {
+      "en": "Trevenant",
+      "fr": "Desséliande"
+    },
     "image": "cPK_10_005890_00_OHROT_U.webp",
     "packs": [
       "Solgaleo"
@@ -86,7 +110,10 @@
     "set": "A3",
     "number": 9,
     "rarity": "C",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_10_005900_00_MOKUROH_C.webp",
     "packs": [
       "Solgaleo"
@@ -96,7 +123,10 @@
     "set": "A3",
     "number": 10,
     "rarity": "C",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_10_005910_00_MOKUROH_C.webp",
     "packs": [
       "Lunala"
@@ -106,7 +136,10 @@
     "set": "A3",
     "number": 11,
     "rarity": "U",
-    "name": "Dartrix",
+    "name": {
+      "en": "Dartrix",
+      "fr": "Efflèche"
+    },
     "image": "cPK_10_005920_00_FUKUTHROW_U.webp",
     "packs": [
       "Lunala"
@@ -116,7 +149,10 @@
     "set": "A3",
     "number": 12,
     "rarity": "RR",
-    "name": "Decidueye ex",
+    "name": {
+      "en": "Decidueye ex",
+      "fr": "Archéduc-ex"
+    },
     "image": "cPK_10_005930_00_JUNAIPERex_RR.webp",
     "packs": [
       "Lunala"
@@ -126,7 +162,10 @@
     "set": "A3",
     "number": 13,
     "rarity": "C",
-    "name": "Grubbin",
+    "name": {
+      "en": "Grubbin",
+      "fr": "Larvibule"
+    },
     "image": "cPK_10_005940_00_AGOJIMUSHI_C.webp",
     "packs": [
       "Lunala"
@@ -136,7 +175,10 @@
     "set": "A3",
     "number": 14,
     "rarity": "C",
-    "name": "Fomantis",
+    "name": {
+      "en": "Fomantis",
+      "fr": "Mimantis"
+    },
     "image": "cPK_10_005950_00_KARIKIRI_C.webp",
     "packs": [
       "Solgaleo",
@@ -147,7 +189,10 @@
     "set": "A3",
     "number": 15,
     "rarity": "U",
-    "name": "Lurantis",
+    "name": {
+      "en": "Lurantis",
+      "fr": "Floramantis"
+    },
     "image": "cPK_10_005960_00_LALANTES_U.webp",
     "packs": [
       "Solgaleo",
@@ -158,7 +203,10 @@
     "set": "A3",
     "number": 16,
     "rarity": "C",
-    "name": "Morelull",
+    "name": {
+      "en": "Morelull",
+      "fr": "Spododo"
+    },
     "image": "cPK_10_005970_00_NEMASYU_C.webp",
     "packs": [
       "Lunala"
@@ -168,7 +216,10 @@
     "set": "A3",
     "number": 17,
     "rarity": "U",
-    "name": "Shiinotic",
+    "name": {
+      "en": "Shiinotic",
+      "fr": "Lampignon"
+    },
     "image": "cPK_10_005980_00_MASHADE_U.webp",
     "packs": [
       "Lunala"
@@ -178,7 +229,10 @@
     "set": "A3",
     "number": 18,
     "rarity": "C",
-    "name": "Bounsweet",
+    "name": {
+      "en": "Bounsweet",
+      "fr": "Croquine"
+    },
     "image": "cPK_10_005990_00_AMAKAJI_C.webp",
     "packs": [
       "Solgaleo"
@@ -188,7 +242,10 @@
     "set": "A3",
     "number": 19,
     "rarity": "U",
-    "name": "Steenee",
+    "name": {
+      "en": "Steenee",
+      "fr": "Candine"
+    },
     "image": "cPK_10_006000_00_AMAMAIKO_U.webp",
     "packs": [
       "Solgaleo"
@@ -198,7 +255,10 @@
     "set": "A3",
     "number": 20,
     "rarity": "R",
-    "name": "Tsareena",
+    "name": {
+      "en": "Tsareena",
+      "fr": "Sucreine"
+    },
     "image": "cPK_10_006010_00_AMAJO_R.webp",
     "packs": [
       "Solgaleo"
@@ -208,7 +268,10 @@
     "set": "A3",
     "number": 21,
     "rarity": "C",
-    "name": "Wimpod",
+    "name": {
+      "en": "Wimpod",
+      "fr": "Sovkipou"
+    },
     "image": "cPK_10_006020_00_KOSOKUMUSHI_C.webp",
     "packs": [
       "Solgaleo"
@@ -218,7 +281,10 @@
     "set": "A3",
     "number": 22,
     "rarity": "R",
-    "name": "Golisopod",
+    "name": {
+      "en": "Golisopod",
+      "fr": "Sarmuraï"
+    },
     "image": "cPK_10_006030_00_GUSOKUMUSHA_R.webp",
     "packs": [
       "Solgaleo"
@@ -228,7 +294,10 @@
     "set": "A3",
     "number": 23,
     "rarity": "RR",
-    "name": "Dhelmise ex",
+    "name": {
+      "en": "Dhelmise ex",
+      "fr": "Sinistrail-ex"
+    },
     "image": "cPK_10_006040_00_DADARINex_RR.webp",
     "packs": [
       "Solgaleo"
@@ -238,7 +307,10 @@
     "set": "A3",
     "number": 24,
     "rarity": "R",
-    "name": "Tapu Bulu",
+    "name": {
+      "en": "Tapu Bulu",
+      "fr": "Tokotoro"
+    },
     "image": "cPK_10_006050_00_KAPU-BULUL_R.webp",
     "packs": [
       "Solgaleo"
@@ -248,7 +320,10 @@
     "set": "A3",
     "number": 25,
     "rarity": "C",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_10_006060_00_GARDIE_C.webp",
     "packs": [
       "Solgaleo",
@@ -259,7 +334,10 @@
     "set": "A3",
     "number": 26,
     "rarity": "U",
-    "name": "Arcanine",
+    "name": {
+      "en": "Arcanine",
+      "fr": "Arcanin"
+    },
     "image": "cPK_10_006070_00_WINDIE_U.webp",
     "packs": [
       "Solgaleo",
@@ -270,7 +348,10 @@
     "set": "A3",
     "number": 27,
     "rarity": "U",
-    "name": "Alolan Marowak",
+    "name": {
+      "en": "Alolan Marowak",
+      "fr": "Ossatueur d'Alola"
+    },
     "image": "cPK_10_006080_00_ALOLAGARAGARA_U.webp",
     "packs": [
       "Lunala"
@@ -280,7 +361,10 @@
     "set": "A3",
     "number": 28,
     "rarity": "C",
-    "name": "Fletchinder",
+    "name": {
+      "en": "Fletchinder",
+      "fr": "Braisillon"
+    },
     "image": "cPK_10_006090_00_HINOYAKOMA_C.webp",
     "packs": [
       "Solgaleo"
@@ -290,7 +374,10 @@
     "set": "A3",
     "number": 29,
     "rarity": "R",
-    "name": "Talonflame",
+    "name": {
+      "en": "Talonflame",
+      "fr": "Flambusard"
+    },
     "image": "cPK_10_006100_00_FIARROW_R.webp",
     "packs": [
       "Solgaleo"
@@ -300,7 +387,10 @@
     "set": "A3",
     "number": 30,
     "rarity": "C",
-    "name": "Litten",
+    "name": {
+      "en": "Litten",
+      "fr": "Flamiaou"
+    },
     "image": "cPK_10_006110_00_NYABBY_C.webp",
     "packs": [
       "Solgaleo"
@@ -310,7 +400,10 @@
     "set": "A3",
     "number": 31,
     "rarity": "C",
-    "name": "Litten",
+    "name": {
+      "en": "Litten",
+      "fr": "Flamiaou"
+    },
     "image": "cPK_10_006120_00_NYABBY_C.webp",
     "packs": [
       "Lunala"
@@ -320,7 +413,10 @@
     "set": "A3",
     "number": 32,
     "rarity": "U",
-    "name": "Torracat",
+    "name": {
+      "en": "Torracat",
+      "fr": "Matoufeu"
+    },
     "image": "cPK_10_006130_00_NYAHEAT_U.webp",
     "packs": [
       "Solgaleo"
@@ -330,7 +426,10 @@
     "set": "A3",
     "number": 33,
     "rarity": "RR",
-    "name": "Incineroar ex",
+    "name": {
+      "en": "Incineroar ex",
+      "fr": "Félinferno-ex"
+    },
     "image": "cPK_10_006140_00_GAOGAENex_RR.webp",
     "packs": [
       "Solgaleo"
@@ -340,7 +439,10 @@
     "set": "A3",
     "number": 34,
     "rarity": "U",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006150_00_ODORIDORIMERAMERASTYLE_U.webp",
     "packs": [
       "Lunala"
@@ -350,7 +452,10 @@
     "set": "A3",
     "number": 35,
     "rarity": "C",
-    "name": "Salandit",
+    "name": {
+      "en": "Salandit",
+      "fr": "Tritox"
+    },
     "image": "cPK_10_006160_00_YATOUMORI_C.webp",
     "packs": [
       "Solgaleo",
@@ -361,7 +466,10 @@
     "set": "A3",
     "number": 36,
     "rarity": "C",
-    "name": "Salazzle",
+    "name": {
+      "en": "Salazzle",
+      "fr": "Malamandre"
+    },
     "image": "cPK_10_006170_00_ENNEWT_C.webp",
     "packs": [
       "Solgaleo",
@@ -372,7 +480,10 @@
     "set": "A3",
     "number": 37,
     "rarity": "R",
-    "name": "Turtonator",
+    "name": {
+      "en": "Turtonator",
+      "fr": "Boumata"
+    },
     "image": "cPK_10_006180_00_BAKUGAMES_R.webp",
     "packs": [
       "Lunala"
@@ -382,7 +493,10 @@
     "set": "A3",
     "number": 38,
     "rarity": "C",
-    "name": "Alolan Sandshrew",
+    "name": {
+      "en": "Alolan Sandshrew",
+      "fr": "Sabelette d'Alola"
+    },
     "image": "cPK_10_006190_00_ALOLASAND_C.webp",
     "packs": [
       "Solgaleo",
@@ -393,7 +507,10 @@
     "set": "A3",
     "number": 39,
     "rarity": "U",
-    "name": "Alolan Sandslash",
+    "name": {
+      "en": "Alolan Sandslash",
+      "fr": "Sablaireau d'Alola"
+    },
     "image": "cPK_10_006200_00_ALOLASANDPAN_U.webp",
     "packs": [
       "Solgaleo",
@@ -404,7 +521,10 @@
     "set": "A3",
     "number": 40,
     "rarity": "C",
-    "name": "Alolan Vulpix",
+    "name": {
+      "en": "Alolan Vulpix",
+      "fr": "Goupix d'Alola"
+    },
     "image": "cPK_10_006210_00_ALOLAROKON_C.webp",
     "packs": [
       "Lunala"
@@ -414,7 +534,10 @@
     "set": "A3",
     "number": 41,
     "rarity": "R",
-    "name": "Alolan Ninetales",
+    "name": {
+      "en": "Alolan Ninetales",
+      "fr": "Feunard d'Alola"
+    },
     "image": "cPK_10_006220_00_ALOLAKYUKON_R.webp",
     "packs": [
       "Lunala"
@@ -424,7 +547,10 @@
     "set": "A3",
     "number": 42,
     "rarity": "C",
-    "name": "Shellder",
+    "name": {
+      "en": "Shellder",
+      "fr": "Kokiyas"
+    },
     "image": "cPK_10_006230_00_SHELLDER_C.webp",
     "packs": [
       "Solgaleo"
@@ -434,7 +560,10 @@
     "set": "A3",
     "number": 43,
     "rarity": "U",
-    "name": "Cloyster",
+    "name": {
+      "en": "Cloyster",
+      "fr": "Crustabri"
+    },
     "image": "cPK_10_006240_00_PARSHEN_U.webp",
     "packs": [
       "Solgaleo"
@@ -444,7 +573,10 @@
     "set": "A3",
     "number": 44,
     "rarity": "U",
-    "name": "Lapras",
+    "name": {
+      "en": "Lapras",
+      "fr": "Lokhlass"
+    },
     "image": "cPK_10_006250_00_LAPLACE_U.webp",
     "packs": [
       "Solgaleo",
@@ -455,7 +587,10 @@
     "set": "A3",
     "number": 45,
     "rarity": "C",
-    "name": "Popplio",
+    "name": {
+      "en": "Popplio",
+      "fr": "Otaquin"
+    },
     "image": "cPK_10_006260_00_ASHIMARI_C.webp",
     "packs": [
       "Lunala"
@@ -465,7 +600,10 @@
     "set": "A3",
     "number": 46,
     "rarity": "C",
-    "name": "Popplio",
+    "name": {
+      "en": "Popplio",
+      "fr": "Otaquin"
+    },
     "image": "cPK_10_006270_00_ASHIMARI_C.webp",
     "packs": [
       "Solgaleo"
@@ -475,7 +613,10 @@
     "set": "A3",
     "number": 47,
     "rarity": "U",
-    "name": "Brionne",
+    "name": {
+      "en": "Brionne",
+      "fr": "Otarlette"
+    },
     "image": "cPK_10_006280_00_OSYAMARI_U.webp",
     "packs": [
       "Lunala"
@@ -485,7 +626,10 @@
     "set": "A3",
     "number": 48,
     "rarity": "R",
-    "name": "Primarina",
+    "name": {
+      "en": "Primarina",
+      "fr": "Oratoria"
+    },
     "image": "cPK_10_006290_00_ASHIRENE_R.webp",
     "packs": [
       "Lunala"
@@ -495,7 +639,10 @@
     "set": "A3",
     "number": 49,
     "rarity": "RR",
-    "name": "Crabominable ex",
+    "name": {
+      "en": "Crabominable ex",
+      "fr": "Crabominable-ex"
+    },
     "image": "cPK_10_006300_00_KEKENKANIex_RR.webp",
     "packs": [
       "Solgaleo"
@@ -505,7 +652,10 @@
     "set": "A3",
     "number": 50,
     "rarity": "C",
-    "name": "Wishiwashi",
+    "name": {
+      "en": "Wishiwashi",
+      "fr": "Froussardine"
+    },
     "image": "cPK_10_006310_00_YOWASHITANDOKUNOSUGATA_C.webp",
     "packs": [
       "Lunala"
@@ -515,7 +665,10 @@
     "set": "A3",
     "number": 51,
     "rarity": "RR",
-    "name": "Wishiwashi ex",
+    "name": {
+      "en": "Wishiwashi ex",
+      "fr": "Froussardine-ex"
+    },
     "image": "cPK_10_006320_00_YOWASHIMURETASUGATA_RR.webp",
     "packs": [
       "Lunala"
@@ -525,7 +678,10 @@
     "set": "A3",
     "number": 52,
     "rarity": "C",
-    "name": "Dewpider",
+    "name": {
+      "en": "Dewpider",
+      "fr": "Araqua"
+    },
     "image": "cPK_10_006330_00_SHIZUKUMO_C.webp",
     "packs": [
       "Solgaleo"
@@ -535,7 +691,10 @@
     "set": "A3",
     "number": 53,
     "rarity": "U",
-    "name": "Araquanid",
+    "name": {
+      "en": "Araquanid",
+      "fr": "Tarenbulle"
+    },
     "image": "cPK_10_006340_00_ONISHIZUKUMO_U.webp",
     "packs": [
       "Solgaleo"
@@ -545,7 +704,10 @@
     "set": "A3",
     "number": 54,
     "rarity": "C",
-    "name": "Pyukumuku",
+    "name": {
+      "en": "Pyukumuku",
+      "fr": "Concombaffe"
+    },
     "image": "cPK_10_006350_00_NAMAKOBUSHI_C.webp",
     "packs": [
       "Lunala"
@@ -555,7 +717,10 @@
     "set": "A3",
     "number": 55,
     "rarity": "C",
-    "name": "Bruxish",
+    "name": {
+      "en": "Bruxish",
+      "fr": "Denticrisse"
+    },
     "image": "cPK_10_006360_00_HAGIGISHIRI_C.webp",
     "packs": [
       "Solgaleo",
@@ -566,7 +731,10 @@
     "set": "A3",
     "number": 56,
     "rarity": "R",
-    "name": "Tapu Fini",
+    "name": {
+      "en": "Tapu Fini",
+      "fr": "Tokopisco"
+    },
     "image": "cPK_10_006370_00_KAPU-REHIRE_R.webp",
     "packs": [
       "Lunala"
@@ -576,7 +744,10 @@
     "set": "A3",
     "number": 57,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_10_006380_00_PIKACHU_C.webp",
     "packs": [
       "Solgaleo"
@@ -586,7 +757,10 @@
     "set": "A3",
     "number": 58,
     "rarity": "RR",
-    "name": "Alolan Raichu ex",
+    "name": {
+      "en": "Alolan Raichu ex",
+      "fr": "Raichu d'Alola-ex"
+    },
     "image": "cPK_10_006390_00_ALOLARAICHUex_RR.webp",
     "packs": [
       "Solgaleo"
@@ -596,7 +770,10 @@
     "set": "A3",
     "number": 59,
     "rarity": "C",
-    "name": "Alolan Geodude",
+    "name": {
+      "en": "Alolan Geodude",
+      "fr": "Racaillou d'Alola"
+    },
     "image": "cPK_10_006400_00_ALOLAISITSUBUTE_C.webp",
     "packs": [
       "Solgaleo"
@@ -606,7 +783,10 @@
     "set": "A3",
     "number": 60,
     "rarity": "U",
-    "name": "Alolan Graveler",
+    "name": {
+      "en": "Alolan Graveler",
+      "fr": "Gravalanch d'Alola"
+    },
     "image": "cPK_10_006410_00_ALOLAGOLONE_U.webp",
     "packs": [
       "Solgaleo"
@@ -616,7 +796,10 @@
     "set": "A3",
     "number": 61,
     "rarity": "R",
-    "name": "Alolan Golem",
+    "name": {
+      "en": "Alolan Golem",
+      "fr": "Grolem d'Alola"
+    },
     "image": "cPK_10_006420_00_ALOLAGOLONYA_R.webp",
     "packs": [
       "Solgaleo"
@@ -626,7 +809,10 @@
     "set": "A3",
     "number": 62,
     "rarity": "C",
-    "name": "Helioptile",
+    "name": {
+      "en": "Helioptile",
+      "fr": "Galvaran"
+    },
     "image": "cPK_10_006430_00_ERIKITERU_C.webp",
     "packs": [
       "Solgaleo",
@@ -637,7 +823,10 @@
     "set": "A3",
     "number": 63,
     "rarity": "C",
-    "name": "Heliolisk",
+    "name": {
+      "en": "Heliolisk",
+      "fr": "Iguolta"
+    },
     "image": "cPK_10_006440_00_ELEZARD_C.webp",
     "packs": [
       "Solgaleo",
@@ -648,7 +837,10 @@
     "set": "A3",
     "number": 64,
     "rarity": "U",
-    "name": "Charjabug",
+    "name": {
+      "en": "Charjabug",
+      "fr": "Chrysapile"
+    },
     "image": "cPK_10_006450_00_DENDIMUSHI_U.webp",
     "packs": [
       "Lunala"
@@ -658,7 +850,10 @@
     "set": "A3",
     "number": 65,
     "rarity": "R",
-    "name": "Vikavolt",
+    "name": {
+      "en": "Vikavolt",
+      "fr": "Lucanon"
+    },
     "image": "cPK_10_006460_00_KUWAGANNON_R.webp",
     "packs": [
       "Lunala"
@@ -668,7 +863,10 @@
     "set": "A3",
     "number": 66,
     "rarity": "R",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006470_00_ODORIDORIPACHIPACHISTYLE_R.webp",
     "packs": [
       "Solgaleo"
@@ -678,7 +876,10 @@
     "set": "A3",
     "number": 67,
     "rarity": "C",
-    "name": "Togedemaru",
+    "name": {
+      "en": "Togedemaru",
+      "fr": "Togedemaru"
+    },
     "image": "cPK_10_006480_00_TOGEDEMARU_C.webp",
     "packs": [
       "Lunala"
@@ -688,7 +889,10 @@
     "set": "A3",
     "number": 68,
     "rarity": "R",
-    "name": "Tapu Koko",
+    "name": {
+      "en": "Tapu Koko",
+      "fr": "Tokorico"
+    },
     "image": "cPK_10_006490_00_KAPU-KOKEKO_R.webp",
     "packs": [
       "Solgaleo"
@@ -698,7 +902,10 @@
     "set": "A3",
     "number": 69,
     "rarity": "U",
-    "name": "Mr. Mime",
+    "name": {
+      "en": "Mr. Mime",
+      "fr": "M. Mime"
+    },
     "image": "cPK_10_006500_00_BARRIERD_U.webp",
     "packs": [
       "Solgaleo"
@@ -708,7 +915,10 @@
     "set": "A3",
     "number": 70,
     "rarity": "U",
-    "name": "Sableye",
+    "name": {
+      "en": "Sableye",
+      "fr": "Ténéfix"
+    },
     "image": "cPK_10_006510_00_YAMIRAMI_U.webp",
     "packs": [
       "Solgaleo",
@@ -719,7 +929,10 @@
     "set": "A3",
     "number": 71,
     "rarity": "C",
-    "name": "Spoink",
+    "name": {
+      "en": "Spoink",
+      "fr": "Spoink"
+    },
     "image": "cPK_10_006520_00_BANEBOO_C.webp",
     "packs": [
       "Solgaleo",
@@ -730,7 +943,10 @@
     "set": "A3",
     "number": 72,
     "rarity": "U",
-    "name": "Grumpig",
+    "name": {
+      "en": "Grumpig",
+      "fr": "Groret"
+    },
     "image": "cPK_10_006530_00_BOOPIG_U.webp",
     "packs": [
       "Solgaleo",
@@ -741,7 +957,10 @@
     "set": "A3",
     "number": 73,
     "rarity": "C",
-    "name": "Lunatone",
+    "name": {
+      "en": "Lunatone",
+      "fr": "Séléroc"
+    },
     "image": "cPK_10_006540_00_LUNATONE_C.webp",
     "packs": [
       "Lunala"
@@ -751,7 +970,10 @@
     "set": "A3",
     "number": 74,
     "rarity": "C",
-    "name": "Shuppet",
+    "name": {
+      "en": "Shuppet",
+      "fr": "Polichombr"
+    },
     "image": "cPK_10_006550_00_KAGEBOUZU_C.webp",
     "packs": [
       "Solgaleo",
@@ -762,7 +984,10 @@
     "set": "A3",
     "number": 75,
     "rarity": "C",
-    "name": "Banette",
+    "name": {
+      "en": "Banette",
+      "fr": "Branette"
+    },
     "image": "cPK_10_006560_00_JUPPETA_C.webp",
     "packs": [
       "Solgaleo",
@@ -773,7 +998,10 @@
     "set": "A3",
     "number": 76,
     "rarity": "U",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006570_00_ODORIDORIFURAFURASTYLE_U.webp",
     "packs": [
       "Solgaleo"
@@ -783,7 +1011,10 @@
     "set": "A3",
     "number": 77,
     "rarity": "U",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006580_00_ODORIDORIMAIMAISTYLE_U.webp",
     "packs": [
       "Lunala"
@@ -793,7 +1024,10 @@
     "set": "A3",
     "number": 78,
     "rarity": "C",
-    "name": "Cutiefly",
+    "name": {
+      "en": "Cutiefly",
+      "fr": "Bombydou"
+    },
     "image": "cPK_10_006590_00_ABULY_C.webp",
     "packs": [
       "Solgaleo"
@@ -803,7 +1037,10 @@
     "set": "A3",
     "number": 79,
     "rarity": "C",
-    "name": "Ribombee",
+    "name": {
+      "en": "Ribombee",
+      "fr": "Rubombelle"
+    },
     "image": "cPK_10_006600_00_ABURIBBON_C.webp",
     "packs": [
       "Solgaleo"
@@ -813,7 +1050,10 @@
     "set": "A3",
     "number": 80,
     "rarity": "R",
-    "name": "Comfey",
+    "name": {
+      "en": "Comfey",
+      "fr": "Guérilande"
+    },
     "image": "cPK_10_006610_00_CUWAWA_R.webp",
     "packs": [
       "Solgaleo"
@@ -823,7 +1063,10 @@
     "set": "A3",
     "number": 81,
     "rarity": "C",
-    "name": "Sandygast",
+    "name": {
+      "en": "Sandygast",
+      "fr": "Bacabouh"
+    },
     "image": "cPK_10_006620_00_SUNABA_C.webp",
     "packs": [
       "Solgaleo"
@@ -833,7 +1076,10 @@
     "set": "A3",
     "number": 82,
     "rarity": "R",
-    "name": "Palossand",
+    "name": {
+      "en": "Palossand",
+      "fr": "Trépassable"
+    },
     "image": "cPK_10_006630_00_SIRODETHNA_R.webp",
     "packs": [
       "Solgaleo"
@@ -843,7 +1089,10 @@
     "set": "A3",
     "number": 83,
     "rarity": "C",
-    "name": "Mimikyu",
+    "name": {
+      "en": "Mimikyu",
+      "fr": "Mimiqui"
+    },
     "image": "cPK_10_006640_00_MIMIKKYU_C.webp",
     "packs": [
       "Lunala"
@@ -853,7 +1102,10 @@
     "set": "A3",
     "number": 84,
     "rarity": "R",
-    "name": "Tapu Lele",
+    "name": {
+      "en": "Tapu Lele",
+      "fr": "Tokopiyon"
+    },
     "image": "cPK_10_006650_00_KAPU-TETEFU_R.webp",
     "packs": [
       "Lunala"
@@ -863,7 +1115,10 @@
     "set": "A3",
     "number": 85,
     "rarity": "C",
-    "name": "Cosmog",
+    "name": {
+      "en": "Cosmog",
+      "fr": "Cosmog"
+    },
     "image": "cPK_10_006660_00_COSMOG_C.webp",
     "packs": [
       "Solgaleo",
@@ -874,7 +1129,10 @@
     "set": "A3",
     "number": 86,
     "rarity": "U",
-    "name": "Cosmoem",
+    "name": {
+      "en": "Cosmoem",
+      "fr": "Cosmovum"
+    },
     "image": "cPK_10_006670_00_COSMOVUM_U.webp",
     "packs": [
       "Solgaleo",
@@ -885,7 +1143,10 @@
     "set": "A3",
     "number": 87,
     "rarity": "RR",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "image": "cPK_10_006680_00_LUNALAex_RR.webp",
     "packs": [
       "Lunala"
@@ -895,7 +1156,10 @@
     "set": "A3",
     "number": 88,
     "rarity": "R",
-    "name": "Necrozma",
+    "name": {
+      "en": "Necrozma",
+      "fr": "Necrozma"
+    },
     "image": "cPK_10_006690_00_NECROZMA_R.webp",
     "packs": [
       "Lunala"
@@ -905,7 +1169,10 @@
     "set": "A3",
     "number": 89,
     "rarity": "C",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "image": "cPK_10_006700_00_KARAKARA_C.webp",
     "packs": [
       "Lunala"
@@ -915,7 +1182,10 @@
     "set": "A3",
     "number": 90,
     "rarity": "C",
-    "name": "Makuhita",
+    "name": {
+      "en": "Makuhita",
+      "fr": "Makuhita"
+    },
     "image": "cPK_10_006710_00_MAKUNOSHITA_C.webp",
     "packs": [
       "Solgaleo",
@@ -926,7 +1196,10 @@
     "set": "A3",
     "number": 91,
     "rarity": "U",
-    "name": "Hariyama",
+    "name": {
+      "en": "Hariyama",
+      "fr": "Hariyama"
+    },
     "image": "cPK_10_006720_00_HARITEYAMA_U.webp",
     "packs": [
       "Solgaleo",
@@ -937,7 +1210,10 @@
     "set": "A3",
     "number": 92,
     "rarity": "C",
-    "name": "Solrock",
+    "name": {
+      "en": "Solrock",
+      "fr": "Solaroc"
+    },
     "image": "cPK_10_006730_00_SOLROCK_C.webp",
     "packs": [
       "Solgaleo"
@@ -947,7 +1223,10 @@
     "set": "A3",
     "number": 93,
     "rarity": "C",
-    "name": "Drilbur",
+    "name": {
+      "en": "Drilbur",
+      "fr": "Rototaupe"
+    },
     "image": "cPK_10_006740_00_MOGUREW_C.webp",
     "packs": [
       "Solgaleo",
@@ -958,7 +1237,10 @@
     "set": "A3",
     "number": 94,
     "rarity": "C",
-    "name": "Timburr",
+    "name": {
+      "en": "Timburr",
+      "fr": "Charpenti"
+    },
     "image": "cPK_10_006750_00_DOKKORER_C.webp",
     "packs": [
       "Lunala"
@@ -968,7 +1250,10 @@
     "set": "A3",
     "number": 95,
     "rarity": "U",
-    "name": "Gurdurr",
+    "name": {
+      "en": "Gurdurr",
+      "fr": "Ouvrifier"
+    },
     "image": "cPK_10_006760_00_DOTEKKOTSU_U.webp",
     "packs": [
       "Lunala"
@@ -978,7 +1263,10 @@
     "set": "A3",
     "number": 96,
     "rarity": "R",
-    "name": "Conkeldurr",
+    "name": {
+      "en": "Conkeldurr",
+      "fr": "Bétochef"
+    },
     "image": "cPK_10_006770_00_ROUBUSHIN_R.webp",
     "packs": [
       "Lunala"
@@ -988,7 +1276,10 @@
     "set": "A3",
     "number": 97,
     "rarity": "C",
-    "name": "Crabrawler",
+    "name": {
+      "en": "Crabrawler",
+      "fr": "Crabagarre"
+    },
     "image": "cPK_10_006780_00_MAKENKANI_C.webp",
     "packs": [
       "Solgaleo"
@@ -998,7 +1289,10 @@
     "set": "A3",
     "number": 98,
     "rarity": "C",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_10_006790_00_IWANKO_C.webp",
     "packs": [
       "Lunala"
@@ -1008,7 +1302,10 @@
     "set": "A3",
     "number": 99,
     "rarity": "C",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_10_006800_00_IWANKO_C.webp",
     "packs": [
       "Solgaleo"
@@ -1018,7 +1315,10 @@
     "set": "A3",
     "number": 100,
     "rarity": "R",
-    "name": "Lycanroc",
+    "name": {
+      "en": "Lycanroc",
+      "fr": "Lougaroc"
+    },
     "image": "cPK_10_006810_00_LUGARUGANMAHIRUNOSUGATA_R.webp",
     "packs": [
       "Solgaleo"
@@ -1028,7 +1328,10 @@
     "set": "A3",
     "number": 101,
     "rarity": "R",
-    "name": "Lycanroc",
+    "name": {
+      "en": "Lycanroc",
+      "fr": "Lougaroc"
+    },
     "image": "cPK_10_006820_00_LUGARUGANMAYONAKANOSUGATA_R.webp",
     "packs": [
       "Lunala"
@@ -1038,7 +1341,10 @@
     "set": "A3",
     "number": 102,
     "rarity": "C",
-    "name": "Mudbray",
+    "name": {
+      "en": "Mudbray",
+      "fr": "Tiboudet"
+    },
     "image": "cPK_10_006830_00_DOROBANKO_C.webp",
     "packs": [
       "Solgaleo"
@@ -1048,7 +1354,10 @@
     "set": "A3",
     "number": 103,
     "rarity": "U",
-    "name": "Mudsdale",
+    "name": {
+      "en": "Mudsdale",
+      "fr": "Bourrinos"
+    },
     "image": "cPK_10_006840_00_BANBADORO_U.webp",
     "packs": [
       "Solgaleo"
@@ -1058,7 +1367,10 @@
     "set": "A3",
     "number": 104,
     "rarity": "RR",
-    "name": "Passimian ex",
+    "name": {
+      "en": "Passimian ex",
+      "fr": "Quartermac-ex"
+    },
     "image": "cPK_10_006850_00_NAGETUKESARUex_RR.webp",
     "packs": [
       "Lunala"
@@ -1068,7 +1380,10 @@
     "set": "A3",
     "number": 105,
     "rarity": "U",
-    "name": "Minior",
+    "name": {
+      "en": "Minior",
+      "fr": "Météno"
+    },
     "image": "cPK_10_006860_00_METENOAKAIRONOCORE_U.webp",
     "packs": [
       "Lunala"
@@ -1078,7 +1393,10 @@
     "set": "A3",
     "number": 106,
     "rarity": "C",
-    "name": "Alolan Rattata",
+    "name": {
+      "en": "Alolan Rattata",
+      "fr": "Rattata d'Alola"
+    },
     "image": "cPK_10_006870_00_ALOLAKORATTA_C.webp",
     "packs": [
       "Lunala"
@@ -1088,7 +1406,10 @@
     "set": "A3",
     "number": 107,
     "rarity": "U",
-    "name": "Alolan Raticate",
+    "name": {
+      "en": "Alolan Raticate",
+      "fr": "Rattatac d'Alola"
+    },
     "image": "cPK_10_006880_00_ALOLARATTA_U.webp",
     "packs": [
       "Lunala"
@@ -1098,7 +1419,10 @@
     "set": "A3",
     "number": 108,
     "rarity": "C",
-    "name": "Alolan Meowth",
+    "name": {
+      "en": "Alolan Meowth",
+      "fr": "Miaouss d'Alola"
+    },
     "image": "cPK_10_006890_00_ALOLANYARTH_C.webp",
     "packs": [
       "Solgaleo"
@@ -1108,7 +1432,10 @@
     "set": "A3",
     "number": 109,
     "rarity": "R",
-    "name": "Alolan Persian",
+    "name": {
+      "en": "Alolan Persian",
+      "fr": "Persian d'Alola"
+    },
     "image": "cPK_10_006900_00_ALOLAPERSIAN_R.webp",
     "packs": [
       "Solgaleo"
@@ -1118,7 +1445,10 @@
     "set": "A3",
     "number": 110,
     "rarity": "C",
-    "name": "Alolan Grimer",
+    "name": {
+      "en": "Alolan Grimer",
+      "fr": "Tadmorv d'Alola"
+    },
     "image": "cPK_10_006910_00_ALOLABETBETER_C.webp",
     "packs": [
       "Lunala"
@@ -1128,7 +1458,10 @@
     "set": "A3",
     "number": 111,
     "rarity": "RR",
-    "name": "Alolan Muk ex",
+    "name": {
+      "en": "Alolan Muk ex",
+      "fr": "Grotadmorv d'Alola-ex"
+    },
     "image": "cPK_10_006920_00_ALOLABETBETONex_RR.webp",
     "packs": [
       "Lunala"
@@ -1138,7 +1471,10 @@
     "set": "A3",
     "number": 112,
     "rarity": "R",
-    "name": "Absol",
+    "name": {
+      "en": "Absol",
+      "fr": "Absol"
+    },
     "image": "cPK_10_006930_00_ABSOL_R.webp",
     "packs": [
       "Lunala"
@@ -1148,7 +1484,10 @@
     "set": "A3",
     "number": 113,
     "rarity": "C",
-    "name": "Trubbish",
+    "name": {
+      "en": "Trubbish",
+      "fr": "Miamiasme"
+    },
     "image": "cPK_10_006940_00_YABUKURON_C.webp",
     "packs": [
       "Solgaleo",
@@ -1159,7 +1498,10 @@
     "set": "A3",
     "number": 114,
     "rarity": "U",
-    "name": "Garbodor",
+    "name": {
+      "en": "Garbodor",
+      "fr": "Miasmax"
+    },
     "image": "cPK_10_006950_00_DUSTDAS_U.webp",
     "packs": [
       "Solgaleo",
@@ -1170,7 +1512,10 @@
     "set": "A3",
     "number": 115,
     "rarity": "C",
-    "name": "Mareanie",
+    "name": {
+      "en": "Mareanie",
+      "fr": "Vorastérie"
+    },
     "image": "cPK_10_006960_00_HIDOIDE_C.webp",
     "packs": [
       "Lunala"
@@ -1180,7 +1525,10 @@
     "set": "A3",
     "number": 116,
     "rarity": "C",
-    "name": "Toxapex",
+    "name": {
+      "en": "Toxapex",
+      "fr": "Prédastérie"
+    },
     "image": "cPK_10_006970_00_DOHIDOIDE_C.webp",
     "packs": [
       "Lunala"
@@ -1190,7 +1538,10 @@
     "set": "A3",
     "number": 117,
     "rarity": "C",
-    "name": "Alolan Diglett",
+    "name": {
+      "en": "Alolan Diglett",
+      "fr": "Taupiqueur d'Alola"
+    },
     "image": "cPK_10_006980_00_ALOLADIGDA_C.webp",
     "packs": [
       "Solgaleo",
@@ -1201,7 +1552,10 @@
     "set": "A3",
     "number": 118,
     "rarity": "C",
-    "name": "Alolan Dugtrio",
+    "name": {
+      "en": "Alolan Dugtrio",
+      "fr": "Triopikeur d'Alola"
+    },
     "image": "cPK_10_006990_00_ALOLADUGTRIO_C.webp",
     "packs": [
       "Solgaleo",
@@ -1212,7 +1566,10 @@
     "set": "A3",
     "number": 119,
     "rarity": "U",
-    "name": "Excadrill",
+    "name": {
+      "en": "Excadrill",
+      "fr": "Minotaupe"
+    },
     "image": "cPK_10_007000_00_DORYUZU_U.webp",
     "packs": [
       "Solgaleo",
@@ -1223,7 +1580,10 @@
     "set": "A3",
     "number": 120,
     "rarity": "U",
-    "name": "Escavalier",
+    "name": {
+      "en": "Escavalier",
+      "fr": "Lançargot"
+    },
     "image": "cPK_10_007010_00_CHEVARGO_U.webp",
     "packs": [
       "Solgaleo",
@@ -1234,7 +1594,10 @@
     "set": "A3",
     "number": 121,
     "rarity": "R",
-    "name": "Klefki",
+    "name": {
+      "en": "Klefki",
+      "fr": "Trousselin"
+    },
     "image": "cPK_10_007020_00_CLEFFY_R.webp",
     "packs": [
       "Solgaleo"
@@ -1244,7 +1607,10 @@
     "set": "A3",
     "number": 122,
     "rarity": "RR",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "image": "cPK_10_007030_00_SOLGALEOex_RR.webp",
     "packs": [
       "Solgaleo"
@@ -1254,7 +1620,10 @@
     "set": "A3",
     "number": 123,
     "rarity": "R",
-    "name": "Magearna",
+    "name": {
+      "en": "Magearna",
+      "fr": "Magearna"
+    },
     "image": "cPK_10_007040_00_MAGEARNA_R.webp",
     "packs": [
       "Solgaleo"
@@ -1264,7 +1633,10 @@
     "set": "A3",
     "number": 124,
     "rarity": "R",
-    "name": "Drampa",
+    "name": {
+      "en": "Drampa",
+      "fr": "Draïeul"
+    },
     "image": "cPK_10_007050_00_JIJILONG_R.webp",
     "packs": [
       "Solgaleo"
@@ -1274,7 +1646,10 @@
     "set": "A3",
     "number": 125,
     "rarity": "C",
-    "name": "Jangmo-o",
+    "name": {
+      "en": "Jangmo-o",
+      "fr": "Bébécaille"
+    },
     "image": "cPK_10_007060_00_JYARAKO_C.webp",
     "packs": [
       "Lunala"
@@ -1284,7 +1659,10 @@
     "set": "A3",
     "number": 126,
     "rarity": "U",
-    "name": "Hakamo-o",
+    "name": {
+      "en": "Hakamo-o",
+      "fr": "Écaïd"
+    },
     "image": "cPK_10_007070_00_JYARANGO_U.webp",
     "packs": [
       "Lunala"
@@ -1294,7 +1672,10 @@
     "set": "A3",
     "number": 127,
     "rarity": "R",
-    "name": "Kommo-o",
+    "name": {
+      "en": "Kommo-o",
+      "fr": "Ékaïser"
+    },
     "image": "cPK_10_007080_00_JYARARANGA_R.webp",
     "packs": [
       "Lunala"
@@ -1304,7 +1685,10 @@
     "set": "A3",
     "number": 128,
     "rarity": "U",
-    "name": "Tauros",
+    "name": {
+      "en": "Tauros",
+      "fr": "Tauros"
+    },
     "image": "cPK_10_007090_00_KENTAUROS_U.webp",
     "packs": [
       "Solgaleo",
@@ -1315,7 +1699,10 @@
     "set": "A3",
     "number": 129,
     "rarity": "C",
-    "name": "Skitty",
+    "name": {
+      "en": "Skitty",
+      "fr": "Skitty"
+    },
     "image": "cPK_10_007100_00_ENECO_C.webp",
     "packs": [
       "Solgaleo",
@@ -1326,7 +1713,10 @@
     "set": "A3",
     "number": 130,
     "rarity": "U",
-    "name": "Delcatty",
+    "name": {
+      "en": "Delcatty",
+      "fr": "Delcatty"
+    },
     "image": "cPK_10_007110_00_ENEKORORO_U.webp",
     "packs": [
       "Solgaleo",
@@ -1337,7 +1727,10 @@
     "set": "A3",
     "number": 131,
     "rarity": "C",
-    "name": "Fletchling",
+    "name": {
+      "en": "Fletchling",
+      "fr": "Passerouge"
+    },
     "image": "cPK_10_007120_00_YAYAKOMA_C.webp",
     "packs": [
       "Solgaleo"
@@ -1347,7 +1740,10 @@
     "set": "A3",
     "number": 132,
     "rarity": "U",
-    "name": "Hawlucha",
+    "name": {
+      "en": "Hawlucha",
+      "fr": "Brutalibré"
+    },
     "image": "cPK_10_007130_00_LUCHABULL_U.webp",
     "packs": [
       "Solgaleo"
@@ -1357,7 +1753,10 @@
     "set": "A3",
     "number": 133,
     "rarity": "C",
-    "name": "Pikipek",
+    "name": {
+      "en": "Pikipek",
+      "fr": "Picassaut"
+    },
     "image": "cPK_10_007140_00_TSUTSUKERA_C.webp",
     "packs": [
       "Solgaleo",
@@ -1368,7 +1767,10 @@
     "set": "A3",
     "number": 134,
     "rarity": "C",
-    "name": "Trumbeak",
+    "name": {
+      "en": "Trumbeak",
+      "fr": "Piclairon"
+    },
     "image": "cPK_10_007150_00_KERARAPPA_C.webp",
     "packs": [
       "Solgaleo",
@@ -1379,7 +1781,10 @@
     "set": "A3",
     "number": 135,
     "rarity": "U",
-    "name": "Toucannon",
+    "name": {
+      "en": "Toucannon",
+      "fr": "Bazoucan"
+    },
     "image": "cPK_10_007160_00_DODEKABASHI_U.webp",
     "packs": [
       "Solgaleo",
@@ -1390,7 +1795,10 @@
     "set": "A3",
     "number": 136,
     "rarity": "C",
-    "name": "Yungoos",
+    "name": {
+      "en": "Yungoos",
+      "fr": "Manglouton"
+    },
     "image": "cPK_10_007170_00_YOUNGOOSE_C.webp",
     "packs": [
       "Solgaleo"
@@ -1400,7 +1808,10 @@
     "set": "A3",
     "number": 137,
     "rarity": "C",
-    "name": "Gumshoos",
+    "name": {
+      "en": "Gumshoos",
+      "fr": "Argouste"
+    },
     "image": "cPK_10_007180_00_DEKAGOOSE_C.webp",
     "packs": [
       "Solgaleo"
@@ -1410,7 +1821,10 @@
     "set": "A3",
     "number": 138,
     "rarity": "C",
-    "name": "Stufful",
+    "name": {
+      "en": "Stufful",
+      "fr": "Nounourson"
+    },
     "image": "cPK_10_007190_00_NUIKOGUMA_C.webp",
     "packs": [
       "Lunala"
@@ -1420,7 +1834,10 @@
     "set": "A3",
     "number": 139,
     "rarity": "R",
-    "name": "Bewear",
+    "name": {
+      "en": "Bewear",
+      "fr": "Chelours"
+    },
     "image": "cPK_10_007200_00_KITERUGUMA_R.webp",
     "packs": [
       "Lunala"
@@ -1430,7 +1847,10 @@
     "set": "A3",
     "number": 140,
     "rarity": "R",
-    "name": "Oranguru",
+    "name": {
+      "en": "Oranguru",
+      "fr": "Gouroutan"
+    },
     "image": "cPK_10_007210_00_YAREYUUTAN_R.webp",
     "packs": [
       "Lunala"
@@ -1440,7 +1860,10 @@
     "set": "A3",
     "number": 141,
     "rarity": "U",
-    "name": "Komala",
+    "name": {
+      "en": "Komala",
+      "fr": "Dodoala"
+    },
     "image": "cPK_10_007220_00_NEKKOARA_U.webp",
     "packs": [
       "Solgaleo"
@@ -1450,7 +1873,10 @@
     "set": "A3",
     "number": 142,
     "rarity": "U",
-    "name": "Big Malasada",
+    "name": {
+      "en": "Big Malasada",
+      "fr": "Malasada Maxi"
+    },
     "image": "cTR_10_000460_00_OOKIIMARASADA_U.webp",
     "packs": [
       "Solgaleo",
@@ -1461,7 +1887,10 @@
     "set": "A3",
     "number": 143,
     "rarity": "U",
-    "name": "Fishing Net",
+    "name": {
+      "en": "Fishing Net",
+      "fr": "Filet de Pêche"
+    },
     "image": "cTR_10_000470_00_OSAKANANETTO_U.webp",
     "packs": [
       "Lunala"
@@ -1471,7 +1900,10 @@
     "set": "A3",
     "number": 144,
     "rarity": "U",
-    "name": "Rare Candy",
+    "name": {
+      "en": "Rare Candy",
+      "fr": "Super Bonbon"
+    },
     "image": "cTR_10_000480_00_FUSHIGINAAME_U.webp",
     "packs": [
       "Solgaleo",
@@ -1482,7 +1914,10 @@
     "set": "A3",
     "number": 145,
     "rarity": "U",
-    "name": "Rotom Dex",
+    "name": {
+      "en": "Rotom Dex",
+      "fr": "Motisma-Dex"
+    },
     "image": "cTR_10_000490_00_ROTOMUZUKAN_U.webp",
     "packs": [
       "Solgaleo"
@@ -1492,7 +1927,10 @@
     "set": "A3",
     "number": 146,
     "rarity": "U",
-    "name": "Poison Barb",
+    "name": {
+      "en": "Poison Barb",
+      "fr": "Pic Venin"
+    },
     "image": "cTR_10_000500_00_DOKUBARI_U.webp",
     "packs": [
       "Lunala"
@@ -1502,7 +1940,10 @@
     "set": "A3",
     "number": 147,
     "rarity": "U",
-    "name": "Leaf Cape",
+    "name": {
+      "en": "Leaf Cape",
+      "fr": "Cape Sylvestre"
+    },
     "image": "cTR_10_000510_00_LEAFMANTO_U.webp",
     "packs": [
       "Solgaleo"
@@ -1512,7 +1953,10 @@
     "set": "A3",
     "number": 148,
     "rarity": "U",
-    "name": "Acerola",
+    "name": {
+      "en": "Acerola",
+      "fr": "Margie"
+    },
     "image": "cTR_10_000520_00_ACEROLA_U.webp",
     "packs": [
       "Lunala"
@@ -1522,7 +1966,10 @@
     "set": "A3",
     "number": 149,
     "rarity": "U",
-    "name": "Ilima",
+    "name": {
+      "en": "Ilima",
+      "fr": "Althéo"
+    },
     "image": "cTR_10_000530_00_ILIMA_U.webp",
     "packs": [
       "Lunala"
@@ -1532,7 +1979,10 @@
     "set": "A3",
     "number": 150,
     "rarity": "U",
-    "name": "Kiawe",
+    "name": {
+      "en": "Kiawe",
+      "fr": "Kiawe"
+    },
     "image": "cTR_10_000540_00_KAKI_U.webp",
     "packs": [
       "Lunala"
@@ -1542,7 +1992,10 @@
     "set": "A3",
     "number": 151,
     "rarity": "U",
-    "name": "Guzma",
+    "name": {
+      "en": "Guzma",
+      "fr": "Guzma"
+    },
     "image": "cTR_10_000550_00_GUZUMA_U.webp",
     "packs": [
       "Lunala"
@@ -1552,7 +2005,10 @@
     "set": "A3",
     "number": 152,
     "rarity": "U",
-    "name": "Lana",
+    "name": {
+      "en": "Lana",
+      "fr": "Néphie"
+    },
     "image": "cTR_10_000560_00_SUIREN_U.webp",
     "packs": [
       "Solgaleo"
@@ -1562,7 +2018,10 @@
     "set": "A3",
     "number": 153,
     "rarity": "U",
-    "name": "Sophocles",
+    "name": {
+      "en": "Sophocles",
+      "fr": "Chrys"
+    },
     "image": "cTR_10_000570_00_MAMANE_U.webp",
     "packs": [
       "Solgaleo"
@@ -1572,7 +2031,10 @@
     "set": "A3",
     "number": 154,
     "rarity": "U",
-    "name": "Mallow",
+    "name": {
+      "en": "Mallow",
+      "fr": "Barbara"
+    },
     "image": "cTR_10_000580_00_MAO_U.webp",
     "packs": [
       "Solgaleo"
@@ -1582,7 +2044,10 @@
     "set": "A3",
     "number": 155,
     "rarity": "U",
-    "name": "Lillie",
+    "name": {
+      "en": "Lillie",
+      "fr": "Lilie"
+    },
     "image": "cTR_10_000590_00_LILIE_U.webp",
     "packs": [
       "Solgaleo"
@@ -1592,7 +2057,10 @@
     "set": "A3",
     "number": 156,
     "rarity": "AR",
-    "name": "Alolan Exeggutor",
+    "name": {
+      "en": "Alolan Exeggutor",
+      "fr": "Noadkoko d'Alola"
+    },
     "image": "cPK_20_005830_00_ALOLANASSY_AR.webp",
     "packs": [
       "Lunala"
@@ -1602,7 +2070,10 @@
     "set": "A3",
     "number": 157,
     "rarity": "AR",
-    "name": "Morelull",
+    "name": {
+      "en": "Morelull",
+      "fr": "Spododo"
+    },
     "image": "cPK_20_005970_00_NEMASYU_AR.webp",
     "packs": [
       "Lunala"
@@ -1612,7 +2083,10 @@
     "set": "A3",
     "number": 158,
     "rarity": "AR",
-    "name": "Tsareena",
+    "name": {
+      "en": "Tsareena",
+      "fr": "Sucreine"
+    },
     "image": "cPK_20_006010_00_AMAJO_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1622,7 +2096,10 @@
     "set": "A3",
     "number": 159,
     "rarity": "AR",
-    "name": "Tapu Bulu",
+    "name": {
+      "en": "Tapu Bulu",
+      "fr": "Tokotoro"
+    },
     "image": "cPK_20_006050_00_KAPU-BULUL_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1632,7 +2109,10 @@
     "set": "A3",
     "number": 160,
     "rarity": "AR",
-    "name": "Alolan Marowak",
+    "name": {
+      "en": "Alolan Marowak",
+      "fr": "Ossatueur d'Alola"
+    },
     "image": "cPK_20_006080_00_ALOLAGARAGARA_AR.webp",
     "packs": [
       "Lunala"
@@ -1642,7 +2122,10 @@
     "set": "A3",
     "number": 161,
     "rarity": "AR",
-    "name": "Turtonator",
+    "name": {
+      "en": "Turtonator",
+      "fr": "Boumata"
+    },
     "image": "cPK_20_006180_00_BAKUGAMES_AR.webp",
     "packs": [
       "Lunala"
@@ -1652,7 +2135,10 @@
     "set": "A3",
     "number": 162,
     "rarity": "AR",
-    "name": "Alolan Vulpix",
+    "name": {
+      "en": "Alolan Vulpix",
+      "fr": "Goupix d'Alola"
+    },
     "image": "cPK_20_006210_00_ALOLAROKON_AR.webp",
     "packs": [
       "Lunala"
@@ -1662,7 +2148,10 @@
     "set": "A3",
     "number": 163,
     "rarity": "AR",
-    "name": "Pyukumuku",
+    "name": {
+      "en": "Pyukumuku",
+      "fr": "Concombaffe"
+    },
     "image": "cPK_20_006350_00_NAMAKOBUSHI_AR.webp",
     "packs": [
       "Lunala"
@@ -1672,7 +2161,10 @@
     "set": "A3",
     "number": 164,
     "rarity": "AR",
-    "name": "Tapu Fini",
+    "name": {
+      "en": "Tapu Fini",
+      "fr": "Tokopisco"
+    },
     "image": "cPK_20_006370_00_KAPU-REHIRE_AR.webp",
     "packs": [
       "Lunala"
@@ -1682,7 +2174,10 @@
     "set": "A3",
     "number": 165,
     "rarity": "AR",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_20_006470_00_ODORIDORIPACHIPACHISTYLE_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1692,7 +2187,10 @@
     "set": "A3",
     "number": 166,
     "rarity": "AR",
-    "name": "Tapu Koko",
+    "name": {
+      "en": "Tapu Koko",
+      "fr": "Tokorico"
+    },
     "image": "cPK_20_006490_00_KAPU-KOKEKO_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1702,7 +2200,10 @@
     "set": "A3",
     "number": 167,
     "rarity": "AR",
-    "name": "Cutiefly",
+    "name": {
+      "en": "Cutiefly",
+      "fr": "Bombydou"
+    },
     "image": "cPK_20_006590_00_ABULY_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1712,7 +2213,10 @@
     "set": "A3",
     "number": 168,
     "rarity": "AR",
-    "name": "Comfey",
+    "name": {
+      "en": "Comfey",
+      "fr": "Guérilande"
+    },
     "image": "cPK_20_006610_00_CUWAWA_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1722,7 +2226,10 @@
     "set": "A3",
     "number": 169,
     "rarity": "AR",
-    "name": "Sandygast",
+    "name": {
+      "en": "Sandygast",
+      "fr": "Bacabouh"
+    },
     "image": "cPK_20_006620_00_SUNABA_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1732,7 +2239,10 @@
     "set": "A3",
     "number": 170,
     "rarity": "AR",
-    "name": "Tapu Lele",
+    "name": {
+      "en": "Tapu Lele",
+      "fr": "Tokopiyon"
+    },
     "image": "cPK_20_006650_00_KAPU-TETEFU_AR.webp",
     "packs": [
       "Lunala"
@@ -1742,7 +2252,10 @@
     "set": "A3",
     "number": 171,
     "rarity": "AR",
-    "name": "Cosmog",
+    "name": {
+      "en": "Cosmog",
+      "fr": "Cosmog"
+    },
     "image": "cPK_20_006660_00_COSMOG_AR.webp",
     "packs": [
       "Lunala"
@@ -1752,7 +2265,10 @@
     "set": "A3",
     "number": 172,
     "rarity": "AR",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_20_006790_00_IWANKO_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1762,7 +2278,10 @@
     "set": "A3",
     "number": 173,
     "rarity": "AR",
-    "name": "Mudsdale",
+    "name": {
+      "en": "Mudsdale",
+      "fr": "Bourrinos"
+    },
     "image": "cPK_20_006840_00_BANBADORO_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1772,7 +2291,10 @@
     "set": "A3",
     "number": 174,
     "rarity": "AR",
-    "name": "Minior",
+    "name": {
+      "en": "Minior",
+      "fr": "Météno"
+    },
     "image": "cPK_20_006860_00_METENOAKAIRONOCORE_AR.webp",
     "packs": [
       "Lunala"
@@ -1782,7 +2304,10 @@
     "set": "A3",
     "number": 175,
     "rarity": "AR",
-    "name": "Magearna",
+    "name": {
+      "en": "Magearna",
+      "fr": "Magearna"
+    },
     "image": "cPK_20_007040_00_MAGEARNA_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1792,7 +2317,10 @@
     "set": "A3",
     "number": 176,
     "rarity": "AR",
-    "name": "Drampa",
+    "name": {
+      "en": "Drampa",
+      "fr": "Draïeul"
+    },
     "image": "cPK_20_007050_00_JIJILONG_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1802,7 +2330,10 @@
     "set": "A3",
     "number": 177,
     "rarity": "AR",
-    "name": "Pikipek",
+    "name": {
+      "en": "Pikipek",
+      "fr": "Picassaut"
+    },
     "image": "cPK_20_007140_00_TSUTSUKERA_AR.webp",
     "packs": [
       "Lunala"
@@ -1812,7 +2343,10 @@
     "set": "A3",
     "number": 178,
     "rarity": "AR",
-    "name": "Bewear",
+    "name": {
+      "en": "Bewear",
+      "fr": "Chelours"
+    },
     "image": "cPK_20_007200_00_KITERUGUMA_AR.webp",
     "packs": [
       "Lunala"
@@ -1822,7 +2356,10 @@
     "set": "A3",
     "number": 179,
     "rarity": "AR",
-    "name": "Komala",
+    "name": {
+      "en": "Komala",
+      "fr": "Dodoala"
+    },
     "image": "cPK_20_007220_00_NEKKOARA_AR.webp",
     "packs": [
       "Solgaleo"
@@ -1832,7 +2369,10 @@
     "set": "A3",
     "number": 180,
     "rarity": "SR",
-    "name": "Decidueye ex",
+    "name": {
+      "en": "Decidueye ex",
+      "fr": "Archéduc-ex"
+    },
     "image": "cPK_20_005930_00_JUNAIPERex_SR.webp",
     "packs": [
       "Lunala"
@@ -1842,7 +2382,10 @@
     "set": "A3",
     "number": 181,
     "rarity": "SR",
-    "name": "Dhelmise ex",
+    "name": {
+      "en": "Dhelmise ex",
+      "fr": "Sinistrail-ex"
+    },
     "image": "cPK_20_006040_00_DADARINex_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1852,7 +2395,10 @@
     "set": "A3",
     "number": 182,
     "rarity": "SR",
-    "name": "Incineroar ex",
+    "name": {
+      "en": "Incineroar ex",
+      "fr": "Félinferno-ex"
+    },
     "image": "cPK_20_006140_00_GAOGAENex_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1862,7 +2408,10 @@
     "set": "A3",
     "number": 183,
     "rarity": "SR",
-    "name": "Crabominable ex",
+    "name": {
+      "en": "Crabominable ex",
+      "fr": "Crabominable-ex"
+    },
     "image": "cPK_20_006300_00_KEKENKANIex_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1872,7 +2421,10 @@
     "set": "A3",
     "number": 184,
     "rarity": "SR",
-    "name": "Wishiwashi ex",
+    "name": {
+      "en": "Wishiwashi ex",
+      "fr": "Froussardine-ex"
+    },
     "image": "cPK_20_006320_00_YOWASHIMURETASUGATA_SR.webp",
     "packs": [
       "Lunala"
@@ -1882,7 +2434,10 @@
     "set": "A3",
     "number": 185,
     "rarity": "SR",
-    "name": "Alolan Raichu ex",
+    "name": {
+      "en": "Alolan Raichu ex",
+      "fr": "Raichu d'Alola-ex"
+    },
     "image": "cPK_20_006390_00_ALOLARAICHUex_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1892,7 +2447,10 @@
     "set": "A3",
     "number": 186,
     "rarity": "SR",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "image": "cPK_20_006680_00_LUNALAex_SR.webp",
     "packs": [
       "Lunala"
@@ -1902,7 +2460,10 @@
     "set": "A3",
     "number": 187,
     "rarity": "SR",
-    "name": "Passimian ex",
+    "name": {
+      "en": "Passimian ex",
+      "fr": "Quartermac-ex"
+    },
     "image": "cPK_20_006850_00_NAGETUKESARUex_SR.webp",
     "packs": [
       "Lunala"
@@ -1912,7 +2473,10 @@
     "set": "A3",
     "number": 188,
     "rarity": "SR",
-    "name": "Alolan Muk ex",
+    "name": {
+      "en": "Alolan Muk ex",
+      "fr": "Grotadmorv d'Alola-ex"
+    },
     "image": "cPK_20_006920_00_ALOLABETBETONex_SR.webp",
     "packs": [
       "Lunala"
@@ -1922,7 +2486,10 @@
     "set": "A3",
     "number": 189,
     "rarity": "SR",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "image": "cPK_20_007030_00_SOLGALEOex_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1932,7 +2499,10 @@
     "set": "A3",
     "number": 190,
     "rarity": "SR",
-    "name": "Acerola",
+    "name": {
+      "en": "Acerola",
+      "fr": "Margie"
+    },
     "image": "cTR_20_000520_00_ACEROLA_SR.webp",
     "packs": [
       "Lunala"
@@ -1942,7 +2512,10 @@
     "set": "A3",
     "number": 191,
     "rarity": "SR",
-    "name": "Ilima",
+    "name": {
+      "en": "Ilima",
+      "fr": "Althéo"
+    },
     "image": "cTR_20_000530_00_ILIMA_SR.webp",
     "packs": [
       "Lunala"
@@ -1952,7 +2525,10 @@
     "set": "A3",
     "number": 192,
     "rarity": "SR",
-    "name": "Kiawe",
+    "name": {
+      "en": "Kiawe",
+      "fr": "Kiawe"
+    },
     "image": "cTR_20_000540_00_KAKI_SR.webp",
     "packs": [
       "Lunala"
@@ -1962,7 +2538,10 @@
     "set": "A3",
     "number": 193,
     "rarity": "SR",
-    "name": "Guzma",
+    "name": {
+      "en": "Guzma",
+      "fr": "Guzma"
+    },
     "image": "cTR_20_000550_00_GUZUMA_SR.webp",
     "packs": [
       "Lunala"
@@ -1972,7 +2551,10 @@
     "set": "A3",
     "number": 194,
     "rarity": "SR",
-    "name": "Lana",
+    "name": {
+      "en": "Lana",
+      "fr": "Néphie"
+    },
     "image": "cTR_20_000560_00_SUIREN_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1982,7 +2564,10 @@
     "set": "A3",
     "number": 195,
     "rarity": "SR",
-    "name": "Sophocles",
+    "name": {
+      "en": "Sophocles",
+      "fr": "Chrys"
+    },
     "image": "cTR_20_000570_00_MAMANE_SR.webp",
     "packs": [
       "Solgaleo"
@@ -1992,7 +2577,10 @@
     "set": "A3",
     "number": 196,
     "rarity": "SR",
-    "name": "Mallow",
+    "name": {
+      "en": "Mallow",
+      "fr": "Barbara"
+    },
     "image": "cTR_20_000580_00_MAO_SR.webp",
     "packs": [
       "Solgaleo"
@@ -2002,7 +2590,10 @@
     "set": "A3",
     "number": 197,
     "rarity": "SR",
-    "name": "Lillie",
+    "name": {
+      "en": "Lillie",
+      "fr": "Lilie"
+    },
     "image": "cTR_20_000590_00_LILIE_SR.webp",
     "packs": [
       "Solgaleo"
@@ -2012,7 +2603,10 @@
     "set": "A3",
     "number": 198,
     "rarity": "SAR",
-    "name": "Decidueye ex",
+    "name": {
+      "en": "Decidueye ex",
+      "fr": "Archéduc-ex"
+    },
     "image": "cPK_20_005930_01_JUNAIPERex_SAR.webp",
     "packs": [
       "Lunala"
@@ -2022,7 +2616,10 @@
     "set": "A3",
     "number": 199,
     "rarity": "SAR",
-    "name": "Dhelmise ex",
+    "name": {
+      "en": "Dhelmise ex",
+      "fr": "Sinistrail-ex"
+    },
     "image": "cPK_20_006040_01_DADARINex_SAR.webp",
     "packs": [
       "Solgaleo"
@@ -2032,7 +2629,10 @@
     "set": "A3",
     "number": 200,
     "rarity": "SAR",
-    "name": "Incineroar ex",
+    "name": {
+      "en": "Incineroar ex",
+      "fr": "Félinferno-ex"
+    },
     "image": "cPK_20_006140_01_GAOGAENex_SAR.webp",
     "packs": [
       "Solgaleo"
@@ -2042,7 +2642,10 @@
     "set": "A3",
     "number": 201,
     "rarity": "SAR",
-    "name": "Crabominable ex",
+    "name": {
+      "en": "Crabominable ex",
+      "fr": "Crabominable-ex"
+    },
     "image": "cPK_20_006300_01_KEKENKANIex_SAR.webp",
     "packs": [
       "Solgaleo"
@@ -2052,7 +2655,10 @@
     "set": "A3",
     "number": 202,
     "rarity": "SAR",
-    "name": "Wishiwashi ex",
+    "name": {
+      "en": "Wishiwashi ex",
+      "fr": "Froussardine-ex"
+    },
     "image": "cPK_20_006320_01_YOWASHIMURETASUGATA_SAR.webp",
     "packs": [
       "Lunala"
@@ -2062,7 +2668,10 @@
     "set": "A3",
     "number": 203,
     "rarity": "SAR",
-    "name": "Alolan Raichu ex",
+    "name": {
+      "en": "Alolan Raichu ex",
+      "fr": "Raichu d'Alola-ex"
+    },
     "image": "cPK_20_006390_01_ALOLARAICHUex_SAR.webp",
     "packs": [
       "Solgaleo"
@@ -2072,7 +2681,10 @@
     "set": "A3",
     "number": 204,
     "rarity": "SAR",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "image": "cPK_20_006680_01_LUNALAex_SAR.webp",
     "packs": [
       "Lunala"
@@ -2082,7 +2694,10 @@
     "set": "A3",
     "number": 205,
     "rarity": "SAR",
-    "name": "Passimian ex",
+    "name": {
+      "en": "Passimian ex",
+      "fr": "Quartermac-ex"
+    },
     "image": "cPK_20_006850_01_NAGETUKESARUex_SAR.webp",
     "packs": [
       "Lunala"
@@ -2092,7 +2707,10 @@
     "set": "A3",
     "number": 206,
     "rarity": "SAR",
-    "name": "Alolan Muk ex",
+    "name": {
+      "en": "Alolan Muk ex",
+      "fr": "Grotadmorv d'Alola-ex"
+    },
     "image": "cPK_20_006920_01_ALOLABETBETONex_SAR.webp",
     "packs": [
       "Lunala"
@@ -2102,7 +2720,10 @@
     "set": "A3",
     "number": 207,
     "rarity": "SAR",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "image": "cPK_20_007030_01_SOLGALEOex_SAR.webp",
     "packs": [
       "Solgaleo"
@@ -2112,7 +2733,10 @@
     "set": "A3",
     "number": 208,
     "rarity": "IM",
-    "name": "Guzma",
+    "name": {
+      "en": "Guzma",
+      "fr": "Guzma"
+    },
     "image": "cTR_20_000550_01_GUZUMA_IM.webp",
     "packs": [
       "Lunala"
@@ -2122,7 +2746,10 @@
     "set": "A3",
     "number": 209,
     "rarity": "IM",
-    "name": "Lillie",
+    "name": {
+      "en": "Lillie",
+      "fr": "Lilie"
+    },
     "image": "cTR_20_000590_01_LILIE_IM.webp",
     "packs": [
       "Solgaleo"
@@ -2132,7 +2759,10 @@
     "set": "A3",
     "number": 210,
     "rarity": "S",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "image": "cPK_20_000010_01_FUSHIGIDANE_S.webp",
     "packs": [
       "Solgaleo"
@@ -2142,7 +2772,10 @@
     "set": "A3",
     "number": 211,
     "rarity": "S",
-    "name": "Ivysaur",
+    "name": {
+      "en": "Ivysaur",
+      "fr": "Herbizarre"
+    },
     "image": "cPK_20_000020_00_FUSHIGISOU_S.webp",
     "packs": [
       "Solgaleo"
@@ -2152,7 +2785,10 @@
     "set": "A3",
     "number": 212,
     "rarity": "S",
-    "name": "Venusaur",
+    "name": {
+      "en": "Venusaur",
+      "fr": "Florizarre"
+    },
     "image": "cPK_20_000030_00_FUSHIGIBANA_S.webp",
     "packs": [
       "Solgaleo"
@@ -2162,7 +2798,10 @@
     "set": "A3",
     "number": 213,
     "rarity": "S",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_20_005820_00_TAMATAMA_S.webp",
     "packs": [
       "Lunala"
@@ -2172,7 +2811,10 @@
     "set": "A3",
     "number": 214,
     "rarity": "S",
-    "name": "Exeggutor",
+    "name": {
+      "en": "Exeggutor",
+      "fr": "Noadkoko"
+    },
     "image": "cPK_20_002160_01_NASSY_S.webp",
     "packs": [
       "Lunala"
@@ -2182,7 +2824,10 @@
     "set": "A3",
     "number": 215,
     "rarity": "S",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "image": "cPK_20_000530_01_ZENIGAME_S.webp",
     "packs": [
       "Lunala"
@@ -2192,7 +2837,10 @@
     "set": "A3",
     "number": 216,
     "rarity": "S",
-    "name": "Wartortle",
+    "name": {
+      "en": "Wartortle",
+      "fr": "Carabaffe"
+    },
     "image": "cPK_20_000540_00_KAMEIL_S.webp",
     "packs": [
       "Lunala"
@@ -2202,7 +2850,10 @@
     "set": "A3",
     "number": 217,
     "rarity": "S",
-    "name": "Blastoise",
+    "name": {
+      "en": "Blastoise",
+      "fr": "Tortank"
+    },
     "image": "cPK_20_000550_00_KAMEX_S.webp",
     "packs": [
       "Lunala"
@@ -2212,7 +2863,10 @@
     "set": "A3",
     "number": 218,
     "rarity": "S",
-    "name": "Staryu",
+    "name": {
+      "en": "Staryu",
+      "fr": "Stari"
+    },
     "image": "cPK_20_000740_00_HITODEMAN_S.webp",
     "packs": [
       "Solgaleo"
@@ -2222,7 +2876,10 @@
     "set": "A3",
     "number": 219,
     "rarity": "S",
-    "name": "Starmie",
+    "name": {
+      "en": "Starmie",
+      "fr": "Staross"
+    },
     "image": "cPK_20_000750_00_STARMIE_S.webp",
     "packs": [
       "Solgaleo"
@@ -2232,7 +2889,10 @@
     "set": "A3",
     "number": 220,
     "rarity": "S",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "image": "cPK_20_004550_00_GHOS_S.webp",
     "packs": [
       "Lunala"
@@ -2242,7 +2902,10 @@
     "set": "A3",
     "number": 221,
     "rarity": "S",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "image": "cPK_20_001210_00_GHOST_S.webp",
     "packs": [
       "Lunala"
@@ -2252,7 +2915,10 @@
     "set": "A3",
     "number": 222,
     "rarity": "S",
-    "name": "Gengar",
+    "name": {
+      "en": "Gengar",
+      "fr": "Ectoplasma"
+    },
     "image": "cPK_20_001220_00_GANGAR_S.webp",
     "packs": [
       "Lunala"
@@ -2262,7 +2928,10 @@
     "set": "A3",
     "number": 223,
     "rarity": "S",
-    "name": "Machop",
+    "name": {
+      "en": "Machop",
+      "fr": "Machoc"
+    },
     "image": "cPK_20_001430_00_WANRIKY_S.webp",
     "packs": [
       "Solgaleo"
@@ -2272,7 +2941,10 @@
     "set": "A3",
     "number": 224,
     "rarity": "S",
-    "name": "Machoke",
+    "name": {
+      "en": "Machoke",
+      "fr": "Machopeur"
+    },
     "image": "cPK_20_001440_00_GORIKY_S.webp",
     "packs": [
       "Solgaleo"
@@ -2282,7 +2954,10 @@
     "set": "A3",
     "number": 225,
     "rarity": "S",
-    "name": "Machamp",
+    "name": {
+      "en": "Machamp",
+      "fr": "Mackogneur"
+    },
     "image": "cPK_20_005020_00_KAIRIKY_S.webp",
     "packs": [
       "Solgaleo"
@@ -2292,7 +2967,10 @@
     "set": "A3",
     "number": 226,
     "rarity": "S",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "image": "cPK_20_001510_01_KARAKARA_S.webp",
     "packs": [
       "Lunala"
@@ -2302,7 +2980,10 @@
     "set": "A3",
     "number": 227,
     "rarity": "S",
-    "name": "Marowak",
+    "name": {
+      "en": "Marowak",
+      "fr": "Ossatueur"
+    },
     "image": "cPK_20_001520_00_GARAGARA_S.webp",
     "packs": [
       "Lunala"
@@ -2312,7 +2993,10 @@
     "set": "A3",
     "number": 228,
     "rarity": "S",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "image": "cPK_20_005750_00_PURIN_S.webp",
     "packs": [
       "Solgaleo"
@@ -2322,7 +3006,10 @@
     "set": "A3",
     "number": 229,
     "rarity": "S",
-    "name": "Wigglytuff",
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    },
     "image": "cPK_20_005760_01_PUKURIN_S.webp",
     "packs": [
       "Solgaleo"
@@ -2332,7 +3019,10 @@
     "set": "A3",
     "number": 230,
     "rarity": "SSR",
-    "name": "Venusaur ex",
+    "name": {
+      "en": "Venusaur ex",
+      "fr": "Florizarre-ex"
+    },
     "image": "cPK_20_000040_01_FUSHIGIBANAex_SSR.webp",
     "packs": [
       "Solgaleo"
@@ -2342,7 +3032,10 @@
     "set": "A3",
     "number": 231,
     "rarity": "SSR",
-    "name": "Exeggutor ex",
+    "name": {
+      "en": "Exeggutor ex",
+      "fr": "Noadkoko-ex"
+    },
     "image": "cPK_20_000230_01_NASSYex_SSR.webp",
     "packs": [
       "Lunala"
@@ -2352,7 +3045,10 @@
     "set": "A3",
     "number": 232,
     "rarity": "SSR",
-    "name": "Blastoise ex",
+    "name": {
+      "en": "Blastoise ex",
+      "fr": "Tortank-ex"
+    },
     "image": "cPK_20_000560_01_KAMEXex_SSR.webp",
     "packs": [
       "Lunala"
@@ -2362,7 +3058,10 @@
     "set": "A3",
     "number": 233,
     "rarity": "SSR",
-    "name": "Starmie ex",
+    "name": {
+      "en": "Starmie ex",
+      "fr": "Staross-ex"
+    },
     "image": "cPK_20_000760_01_STARMIEex_SSR.webp",
     "packs": [
       "Solgaleo"
@@ -2372,7 +3071,10 @@
     "set": "A3",
     "number": 234,
     "rarity": "SSR",
-    "name": "Gengar ex",
+    "name": {
+      "en": "Gengar ex",
+      "fr": "Ectoplasma-ex"
+    },
     "image": "cPK_20_001230_02_GANGARex_SSR.webp",
     "packs": [
       "Lunala"
@@ -2382,7 +3084,10 @@
     "set": "A3",
     "number": 235,
     "rarity": "SSR",
-    "name": "Machamp ex",
+    "name": {
+      "en": "Machamp ex",
+      "fr": "Mackogneur-ex"
+    },
     "image": "cPK_20_001460_02_KAIRIKYex_SSR.webp",
     "packs": [
       "Solgaleo"
@@ -2392,7 +3097,10 @@
     "set": "A3",
     "number": 236,
     "rarity": "SSR",
-    "name": "Marowak ex",
+    "name": {
+      "en": "Marowak ex",
+      "fr": "Ossatueur-ex"
+    },
     "image": "cPK_20_001530_01_GARAGARAex_SSR.webp",
     "packs": [
       "Lunala"
@@ -2402,7 +3110,10 @@
     "set": "A3",
     "number": 237,
     "rarity": "SSR",
-    "name": "Wigglytuff ex",
+    "name": {
+      "en": "Wigglytuff ex",
+      "fr": "Grodoudou-ex"
+    },
     "image": "cPK_20_001950_02_PUKURINex_SSR.webp",
     "packs": [
       "Solgaleo"
@@ -2412,7 +3123,10 @@
     "set": "A3",
     "number": 238,
     "rarity": "UR",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "image": "cPK_20_006680_02_LUNALAex_UR.webp",
     "packs": [
       "Solgaleo",
@@ -2423,7 +3137,10 @@
     "set": "A3",
     "number": 239,
     "rarity": "UR",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "image": "cPK_20_007030_02_SOLGALEOex_UR.webp",
     "packs": [
       "Solgaleo",

--- a/dist/cards/A3a.json
+++ b/dist/cards/A3a.json
@@ -3,7 +3,10 @@
     "set": "A3a",
     "number": 1,
     "rarity": "C",
-    "name": "Petilil",
+    "name": {
+      "en": "Petilil",
+      "fr": "Chlorobule"
+    },
     "image": "cPK_10_007430_00_CHURINE_C.webp",
     "packs": [
       "Extradimensional"
@@ -13,7 +16,10 @@
     "set": "A3a",
     "number": 2,
     "rarity": "C",
-    "name": "Lilligant",
+    "name": {
+      "en": "Lilligant",
+      "fr": "Fragilady"
+    },
     "image": "cPK_10_007440_00_DREDEAR_C.webp",
     "packs": [
       "Extradimensional"
@@ -23,7 +29,10 @@
     "set": "A3a",
     "number": 3,
     "rarity": "C",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_10_007450_00_MOKUROH_C.webp",
     "packs": [
       "Extradimensional"
@@ -33,7 +42,10 @@
     "set": "A3a",
     "number": 4,
     "rarity": "U",
-    "name": "Dartrix",
+    "name": {
+      "en": "Dartrix",
+      "fr": "Efflèche"
+    },
     "image": "cPK_10_007460_00_FUKUTHROW_U.webp",
     "packs": [
       "Extradimensional"
@@ -43,7 +55,10 @@
     "set": "A3a",
     "number": 5,
     "rarity": "R",
-    "name": "Decidueye",
+    "name": {
+      "en": "Decidueye",
+      "fr": "Archéduc"
+    },
     "image": "cPK_10_007470_00_JUNAIPER_R.webp",
     "packs": [
       "Extradimensional"
@@ -53,7 +68,10 @@
     "set": "A3a",
     "number": 6,
     "rarity": "RR",
-    "name": "Buzzwole ex",
+    "name": {
+      "en": "Buzzwole ex",
+      "fr": "Mouscoto-ex"
+    },
     "image": "cPK_10_007480_00_MASSIVOONex_RR.webp",
     "packs": [
       "Extradimensional"
@@ -63,7 +81,10 @@
     "set": "A3a",
     "number": 7,
     "rarity": "U",
-    "name": "Pheromosa",
+    "name": {
+      "en": "Pheromosa",
+      "fr": "Cancrelove"
+    },
     "image": "cPK_10_007490_00_PHEROACHE_U.webp",
     "packs": [
       "Extradimensional"
@@ -73,7 +94,10 @@
     "set": "A3a",
     "number": 8,
     "rarity": "C",
-    "name": "Kartana",
+    "name": {
+      "en": "Kartana",
+      "fr": "Katagami"
+    },
     "image": "cPK_10_007250_00_KAMITURUGI_C.webp",
     "packs": [
       "Extradimensional"
@@ -83,7 +107,10 @@
     "set": "A3a",
     "number": 9,
     "rarity": "U",
-    "name": "Blacephalon",
+    "name": {
+      "en": "Blacephalon",
+      "fr": "Pierroteknik"
+    },
     "image": "cPK_10_007260_00_ZUGADOON_U.webp",
     "packs": [
       "Extradimensional"
@@ -93,7 +120,10 @@
     "set": "A3a",
     "number": 10,
     "rarity": "C",
-    "name": "Mantine",
+    "name": {
+      "en": "Mantine",
+      "fr": "Démanta"
+    },
     "image": "cPK_10_007500_00_MANTAIN_C.webp",
     "packs": [
       "Extradimensional"
@@ -103,7 +133,10 @@
     "set": "A3a",
     "number": 11,
     "rarity": "C",
-    "name": "Carvanha",
+    "name": {
+      "en": "Carvanha",
+      "fr": "Carvanha"
+    },
     "image": "cPK_10_007510_00_KIBANHA_C.webp",
     "packs": [
       "Extradimensional"
@@ -113,7 +146,10 @@
     "set": "A3a",
     "number": 12,
     "rarity": "U",
-    "name": "Sharpedo",
+    "name": {
+      "en": "Sharpedo",
+      "fr": "Sharpedo"
+    },
     "image": "cPK_10_007520_00_SAMEHADER_U.webp",
     "packs": [
       "Extradimensional"
@@ -123,7 +159,10 @@
     "set": "A3a",
     "number": 13,
     "rarity": "C",
-    "name": "Shinx",
+    "name": {
+      "en": "Shinx",
+      "fr": "Lixy"
+    },
     "image": "cPK_10_007530_00_KOLINK_C.webp",
     "packs": [
       "Extradimensional"
@@ -133,7 +172,10 @@
     "set": "A3a",
     "number": 14,
     "rarity": "C",
-    "name": "Luxio",
+    "name": {
+      "en": "Luxio",
+      "fr": "Luxio"
+    },
     "image": "cPK_10_007540_00_LUXIO_C.webp",
     "packs": [
       "Extradimensional"
@@ -143,7 +185,10 @@
     "set": "A3a",
     "number": 15,
     "rarity": "R",
-    "name": "Luxray",
+    "name": {
+      "en": "Luxray",
+      "fr": "Luxray"
+    },
     "image": "cPK_10_007550_00_RENTORAR_R.webp",
     "packs": [
       "Extradimensional"
@@ -153,7 +198,10 @@
     "set": "A3a",
     "number": 16,
     "rarity": "C",
-    "name": "Blitzle",
+    "name": {
+      "en": "Blitzle",
+      "fr": "Zébibron"
+    },
     "image": "cPK_10_007560_00_SHIMAMA_C.webp",
     "packs": [
       "Extradimensional"
@@ -163,7 +211,10 @@
     "set": "A3a",
     "number": 17,
     "rarity": "C",
-    "name": "Zebstrika",
+    "name": {
+      "en": "Zebstrika",
+      "fr": "Zéblitz"
+    },
     "image": "cPK_10_007570_00_ZEBRAIKA_C.webp",
     "packs": [
       "Extradimensional"
@@ -173,7 +224,10 @@
     "set": "A3a",
     "number": 18,
     "rarity": "C",
-    "name": "Emolga",
+    "name": {
+      "en": "Emolga",
+      "fr": "Emolga"
+    },
     "image": "cPK_10_007580_00_EMOLGA_C.webp",
     "packs": [
       "Extradimensional"
@@ -183,7 +237,10 @@
     "set": "A3a",
     "number": 19,
     "rarity": "RR",
-    "name": "Tapu Koko ex",
+    "name": {
+      "en": "Tapu Koko ex",
+      "fr": "Tokorico-ex"
+    },
     "image": "cPK_10_007420_00_KAPU-KOKEKOex_RR.webp",
     "packs": [
       "Extradimensional"
@@ -193,7 +250,10 @@
     "set": "A3a",
     "number": 20,
     "rarity": "U",
-    "name": "Xurkitree",
+    "name": {
+      "en": "Xurkitree",
+      "fr": "Câblifère"
+    },
     "image": "cPK_10_007270_00_DENJYUMOKU_U.webp",
     "packs": [
       "Extradimensional"
@@ -203,7 +263,10 @@
     "set": "A3a",
     "number": 21,
     "rarity": "R",
-    "name": "Zeraora",
+    "name": {
+      "en": "Zeraora",
+      "fr": "Zeraora"
+    },
     "image": "cPK_10_007410_00_ZERAORA_R.webp",
     "packs": [
       "Extradimensional"
@@ -213,7 +276,10 @@
     "set": "A3a",
     "number": 22,
     "rarity": "C",
-    "name": "Clefairy",
+    "name": {
+      "en": "Clefairy",
+      "fr": "Mélofée"
+    },
     "image": "cPK_10_007590_00_PIPPI_C.webp",
     "packs": [
       "Extradimensional"
@@ -223,7 +289,10 @@
     "set": "A3a",
     "number": 23,
     "rarity": "U",
-    "name": "Clefable",
+    "name": {
+      "en": "Clefable",
+      "fr": "Mélodelfe"
+    },
     "image": "cPK_10_007600_00_PIXY_U.webp",
     "packs": [
       "Extradimensional"
@@ -233,7 +302,10 @@
     "set": "A3a",
     "number": 24,
     "rarity": "C",
-    "name": "Phantump",
+    "name": {
+      "en": "Phantump",
+      "fr": "Brocélôme"
+    },
     "image": "cPK_10_007610_00_BOKUREI_C.webp",
     "packs": [
       "Extradimensional"
@@ -243,7 +315,10 @@
     "set": "A3a",
     "number": 25,
     "rarity": "C",
-    "name": "Trevenant",
+    "name": {
+      "en": "Trevenant",
+      "fr": "Desséliande"
+    },
     "image": "cPK_10_007620_00_OHROT_C.webp",
     "packs": [
       "Extradimensional"
@@ -253,7 +328,10 @@
     "set": "A3a",
     "number": 26,
     "rarity": "C",
-    "name": "Morelull",
+    "name": {
+      "en": "Morelull",
+      "fr": "Spododo"
+    },
     "image": "cPK_10_007630_00_NEMASYU_C.webp",
     "packs": [
       "Extradimensional"
@@ -263,7 +341,10 @@
     "set": "A3a",
     "number": 27,
     "rarity": "R",
-    "name": "Shiinotic",
+    "name": {
+      "en": "Shiinotic",
+      "fr": "Lampignon"
+    },
     "image": "cPK_10_007640_00_MASHADE_R.webp",
     "packs": [
       "Extradimensional"
@@ -273,7 +354,10 @@
     "set": "A3a",
     "number": 28,
     "rarity": "C",
-    "name": "Meditite",
+    "name": {
+      "en": "Meditite",
+      "fr": "Méditikka"
+    },
     "image": "cPK_10_007650_00_ASANAN_C.webp",
     "packs": [
       "Extradimensional"
@@ -283,7 +367,10 @@
     "set": "A3a",
     "number": 29,
     "rarity": "U",
-    "name": "Medicham",
+    "name": {
+      "en": "Medicham",
+      "fr": "Charmina"
+    },
     "image": "cPK_10_007660_00_CHAREM_U.webp",
     "packs": [
       "Extradimensional"
@@ -293,7 +380,10 @@
     "set": "A3a",
     "number": 30,
     "rarity": "C",
-    "name": "Baltoy",
+    "name": {
+      "en": "Baltoy",
+      "fr": "Balbuto"
+    },
     "image": "cPK_10_007670_00_YAJILON_C.webp",
     "packs": [
       "Extradimensional"
@@ -303,7 +393,10 @@
     "set": "A3a",
     "number": 31,
     "rarity": "U",
-    "name": "Claydol",
+    "name": {
+      "en": "Claydol",
+      "fr": "Kaorine"
+    },
     "image": "cPK_10_007680_00_NENDOLL_U.webp",
     "packs": [
       "Extradimensional"
@@ -313,7 +406,10 @@
     "set": "A3a",
     "number": 32,
     "rarity": "C",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_10_007690_00_IWANKO_C.webp",
     "packs": [
       "Extradimensional"
@@ -323,7 +419,10 @@
     "set": "A3a",
     "number": 33,
     "rarity": "RR",
-    "name": "Lycanroc ex",
+    "name": {
+      "en": "Lycanroc ex",
+      "fr": "Lougaroc-ex"
+    },
     "image": "cPK_10_007700_00_LUGARUGANTASOGARENOSUGATA_RR.webp",
     "packs": [
       "Extradimensional"
@@ -333,7 +432,10 @@
     "set": "A3a",
     "number": 34,
     "rarity": "C",
-    "name": "Passimian",
+    "name": {
+      "en": "Passimian",
+      "fr": "Quartermac"
+    },
     "image": "cPK_10_007710_00_NAGETUKESARU_C.webp",
     "packs": [
       "Extradimensional"
@@ -343,7 +445,10 @@
     "set": "A3a",
     "number": 35,
     "rarity": "C",
-    "name": "Sandygast",
+    "name": {
+      "en": "Sandygast",
+      "fr": "Bacabouh"
+    },
     "image": "cPK_10_007720_00_SUNABA_C.webp",
     "packs": [
       "Extradimensional"
@@ -353,7 +458,10 @@
     "set": "A3a",
     "number": 36,
     "rarity": "U",
-    "name": "Palossand",
+    "name": {
+      "en": "Palossand",
+      "fr": "Trépassable"
+    },
     "image": "cPK_10_007730_00_SIRODETHNA_U.webp",
     "packs": [
       "Extradimensional"
@@ -363,7 +471,10 @@
     "set": "A3a",
     "number": 37,
     "rarity": "C",
-    "name": "Alolan Meowth",
+    "name": {
+      "en": "Alolan Meowth",
+      "fr": "Miaouss de Alola"
+    },
     "image": "cPK_10_007740_00_ALOLANYARTH_C.webp",
     "packs": [
       "Extradimensional"
@@ -373,7 +484,10 @@
     "set": "A3a",
     "number": 38,
     "rarity": "U",
-    "name": "Alolan Persian",
+    "name": {
+      "en": "Alolan Persian",
+      "fr": "Persian de Alola"
+    },
     "image": "cPK_10_007750_00_ALOLAPERSIAN_U.webp",
     "packs": [
       "Extradimensional"
@@ -383,7 +497,10 @@
     "set": "A3a",
     "number": 39,
     "rarity": "C",
-    "name": "Sandile",
+    "name": {
+      "en": "Sandile",
+      "fr": "Mascaïman"
+    },
     "image": "cPK_10_007760_00_MEGUROCO_C.webp",
     "packs": [
       "Extradimensional"
@@ -393,7 +510,10 @@
     "set": "A3a",
     "number": 40,
     "rarity": "C",
-    "name": "Krokorok",
+    "name": {
+      "en": "Krokorok",
+      "fr": "Escroco"
+    },
     "image": "cPK_10_007770_00_WARUVILE_C.webp",
     "packs": [
       "Extradimensional"
@@ -403,7 +523,10 @@
     "set": "A3a",
     "number": 41,
     "rarity": "U",
-    "name": "Krookodile",
+    "name": {
+      "en": "Krookodile",
+      "fr": "Crocorible"
+    },
     "image": "cPK_10_007780_00_WARUVIAL_U.webp",
     "packs": [
       "Extradimensional"
@@ -413,7 +536,10 @@
     "set": "A3a",
     "number": 42,
     "rarity": "R",
-    "name": "Nihilego",
+    "name": {
+      "en": "Nihilego",
+      "fr": "Zéroïd"
+    },
     "image": "cPK_10_007790_00_UTUROID_R.webp",
     "packs": [
       "Extradimensional"
@@ -423,7 +549,10 @@
     "set": "A3a",
     "number": 43,
     "rarity": "RR",
-    "name": "Guzzlord ex",
+    "name": {
+      "en": "Guzzlord ex",
+      "fr": "Engloutyran-ex"
+    },
     "image": "cPK_10_007800_00_AKUZIKINGex_RR.webp",
     "packs": [
       "Extradimensional"
@@ -433,7 +562,10 @@
     "set": "A3a",
     "number": 44,
     "rarity": "C",
-    "name": "Poipole",
+    "name": {
+      "en": "Poipole",
+      "fr": "Vémini"
+    },
     "image": "cPK_10_007370_00_BEVENOM_C.webp",
     "packs": [
       "Extradimensional"
@@ -443,7 +575,10 @@
     "set": "A3a",
     "number": 45,
     "rarity": "R",
-    "name": "Naganadel",
+    "name": {
+      "en": "Naganadel",
+      "fr": "Mandrillon"
+    },
     "image": "cPK_10_007810_00_AGOYON_R.webp",
     "packs": [
       "Extradimensional"
@@ -453,7 +588,10 @@
     "set": "A3a",
     "number": 46,
     "rarity": "C",
-    "name": "Alolan Diglett",
+    "name": {
+      "en": "Alolan Diglett",
+      "fr": "Taupiqueur de Alola"
+    },
     "image": "cPK_10_007820_00_ALOLADIGDA_C.webp",
     "packs": [
       "Extradimensional"
@@ -463,7 +601,10 @@
     "set": "A3a",
     "number": 47,
     "rarity": "RR",
-    "name": "Alolan Dugtrio ex",
+    "name": {
+      "en": "Alolan Dugtrio ex",
+      "fr": "Triopikeur de Alola-ex"
+    },
     "image": "cPK_10_007830_00_ALOLADUGTRIOex_RR.webp",
     "packs": [
       "Extradimensional"
@@ -473,7 +614,10 @@
     "set": "A3a",
     "number": 48,
     "rarity": "C",
-    "name": "Aron",
+    "name": {
+      "en": "Aron",
+      "fr": "Galekid"
+    },
     "image": "cPK_10_007840_00_COKODORA_C.webp",
     "packs": [
       "Extradimensional"
@@ -483,7 +627,10 @@
     "set": "A3a",
     "number": 49,
     "rarity": "C",
-    "name": "Lairon",
+    "name": {
+      "en": "Lairon",
+      "fr": "Galegon"
+    },
     "image": "cPK_10_007850_00_KODORA_C.webp",
     "packs": [
       "Extradimensional"
@@ -493,7 +640,10 @@
     "set": "A3a",
     "number": 50,
     "rarity": "U",
-    "name": "Aggron",
+    "name": {
+      "en": "Aggron",
+      "fr": "Galeking"
+    },
     "image": "cPK_10_007860_00_BOSSGODORA_U.webp",
     "packs": [
       "Extradimensional"
@@ -503,7 +653,10 @@
     "set": "A3a",
     "number": 51,
     "rarity": "C",
-    "name": "Ferroseed",
+    "name": {
+      "en": "Ferroseed",
+      "fr": "Grindur"
+    },
     "image": "cPK_10_007870_00_TESSEED_C.webp",
     "packs": [
       "Extradimensional"
@@ -513,7 +666,10 @@
     "set": "A3a",
     "number": 52,
     "rarity": "U",
-    "name": "Ferrothorn",
+    "name": {
+      "en": "Ferrothorn",
+      "fr": "Noacier"
+    },
     "image": "cPK_10_007880_00_NUTREY_U.webp",
     "packs": [
       "Extradimensional"
@@ -523,7 +679,10 @@
     "set": "A3a",
     "number": 53,
     "rarity": "U",
-    "name": "Stakataka",
+    "name": {
+      "en": "Stakataka",
+      "fr": "Ama-Ama"
+    },
     "image": "cPK_10_007300_00_TUNDETUNDE_U.webp",
     "packs": [
       "Extradimensional"
@@ -533,7 +692,10 @@
     "set": "A3a",
     "number": 54,
     "rarity": "C",
-    "name": "Lillipup",
+    "name": {
+      "en": "Lillipup",
+      "fr": "Ponchiot"
+    },
     "image": "cPK_10_007890_00_YORTERRIE_C.webp",
     "packs": [
       "Extradimensional"
@@ -543,7 +705,10 @@
     "set": "A3a",
     "number": 55,
     "rarity": "C",
-    "name": "Herdier",
+    "name": {
+      "en": "Herdier",
+      "fr": "Ponchien"
+    },
     "image": "cPK_10_007900_00_HERDERRIE_C.webp",
     "packs": [
       "Extradimensional"
@@ -553,7 +718,10 @@
     "set": "A3a",
     "number": 56,
     "rarity": "U",
-    "name": "Stoutland",
+    "name": {
+      "en": "Stoutland",
+      "fr": "Mastouffe"
+    },
     "image": "cPK_10_007910_00_MOOLAND_U.webp",
     "packs": [
       "Extradimensional"
@@ -563,7 +731,10 @@
     "set": "A3a",
     "number": 57,
     "rarity": "C",
-    "name": "Stufful",
+    "name": {
+      "en": "Stufful",
+      "fr": "Nounourson"
+    },
     "image": "cPK_10_007380_00_NUIKOGUMA_C.webp",
     "packs": [
       "Extradimensional"
@@ -573,7 +744,10 @@
     "set": "A3a",
     "number": 58,
     "rarity": "U",
-    "name": "Bewear",
+    "name": {
+      "en": "Bewear",
+      "fr": "Chelours"
+    },
     "image": "cPK_10_007920_00_KITERUGUMA_U.webp",
     "packs": [
       "Extradimensional"
@@ -583,7 +757,10 @@
     "set": "A3a",
     "number": 59,
     "rarity": "C",
-    "name": "Oranguru",
+    "name": {
+      "en": "Oranguru",
+      "fr": "Gouroutan"
+    },
     "image": "cPK_10_007930_00_YAREYUUTAN_C.webp",
     "packs": [
       "Extradimensional"
@@ -593,7 +770,10 @@
     "set": "A3a",
     "number": 60,
     "rarity": "U",
-    "name": "Type: Null",
+    "name": {
+      "en": "Type: Null",
+      "fr": "Type:0"
+    },
     "image": "cPK_10_007940_00_TYPENULL_U.webp",
     "packs": [
       "Extradimensional"
@@ -603,7 +783,10 @@
     "set": "A3a",
     "number": 61,
     "rarity": "R",
-    "name": "Silvally",
+    "name": {
+      "en": "Silvally",
+      "fr": "Silvallié"
+    },
     "image": "cPK_10_007950_00_SILVADY_R.webp",
     "packs": [
       "Extradimensional"
@@ -613,7 +796,10 @@
     "set": "A3a",
     "number": 62,
     "rarity": "R",
-    "name": "Celesteela",
+    "name": {
+      "en": "Celesteela",
+      "fr": "Bamboiselle"
+    },
     "image": "cPK_10_007960_00_TEKKAGUYA_R.webp",
     "packs": [
       "Extradimensional"
@@ -623,7 +809,10 @@
     "set": "A3a",
     "number": 63,
     "rarity": "U",
-    "name": "Beast Wall",
+    "name": {
+      "en": "Beast Wall",
+      "fr": "Barrière Chimère"
+    },
     "image": "cTR_10_000600_00_BISUTOWORU_U.webp",
     "packs": [
       "Extradimensional"
@@ -633,7 +822,10 @@
     "set": "A3a",
     "number": 64,
     "rarity": "U",
-    "name": "Repel",
+    "name": {
+      "en": "Repel",
+      "fr": "Repousse"
+    },
     "image": "cTR_10_000610_00_MUSHIYOKESUPUREI_U.webp",
     "packs": [
       "Extradimensional"
@@ -643,7 +835,10 @@
     "set": "A3a",
     "number": 65,
     "rarity": "U",
-    "name": "Electrical Cord",
+    "name": {
+      "en": "Electrical Cord",
+      "fr": "Câble Électrique"
+    },
     "image": "cTR_10_000620_00_EREKIKORD_U.webp",
     "packs": [
       "Extradimensional"
@@ -653,7 +848,10 @@
     "set": "A3a",
     "number": 66,
     "rarity": "U",
-    "name": "Beastite",
+    "name": {
+      "en": "Beastite",
+      "fr": "Chimérite"
+    },
     "image": "cTR_10_000630_00_BISUTONAITO_U.webp",
     "packs": [
       "Extradimensional"
@@ -663,7 +861,10 @@
     "set": "A3a",
     "number": 67,
     "rarity": "U",
-    "name": "Gladion",
+    "name": {
+      "en": "Gladion",
+      "fr": "Gladio"
+    },
     "image": "cTR_10_000640_00_GLAZIO_U.webp",
     "packs": [
       "Extradimensional"
@@ -673,7 +874,10 @@
     "set": "A3a",
     "number": 68,
     "rarity": "U",
-    "name": "Looker",
+    "name": {
+      "en": "Looker",
+      "fr": "Beladonis"
+    },
     "image": "cTR_10_000650_00_HANDSOME_U.webp",
     "packs": [
       "Extradimensional"
@@ -683,7 +887,10 @@
     "set": "A3a",
     "number": 69,
     "rarity": "U",
-    "name": "Lusamine",
+    "name": {
+      "en": "Lusamine",
+      "fr": "Elsa-Mina"
+    },
     "image": "cTR_10_000660_00_LUSAMINE_U.webp",
     "packs": [
       "Extradimensional"
@@ -693,7 +900,10 @@
     "set": "A3a",
     "number": 70,
     "rarity": "AR",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_20_007450_00_MOKUROH_AR.webp",
     "packs": [
       "Extradimensional"
@@ -703,7 +913,10 @@
     "set": "A3a",
     "number": 71,
     "rarity": "AR",
-    "name": "Pheromosa",
+    "name": {
+      "en": "Pheromosa",
+      "fr": "Cancrelove"
+    },
     "image": "cPK_20_007490_00_PHEROACHE_AR.webp",
     "packs": [
       "Extradimensional"
@@ -713,7 +926,10 @@
     "set": "A3a",
     "number": 72,
     "rarity": "AR",
-    "name": "Blacephalon",
+    "name": {
+      "en": "Blacephalon",
+      "fr": "Pierroteknik"
+    },
     "image": "cPK_20_007260_00_ZUGADOON_AR.webp",
     "packs": [
       "Extradimensional"
@@ -723,7 +939,10 @@
     "set": "A3a",
     "number": 73,
     "rarity": "AR",
-    "name": "Alolan Meowth",
+    "name": {
+      "en": "Alolan Meowth",
+      "fr": "Miaouss de Alola"
+    },
     "image": "cPK_20_007740_00_ALOLANYARTH_AR.webp",
     "packs": [
       "Extradimensional"
@@ -733,7 +952,10 @@
     "set": "A3a",
     "number": 74,
     "rarity": "AR",
-    "name": "Silvally",
+    "name": {
+      "en": "Silvally",
+      "fr": "Silvallié"
+    },
     "image": "cPK_20_007950_00_SILVADY_AR.webp",
     "packs": [
       "Extradimensional"
@@ -743,7 +965,10 @@
     "set": "A3a",
     "number": 75,
     "rarity": "AR",
-    "name": "Celesteela",
+    "name": {
+      "en": "Celesteela",
+      "fr": "Bamboiselle"
+    },
     "image": "cPK_20_007960_00_TEKKAGUYA_AR.webp",
     "packs": [
       "Extradimensional"
@@ -753,7 +978,10 @@
     "set": "A3a",
     "number": 76,
     "rarity": "SR",
-    "name": "Buzzwole ex",
+    "name": {
+      "en": "Buzzwole ex",
+      "fr": "Mouscoto-ex"
+    },
     "image": "cPK_20_007480_00_MASSIVOONex_SR.webp",
     "packs": [
       "Extradimensional"
@@ -763,7 +991,10 @@
     "set": "A3a",
     "number": 77,
     "rarity": "SR",
-    "name": "Tapu Koko ex",
+    "name": {
+      "en": "Tapu Koko ex",
+      "fr": "Tokorico-ex"
+    },
     "image": "cPK_20_007420_00_KAPU-KOKEKOex_SR.webp",
     "packs": [
       "Extradimensional"
@@ -773,7 +1004,10 @@
     "set": "A3a",
     "number": 78,
     "rarity": "SR",
-    "name": "Lycanroc ex",
+    "name": {
+      "en": "Lycanroc ex",
+      "fr": "Lougaroc-ex"
+    },
     "image": "cPK_20_007700_00_LUGARUGANex_SR.webp",
     "packs": [
       "Extradimensional"
@@ -783,7 +1017,10 @@
     "set": "A3a",
     "number": 79,
     "rarity": "SR",
-    "name": "Guzzlord ex",
+    "name": {
+      "en": "Guzzlord ex",
+      "fr": "Engloutyran-ex"
+    },
     "image": "cPK_20_007800_00_AKUZIKINGex_SR.webp",
     "packs": [
       "Extradimensional"
@@ -793,7 +1030,10 @@
     "set": "A3a",
     "number": 80,
     "rarity": "SR",
-    "name": "Alolan Dugtrio ex",
+    "name": {
+      "en": "Alolan Dugtrio ex",
+      "fr": "Triopikeur de Alola-ex"
+    },
     "image": "cPK_20_007830_00_ALOLADUGTRIOex_SR.webp",
     "packs": [
       "Extradimensional"
@@ -803,7 +1043,10 @@
     "set": "A3a",
     "number": 81,
     "rarity": "SR",
-    "name": "Gladion",
+    "name": {
+      "en": "Gladion",
+      "fr": "Gladio"
+    },
     "image": "cTR_20_000640_00_GLAZIO_SR.webp",
     "packs": [
       "Extradimensional"
@@ -813,7 +1056,10 @@
     "set": "A3a",
     "number": 82,
     "rarity": "SR",
-    "name": "Looker",
+    "name": {
+      "en": "Looker",
+      "fr": "Beladonis"
+    },
     "image": "cTR_20_000650_00_HANDSOME_SR.webp",
     "packs": [
       "Extradimensional"
@@ -823,7 +1069,10 @@
     "set": "A3a",
     "number": 83,
     "rarity": "SR",
-    "name": "Lusamine",
+    "name": {
+      "en": "Lusamine",
+      "fr": "Elsa-Mina"
+    },
     "image": "cTR_20_000660_00_LUSAMINE_SR.webp",
     "packs": [
       "Extradimensional"
@@ -833,7 +1082,10 @@
     "set": "A3a",
     "number": 84,
     "rarity": "SAR",
-    "name": "Tapu Koko ex",
+    "name": {
+      "en": "Tapu Koko ex",
+      "fr": "Tokorico-ex"
+    },
     "image": "cPK_20_007420_01_KAPU-KOKEKOex_SAR.webp",
     "packs": [
       "Extradimensional"
@@ -843,7 +1095,10 @@
     "set": "A3a",
     "number": 85,
     "rarity": "SAR",
-    "name": "Lycanroc ex",
+    "name": {
+      "en": "Lycanroc ex",
+      "fr": "Lougaroc-ex"
+    },
     "image": "cPK_20_007700_01_LUGARUGANex_SAR.webp",
     "packs": [
       "Extradimensional"
@@ -853,7 +1108,10 @@
     "set": "A3a",
     "number": 86,
     "rarity": "SAR",
-    "name": "Guzzlord ex",
+    "name": {
+      "en": "Guzzlord ex",
+      "fr": "Engloutyran-ex"
+    },
     "image": "cPK_20_007800_01_AKUZIKINGex_SAR.webp",
     "packs": [
       "Extradimensional"
@@ -863,7 +1121,10 @@
     "set": "A3a",
     "number": 87,
     "rarity": "SAR",
-    "name": "Alolan Dugtrio ex",
+    "name": {
+      "en": "Alolan Dugtrio ex",
+      "fr": "Triopikeur de Alola-ex"
+    },
     "image": "cPK_20_007830_01_ALOLADUGTRIOex_SAR.webp",
     "packs": [
       "Extradimensional"
@@ -873,7 +1134,10 @@
     "set": "A3a",
     "number": 88,
     "rarity": "IM",
-    "name": "Buzzwole ex",
+    "name": {
+      "en": "Buzzwole ex",
+      "fr": "Mouscoto-ex"
+    },
     "image": "cPK_20_007480_01_MASSIVOONex_IM.webp",
     "packs": [
       "Extradimensional"
@@ -883,7 +1147,10 @@
     "set": "A3a",
     "number": 89,
     "rarity": "S",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_20_000390_00_GARDIE_S.webp",
     "packs": [
       "Extradimensional"
@@ -893,7 +1160,10 @@
     "set": "A3a",
     "number": 90,
     "rarity": "S",
-    "name": "Arcanine",
+    "name": {
+      "en": "Arcanine",
+      "fr": "Arcanin"
+    },
     "image": "cPK_20_000400_00_WINDIE_S.webp",
     "packs": [
       "Extradimensional"
@@ -903,7 +1173,10 @@
     "set": "A3a",
     "number": 91,
     "rarity": "S",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_20_000870_00_KEROMATSU_S.webp",
     "packs": [
       "Extradimensional"
@@ -913,7 +1186,10 @@
     "set": "A3a",
     "number": 92,
     "rarity": "S",
-    "name": "Frogadier",
+    "name": {
+      "en": "Frogadier",
+      "fr": "Croâporal"
+    },
     "image": "cPK_20_000880_00_GEKOGASHIRA_S.webp",
     "packs": [
       "Extradimensional"
@@ -923,7 +1199,10 @@
     "set": "A3a",
     "number": 93,
     "rarity": "S",
-    "name": "Greninja",
+    "name": {
+      "en": "Greninja",
+      "fr": "Amphinobi"
+    },
     "image": "cPK_20_000890_00_GEKKOUGA_S.webp",
     "packs": [
       "Extradimensional"
@@ -933,7 +1212,10 @@
     "set": "A3a",
     "number": 94,
     "rarity": "S",
-    "name": "Jynx",
+    "name": {
+      "en": "Jynx",
+      "fr": "Lippoutou"
+    },
     "image": "cPK_20_001270_00_ROUGELA_S.webp",
     "packs": [
       "Extradimensional"
@@ -943,7 +1225,10 @@
     "set": "A3a",
     "number": 95,
     "rarity": "S",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_20_001860_00_POPPO_S.webp",
     "packs": [
       "Extradimensional"
@@ -953,7 +1238,10 @@
     "set": "A3a",
     "number": 96,
     "rarity": "S",
-    "name": "Pidgeotto",
+    "name": {
+      "en": "Pidgeotto",
+      "fr": "Roucoups"
+    },
     "image": "cPK_20_001870_00_PIGEON_S.webp",
     "packs": [
       "Extradimensional"
@@ -963,7 +1251,10 @@
     "set": "A3a",
     "number": 97,
     "rarity": "S",
-    "name": "Pidgeot",
+    "name": {
+      "en": "Pidgeot",
+      "fr": "Roucarnage"
+    },
     "image": "cPK_20_001880_01_PIGEOT_S.webp",
     "packs": [
       "Extradimensional"
@@ -973,7 +1264,10 @@
     "set": "A3a",
     "number": 98,
     "rarity": "S",
-    "name": "Aerodactyl",
+    "name": {
+      "en": "Aerodactyl",
+      "fr": "Ptéra"
+    },
     "image": "cPK_20_002080_00_PTERA_S.webp",
     "packs": [
       "Extradimensional"
@@ -983,7 +1277,10 @@
     "set": "A3a",
     "number": 99,
     "rarity": "SSR",
-    "name": "Celebi ex",
+    "name": {
+      "en": "Celebi ex",
+      "fr": "Celebi-ex"
+    },
     "image": "cPK_20_002170_02_CELEBIex_SSR.webp",
     "packs": [
       "Extradimensional"
@@ -993,7 +1290,10 @@
     "set": "A3a",
     "number": 100,
     "rarity": "SSR",
-    "name": "Arcanine ex",
+    "name": {
+      "en": "Arcanine ex",
+      "fr": "Arcanin-ex"
+    },
     "image": "cPK_20_000410_01_WINDIEex_SSR.webp",
     "packs": [
       "Extradimensional"
@@ -1003,7 +1303,10 @@
     "set": "A3a",
     "number": 101,
     "rarity": "SSR",
-    "name": "Aerodactyl ex",
+    "name": {
+      "en": "Aerodactyl ex",
+      "fr": "Ptéra-ex"
+    },
     "image": "cPK_20_002590_02_PTERAex_SSR.webp",
     "packs": [
       "Extradimensional"
@@ -1013,7 +1316,10 @@
     "set": "A3a",
     "number": 102,
     "rarity": "SSR",
-    "name": "Pidgeot ex",
+    "name": {
+      "en": "Pidgeot ex",
+      "fr": "Roucarnage-ex"
+    },
     "image": "cPK_20_002720_01_PIGEOTex_SSR.webp",
     "packs": [
       "Extradimensional"
@@ -1023,7 +1329,10 @@
     "set": "A3a",
     "number": 103,
     "rarity": "UR",
-    "name": "Nihilego",
+    "name": {
+      "en": "Nihilego",
+      "fr": "Zéroïd"
+    },
     "image": "cPK_20_007790_00_UTUROID_UR.webp",
     "packs": [
       "Extradimensional"

--- a/dist/cards/A3b.json
+++ b/dist/cards/A3b.json
@@ -3,7 +3,10 @@
     "set": "A3b",
     "number": 1,
     "rarity": "U",
-    "name": "Tropius",
+    "name": {
+      "en": "Tropius",
+      "fr": "Tropius"
+    },
     "image": "cPK_10_007970_00_TROPIUS_U.webp",
     "packs": [
       "Eevee"
@@ -13,7 +16,10 @@
     "set": "A3b",
     "number": 2,
     "rarity": "R",
-    "name": "Leafeon",
+    "name": {
+      "en": "Leafeon",
+      "fr": "Phyllali"
+    },
     "image": "cPK_10_007980_00_LEAFIA_R.webp",
     "packs": [
       "Eevee"
@@ -23,7 +29,10 @@
     "set": "A3b",
     "number": 3,
     "rarity": "C",
-    "name": "Bounsweet",
+    "name": {
+      "en": "Bounsweet",
+      "fr": "Croquine"
+    },
     "image": "cPK_10_007990_00_AMAKAJI_C.webp",
     "packs": [
       "Eevee"
@@ -33,7 +42,10 @@
     "set": "A3b",
     "number": 4,
     "rarity": "C",
-    "name": "Steenee",
+    "name": {
+      "en": "Steenee",
+      "fr": "Candine"
+    },
     "image": "cPK_10_008000_00_AMAMAIKO_C.webp",
     "packs": [
       "Eevee"
@@ -43,7 +55,10 @@
     "set": "A3b",
     "number": 5,
     "rarity": "U",
-    "name": "Tsareena",
+    "name": {
+      "en": "Tsareena",
+      "fr": "Sucreine"
+    },
     "image": "cPK_10_008010_00_AMAJO_U.webp",
     "packs": [
       "Eevee"
@@ -53,7 +68,10 @@
     "set": "A3b",
     "number": 6,
     "rarity": "C",
-    "name": "Applin",
+    "name": {
+      "en": "Applin",
+      "fr": "Verpom"
+    },
     "image": "cPK_10_008020_00_KAJICCHU_C.webp",
     "packs": [
       "Eevee"
@@ -63,7 +81,10 @@
     "set": "A3b",
     "number": 7,
     "rarity": "U",
-    "name": "Appletun",
+    "name": {
+      "en": "Appletun",
+      "fr": "Dratatin"
+    },
     "image": "cPK_10_008030_00_TARUPPLE_U.webp",
     "packs": [
       "Eevee"
@@ -73,7 +94,10 @@
     "set": "A3b",
     "number": 8,
     "rarity": "R",
-    "name": "Flareon",
+    "name": {
+      "en": "Flareon",
+      "fr": "Pyroli"
+    },
     "image": "cPK_10_008040_00_BOOSTER_R.webp",
     "packs": [
       "Eevee"
@@ -83,7 +107,10 @@
     "set": "A3b",
     "number": 9,
     "rarity": "RR",
-    "name": "Flareon ex",
+    "name": {
+      "en": "Flareon ex",
+      "fr": "Pyroli-ex"
+    },
     "image": "cPK_10_008050_00_BOOSTERex_RR.webp",
     "packs": [
       "Eevee"
@@ -93,7 +120,10 @@
     "set": "A3b",
     "number": 10,
     "rarity": "C",
-    "name": "Torkoal",
+    "name": {
+      "en": "Torkoal",
+      "fr": "Chartor"
+    },
     "image": "cPK_10_008060_00_COTOISE_C.webp",
     "packs": [
       "Eevee"
@@ -103,7 +133,10 @@
     "set": "A3b",
     "number": 11,
     "rarity": "C",
-    "name": "Litten",
+    "name": {
+      "en": "Litten",
+      "fr": "Flamiaou"
+    },
     "image": "cPK_10_008070_00_NYABBY_C.webp",
     "packs": [
       "Eevee"
@@ -113,7 +146,10 @@
     "set": "A3b",
     "number": 12,
     "rarity": "C",
-    "name": "Torracat",
+    "name": {
+      "en": "Torracat",
+      "fr": "Matoufeu"
+    },
     "image": "cPK_10_008080_00_NYAHEAT_C.webp",
     "packs": [
       "Eevee"
@@ -123,7 +159,10 @@
     "set": "A3b",
     "number": 13,
     "rarity": "U",
-    "name": "Incineroar",
+    "name": {
+      "en": "Incineroar",
+      "fr": "Félinferno"
+    },
     "image": "cPK_10_008090_00_GAOGAEN_U.webp",
     "packs": [
       "Eevee"
@@ -133,7 +172,10 @@
     "set": "A3b",
     "number": 14,
     "rarity": "C",
-    "name": "Salandit",
+    "name": {
+      "en": "Salandit",
+      "fr": "Tritox"
+    },
     "image": "cPK_10_008100_00_YATOUMORI_C.webp",
     "packs": [
       "Eevee"
@@ -143,7 +185,10 @@
     "set": "A3b",
     "number": 15,
     "rarity": "U",
-    "name": "Salazzle",
+    "name": {
+      "en": "Salazzle",
+      "fr": "Malamandre"
+    },
     "image": "cPK_10_008110_00_ENNEWT_U.webp",
     "packs": [
       "Eevee"
@@ -153,7 +198,10 @@
     "set": "A3b",
     "number": 16,
     "rarity": "R",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_10_008120_00_SHOWERS_R.webp",
     "packs": [
       "Eevee"
@@ -163,7 +211,10 @@
     "set": "A3b",
     "number": 17,
     "rarity": "R",
-    "name": "Glaceon",
+    "name": {
+      "en": "Glaceon",
+      "fr": "Givrali"
+    },
     "image": "cPK_10_008130_00_GLACIA_R.webp",
     "packs": [
       "Eevee"
@@ -173,7 +224,10 @@
     "set": "A3b",
     "number": 18,
     "rarity": "C",
-    "name": "Vanillite",
+    "name": {
+      "en": "Vanillite",
+      "fr": "Sorbébé"
+    },
     "image": "cPK_10_007320_00_VANIPETI_C.webp",
     "packs": [
       "Eevee"
@@ -183,7 +237,10 @@
     "set": "A3b",
     "number": 19,
     "rarity": "C",
-    "name": "Vanillish",
+    "name": {
+      "en": "Vanillish",
+      "fr": "Sorboul"
+    },
     "image": "cPK_10_008140_00_VANIRICH_C.webp",
     "packs": [
       "Eevee"
@@ -193,7 +250,10 @@
     "set": "A3b",
     "number": 20,
     "rarity": "U",
-    "name": "Vanilluxe",
+    "name": {
+      "en": "Vanilluxe",
+      "fr": "Sorbouboul"
+    },
     "image": "cPK_10_008150_00_BAIVANILLA_U.webp",
     "packs": [
       "Eevee"
@@ -203,7 +263,10 @@
     "set": "A3b",
     "number": 21,
     "rarity": "C",
-    "name": "Alomomola",
+    "name": {
+      "en": "Alomomola",
+      "fr": "Mamanbo"
+    },
     "image": "cPK_10_008160_00_MAMANBOU_C.webp",
     "packs": [
       "Eevee"
@@ -213,7 +276,10 @@
     "set": "A3b",
     "number": 22,
     "rarity": "C",
-    "name": "Popplio",
+    "name": {
+      "en": "Popplio",
+      "fr": "Otaquin"
+    },
     "image": "cPK_10_008170_00_ASHIMARI_C.webp",
     "packs": [
       "Eevee"
@@ -223,7 +289,10 @@
     "set": "A3b",
     "number": 23,
     "rarity": "C",
-    "name": "Brionne",
+    "name": {
+      "en": "Brionne",
+      "fr": "Otarlette"
+    },
     "image": "cPK_10_008180_00_OSYAMARI_C.webp",
     "packs": [
       "Eevee"
@@ -233,7 +302,10 @@
     "set": "A3b",
     "number": 24,
     "rarity": "RR",
-    "name": "Primarina ex",
+    "name": {
+      "en": "Primarina ex",
+      "fr": "Oratoria-ex"
+    },
     "image": "cPK_10_008190_00_ASHIRENEex_RR.webp",
     "packs": [
       "Eevee"
@@ -243,7 +315,10 @@
     "set": "A3b",
     "number": 25,
     "rarity": "R",
-    "name": "Jolteon",
+    "name": {
+      "en": "Jolteon",
+      "fr": "Voltali"
+    },
     "image": "cPK_10_007330_00_THUNDERS_R.webp",
     "packs": [
       "Eevee"
@@ -253,7 +328,10 @@
     "set": "A3b",
     "number": 26,
     "rarity": "C",
-    "name": "Joltik",
+    "name": {
+      "en": "Joltik",
+      "fr": "Statitik"
+    },
     "image": "cPK_10_008200_00_BACHURU_C.webp",
     "packs": [
       "Eevee"
@@ -263,7 +341,10 @@
     "set": "A3b",
     "number": 27,
     "rarity": "U",
-    "name": "Galvantula",
+    "name": {
+      "en": "Galvantula",
+      "fr": "Mygavolt"
+    },
     "image": "cPK_10_008210_00_DENTULA_U.webp",
     "packs": [
       "Eevee"
@@ -273,7 +354,10 @@
     "set": "A3b",
     "number": 28,
     "rarity": "R",
-    "name": "Espeon",
+    "name": {
+      "en": "Espeon",
+      "fr": "Mentali"
+    },
     "image": "cPK_10_008220_00_EIFIE_R.webp",
     "packs": [
       "Eevee"
@@ -283,7 +367,10 @@
     "set": "A3b",
     "number": 29,
     "rarity": "C",
-    "name": "Woobat",
+    "name": {
+      "en": "Woobat",
+      "fr": "Chovsourir"
+    },
     "image": "cPK_10_008230_00_KOROMORI_C.webp",
     "packs": [
       "Eevee"
@@ -293,7 +380,10 @@
     "set": "A3b",
     "number": 30,
     "rarity": "U",
-    "name": "Swoobat",
+    "name": {
+      "en": "Swoobat",
+      "fr": "Rhinolove"
+    },
     "image": "cPK_10_008240_00_KOKOROMORI_U.webp",
     "packs": [
       "Eevee"
@@ -303,7 +393,10 @@
     "set": "A3b",
     "number": 31,
     "rarity": "C",
-    "name": "Swirlix",
+    "name": {
+      "en": "Swirlix",
+      "fr": "Sucroquin"
+    },
     "image": "cPK_10_008250_00_PEROPPAFU_C.webp",
     "packs": [
       "Eevee"
@@ -313,7 +406,10 @@
     "set": "A3b",
     "number": 32,
     "rarity": "U",
-    "name": "Slurpuff",
+    "name": {
+      "en": "Slurpuff",
+      "fr": "Cupcanaille"
+    },
     "image": "cPK_10_008260_00_PEROREAM_U.webp",
     "packs": [
       "Eevee"
@@ -323,7 +419,10 @@
     "set": "A3b",
     "number": 33,
     "rarity": "R",
-    "name": "Sylveon",
+    "name": {
+      "en": "Sylveon",
+      "fr": "Nymphali"
+    },
     "image": "cPK_10_008270_00_NYMPHIA_R.webp",
     "packs": [
       "Eevee"
@@ -333,7 +432,10 @@
     "set": "A3b",
     "number": 34,
     "rarity": "RR",
-    "name": "Sylveon ex",
+    "name": {
+      "en": "Sylveon ex",
+      "fr": "Nymphali-ex"
+    },
     "image": "cPK_10_008280_00_NYMPHIAex_RR.webp",
     "packs": [
       "Eevee"
@@ -343,7 +445,10 @@
     "set": "A3b",
     "number": 35,
     "rarity": "U",
-    "name": "Mimikyu",
+    "name": {
+      "en": "Mimikyu",
+      "fr": "Mimiqui"
+    },
     "image": "cPK_10_008290_00_MIMIKKYU_U.webp",
     "packs": [
       "Eevee"
@@ -353,7 +458,10 @@
     "set": "A3b",
     "number": 36,
     "rarity": "C",
-    "name": "Milcery",
+    "name": {
+      "en": "Milcery",
+      "fr": "Crèmy"
+    },
     "image": "cPK_10_008300_00_MAHOMIL_C.webp",
     "packs": [
       "Eevee"
@@ -363,7 +471,10 @@
     "set": "A3b",
     "number": 37,
     "rarity": "U",
-    "name": "Alcremie",
+    "name": {
+      "en": "Alcremie",
+      "fr": "Charmilly"
+    },
     "image": "cPK_10_007340_00_MAWHIP_U.webp",
     "packs": [
       "Eevee"
@@ -373,7 +484,10 @@
     "set": "A3b",
     "number": 38,
     "rarity": "C",
-    "name": "Barboach",
+    "name": {
+      "en": "Barboach",
+      "fr": "Barloche"
+    },
     "image": "cPK_10_008310_00_DOJOACH_C.webp",
     "packs": [
       "Eevee"
@@ -383,7 +497,10 @@
     "set": "A3b",
     "number": 39,
     "rarity": "U",
-    "name": "Whiscash",
+    "name": {
+      "en": "Whiscash",
+      "fr": "Barbicha"
+    },
     "image": "cPK_10_008320_00_NAMAZUN_U.webp",
     "packs": [
       "Eevee"
@@ -393,7 +510,10 @@
     "set": "A3b",
     "number": 40,
     "rarity": "C",
-    "name": "Mienfoo",
+    "name": {
+      "en": "Mienfoo",
+      "fr": "Kungfouine"
+    },
     "image": "cPK_10_008330_00_KOJOFU_C.webp",
     "packs": [
       "Eevee"
@@ -403,7 +523,10 @@
     "set": "A3b",
     "number": 41,
     "rarity": "U",
-    "name": "Mienshao",
+    "name": {
+      "en": "Mienshao",
+      "fr": "Shaofouine"
+    },
     "image": "cPK_10_008340_00_KOJONDO_U.webp",
     "packs": [
       "Eevee"
@@ -413,7 +536,10 @@
     "set": "A3b",
     "number": 42,
     "rarity": "C",
-    "name": "Carbink",
+    "name": {
+      "en": "Carbink",
+      "fr": "Strassie"
+    },
     "image": "cPK_10_008350_00_MELECIE_C.webp",
     "packs": [
       "Eevee"
@@ -423,7 +549,10 @@
     "set": "A3b",
     "number": 43,
     "rarity": "R",
-    "name": "Umbreon",
+    "name": {
+      "en": "Umbreon",
+      "fr": "Noctali"
+    },
     "image": "cPK_10_008360_00_BRACKY_R.webp",
     "packs": [
       "Eevee"
@@ -433,7 +562,10 @@
     "set": "A3b",
     "number": 44,
     "rarity": "C",
-    "name": "Sableye",
+    "name": {
+      "en": "Sableye",
+      "fr": "Ténéfix"
+    },
     "image": "cPK_10_008370_00_YAMIRAMI_C.webp",
     "packs": [
       "Eevee"
@@ -443,7 +575,10 @@
     "set": "A3b",
     "number": 45,
     "rarity": "C",
-    "name": "Purrloin",
+    "name": {
+      "en": "Purrloin",
+      "fr": "Chacripan"
+    },
     "image": "cPK_10_008380_00_CHORONEKO_C.webp",
     "packs": [
       "Eevee"
@@ -453,7 +588,10 @@
     "set": "A3b",
     "number": 46,
     "rarity": "U",
-    "name": "Liepard",
+    "name": {
+      "en": "Liepard",
+      "fr": "Léopardus"
+    },
     "image": "cPK_10_008390_00_LEPARDAS_U.webp",
     "packs": [
       "Eevee"
@@ -463,7 +601,10 @@
     "set": "A3b",
     "number": 47,
     "rarity": "C",
-    "name": "Mawile",
+    "name": {
+      "en": "Mawile",
+      "fr": "Mysdibule"
+    },
     "image": "cPK_10_008400_00_KUCHEAT_C.webp",
     "packs": [
       "Eevee"
@@ -473,7 +614,10 @@
     "set": "A3b",
     "number": 48,
     "rarity": "C",
-    "name": "Togedemaru",
+    "name": {
+      "en": "Togedemaru",
+      "fr": "Togedemaru"
+    },
     "image": "cPK_10_007390_00_TOGEDEMARU_C.webp",
     "packs": [
       "Eevee"
@@ -483,7 +627,10 @@
     "set": "A3b",
     "number": 49,
     "rarity": "C",
-    "name": "Meltan",
+    "name": {
+      "en": "Meltan",
+      "fr": "Meltan"
+    },
     "image": "cPK_10_008410_00_MELTAN_C.webp",
     "packs": [
       "Eevee"
@@ -493,7 +640,10 @@
     "set": "A3b",
     "number": 50,
     "rarity": "U",
-    "name": "Melmetal",
+    "name": {
+      "en": "Melmetal",
+      "fr": "Melmetal"
+    },
     "image": "cPK_10_008420_00_MELMETAL_U.webp",
     "packs": [
       "Eevee"
@@ -503,7 +653,10 @@
     "set": "A3b",
     "number": 51,
     "rarity": "C",
-    "name": "Dratini",
+    "name": {
+      "en": "Dratini",
+      "fr": "Minidraco"
+    },
     "image": "cPK_10_008430_00_MINIRYU_C.webp",
     "packs": [
       "Eevee"
@@ -513,7 +666,10 @@
     "set": "A3b",
     "number": 52,
     "rarity": "C",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "image": "cPK_10_008440_00_HAKURYU_C.webp",
     "packs": [
       "Eevee"
@@ -523,7 +679,10 @@
     "set": "A3b",
     "number": 53,
     "rarity": "RR",
-    "name": "Dragonite ex",
+    "name": {
+      "en": "Dragonite ex",
+      "fr": "Dracolosse-ex"
+    },
     "image": "cPK_10_008450_00_KAIRYUex_RR.webp",
     "packs": [
       "Eevee"
@@ -533,7 +692,10 @@
     "set": "A3b",
     "number": 54,
     "rarity": "U",
-    "name": "Drampa",
+    "name": {
+      "en": "Drampa",
+      "fr": "Draïeul"
+    },
     "image": "cPK_10_008460_00_JIJILONG_U.webp",
     "packs": [
       "Eevee"
@@ -543,7 +705,10 @@
     "set": "A3b",
     "number": 55,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_008470_00_EIEVUI_C.webp",
     "packs": [
       "Eevee"
@@ -553,7 +718,10 @@
     "set": "A3b",
     "number": 56,
     "rarity": "RR",
-    "name": "Eevee ex",
+    "name": {
+      "en": "Eevee ex",
+      "fr": "Évoli-ex"
+    },
     "image": "cPK_10_008480_00_EIEVUIex_RR.webp",
     "packs": [
       "Eevee"
@@ -563,7 +731,10 @@
     "set": "A3b",
     "number": 57,
     "rarity": "RR",
-    "name": "Snorlax ex",
+    "name": {
+      "en": "Snorlax ex",
+      "fr": "Ronflex-ex"
+    },
     "image": "cPK_10_008490_00_KABIGONex_RR.webp",
     "packs": [
       "Eevee"
@@ -573,7 +744,10 @@
     "set": "A3b",
     "number": 58,
     "rarity": "C",
-    "name": "Aipom",
+    "name": {
+      "en": "Aipom",
+      "fr": "Capumain"
+    },
     "image": "cPK_10_008500_00_EIPAM_C.webp",
     "packs": [
       "Eevee"
@@ -583,7 +757,10 @@
     "set": "A3b",
     "number": 59,
     "rarity": "U",
-    "name": "Ambipom",
+    "name": {
+      "en": "Ambipom",
+      "fr": "Capidextre"
+    },
     "image": "cPK_10_008510_00_ETEBOTH_U.webp",
     "packs": [
       "Eevee"
@@ -593,7 +770,10 @@
     "set": "A3b",
     "number": 60,
     "rarity": "C",
-    "name": "Chatot",
+    "name": {
+      "en": "Chatot",
+      "fr": "Pijako"
+    },
     "image": "cPK_10_008520_00_PERAP_C.webp",
     "packs": [
       "Eevee"
@@ -603,7 +783,10 @@
     "set": "A3b",
     "number": 61,
     "rarity": "C",
-    "name": "Audino",
+    "name": {
+      "en": "Audino",
+      "fr": "Nanméouïe"
+    },
     "image": "cPK_10_008530_00_TABUNNE_C.webp",
     "packs": [
       "Eevee"
@@ -613,7 +796,10 @@
     "set": "A3b",
     "number": 62,
     "rarity": "C",
-    "name": "Minccino",
+    "name": {
+      "en": "Minccino",
+      "fr": "Chinchidou"
+    },
     "image": "cPK_10_008540_00_CHILLARMY_C.webp",
     "packs": [
       "Eevee"
@@ -623,7 +809,10 @@
     "set": "A3b",
     "number": 63,
     "rarity": "U",
-    "name": "Cinccino",
+    "name": {
+      "en": "Cinccino",
+      "fr": "Pashmilla"
+    },
     "image": "cPK_10_008550_00_CHILLACCINO_U.webp",
     "packs": [
       "Eevee"
@@ -633,7 +822,10 @@
     "set": "A3b",
     "number": 64,
     "rarity": "C",
-    "name": "Skwovet",
+    "name": {
+      "en": "Skwovet",
+      "fr": "Rongourmand"
+    },
     "image": "cPK_10_008560_00_HOSHIGARISU_C.webp",
     "packs": [
       "Eevee"
@@ -643,7 +835,10 @@
     "set": "A3b",
     "number": 65,
     "rarity": "U",
-    "name": "Greedent",
+    "name": {
+      "en": "Greedent",
+      "fr": "Rongrigou"
+    },
     "image": "cPK_10_007400_00_YOKUBARISU_U.webp",
     "packs": [
       "Eevee"
@@ -653,7 +848,10 @@
     "set": "A3b",
     "number": 66,
     "rarity": "U",
-    "name": "Eevee Bag",
+    "name": {
+      "en": "Eevee Bag",
+      "fr": "Sac Évoli"
+    },
     "image": "cTR_10_000670_00_IIBUINOBAKKU_U.webp",
     "packs": [
       "Eevee"
@@ -663,7 +861,10 @@
     "set": "A3b",
     "number": 67,
     "rarity": "U",
-    "name": "Leftovers",
+    "name": {
+      "en": "Leftovers",
+      "fr": "Restes"
+    },
     "image": "cTR_10_000680_00_TABENOKOSHI_U.webp",
     "packs": [
       "Eevee"
@@ -673,7 +874,10 @@
     "set": "A3b",
     "number": 68,
     "rarity": "U",
-    "name": "Hau",
+    "name": {
+      "en": "Hau",
+      "fr": "Tili"
+    },
     "image": "cTR_10_000690_00_HAU_U.webp",
     "packs": [
       "Eevee"
@@ -683,7 +887,10 @@
     "set": "A3b",
     "number": 69,
     "rarity": "U",
-    "name": "Penny",
+    "name": {
+      "en": "Penny",
+      "fr": "Pania"
+    },
     "image": "cTR_10_000700_00_BOTAN_U.webp",
     "packs": [
       "Eevee"
@@ -693,7 +900,10 @@
     "set": "A3b",
     "number": 70,
     "rarity": "AR",
-    "name": "Leafeon",
+    "name": {
+      "en": "Leafeon",
+      "fr": "Phyllali"
+    },
     "image": "cPK_20_007980_00_LEAFIA_AR.webp",
     "packs": [
       "Eevee"
@@ -703,7 +913,10 @@
     "set": "A3b",
     "number": 71,
     "rarity": "AR",
-    "name": "Flareon",
+    "name": {
+      "en": "Flareon",
+      "fr": "Pyroli"
+    },
     "image": "cPK_20_008040_00_BOOSTER_AR.webp",
     "packs": [
       "Eevee"
@@ -713,7 +926,10 @@
     "set": "A3b",
     "number": 72,
     "rarity": "AR",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_20_008120_00_SHOWERS_AR.webp",
     "packs": [
       "Eevee"
@@ -723,7 +939,10 @@
     "set": "A3b",
     "number": 73,
     "rarity": "AR",
-    "name": "Glaceon",
+    "name": {
+      "en": "Glaceon",
+      "fr": "Givrali"
+    },
     "image": "cPK_20_008130_00_GLACIA_AR.webp",
     "packs": [
       "Eevee"
@@ -733,7 +952,10 @@
     "set": "A3b",
     "number": 74,
     "rarity": "AR",
-    "name": "Jolteon",
+    "name": {
+      "en": "Jolteon",
+      "fr": "Voltali"
+    },
     "image": "cPK_20_007330_00_THUNDERS_AR.webp",
     "packs": [
       "Eevee"
@@ -743,7 +965,10 @@
     "set": "A3b",
     "number": 75,
     "rarity": "AR",
-    "name": "Espeon",
+    "name": {
+      "en": "Espeon",
+      "fr": "Mentali"
+    },
     "image": "cPK_20_008220_00_EIFIE_AR.webp",
     "packs": [
       "Eevee"
@@ -753,7 +978,10 @@
     "set": "A3b",
     "number": 76,
     "rarity": "AR",
-    "name": "Sylveon",
+    "name": {
+      "en": "Sylveon",
+      "fr": "Nymphali"
+    },
     "image": "cPK_20_008270_00_NYMPHIA_AR.webp",
     "packs": [
       "Eevee"
@@ -763,7 +991,10 @@
     "set": "A3b",
     "number": 77,
     "rarity": "AR",
-    "name": "Umbreon",
+    "name": {
+      "en": "Umbreon",
+      "fr": "Noctali"
+    },
     "image": "cPK_20_008360_00_BRACKY_AR.webp",
     "packs": [
       "Eevee"
@@ -773,7 +1004,10 @@
     "set": "A3b",
     "number": 78,
     "rarity": "AR",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_20_008470_00_EIEVUI_AR.webp",
     "packs": [
       "Eevee"
@@ -783,7 +1017,10 @@
     "set": "A3b",
     "number": 79,
     "rarity": "SR",
-    "name": "Flareon ex",
+    "name": {
+      "en": "Flareon ex",
+      "fr": "Pyroli-ex"
+    },
     "image": "cPK_20_008050_00_BOOSTERex_SR.webp",
     "packs": [
       "Eevee"
@@ -793,7 +1030,10 @@
     "set": "A3b",
     "number": 80,
     "rarity": "SR",
-    "name": "Primarina ex",
+    "name": {
+      "en": "Primarina ex",
+      "fr": "Oratoria-ex"
+    },
     "image": "cPK_20_008190_00_ASHIRENEex_SR.webp",
     "packs": [
       "Eevee"
@@ -803,7 +1043,10 @@
     "set": "A3b",
     "number": 81,
     "rarity": "SR",
-    "name": "Sylveon ex",
+    "name": {
+      "en": "Sylveon ex",
+      "fr": "Nymphali-ex"
+    },
     "image": "cPK_20_008280_00_NYMPHIAex_SR.webp",
     "packs": [
       "Eevee"
@@ -813,7 +1056,10 @@
     "set": "A3b",
     "number": 82,
     "rarity": "SR",
-    "name": "Dragonite ex",
+    "name": {
+      "en": "Dragonite ex",
+      "fr": "Dracolosse-ex"
+    },
     "image": "cPK_20_008450_00_KAIRYUex_SR.webp",
     "packs": [
       "Eevee"
@@ -823,7 +1069,10 @@
     "set": "A3b",
     "number": 83,
     "rarity": "SR",
-    "name": "Eevee ex",
+    "name": {
+      "en": "Eevee ex",
+      "fr": "Évoli-ex"
+    },
     "image": "cPK_20_008480_00_EIEVUIex_SR.webp",
     "packs": [
       "Eevee"
@@ -833,7 +1082,10 @@
     "set": "A3b",
     "number": 84,
     "rarity": "SR",
-    "name": "Snorlax ex",
+    "name": {
+      "en": "Snorlax ex",
+      "fr": "Ronflex-ex"
+    },
     "image": "cPK_20_008490_00_KABIGONex_SR.webp",
     "packs": [
       "Eevee"
@@ -843,7 +1095,10 @@
     "set": "A3b",
     "number": 85,
     "rarity": "SR",
-    "name": "Hau",
+    "name": {
+      "en": "Hau",
+      "fr": "Tili"
+    },
     "image": "cTR_20_000690_00_HAU_SR.webp",
     "packs": [
       "Eevee"
@@ -853,7 +1108,10 @@
     "set": "A3b",
     "number": 86,
     "rarity": "SR",
-    "name": "Penny",
+    "name": {
+      "en": "Penny",
+      "fr": "Pania"
+    },
     "image": "cTR_20_000700_00_BOTAN_SR.webp",
     "packs": [
       "Eevee"
@@ -863,7 +1121,10 @@
     "set": "A3b",
     "number": 87,
     "rarity": "SAR",
-    "name": "Flareon ex",
+    "name": {
+      "en": "Flareon ex",
+      "fr": "Pyroli-ex"
+    },
     "image": "cPK_20_008050_01_BOOSTERex_SAR.webp",
     "packs": [
       "Eevee"
@@ -873,7 +1134,10 @@
     "set": "A3b",
     "number": 88,
     "rarity": "SAR",
-    "name": "Primarina ex",
+    "name": {
+      "en": "Primarina ex",
+      "fr": "Oratoria-ex"
+    },
     "image": "cPK_20_008190_01_ASHIRENEex_SAR.webp",
     "packs": [
       "Eevee"
@@ -883,7 +1147,10 @@
     "set": "A3b",
     "number": 89,
     "rarity": "SAR",
-    "name": "Sylveon ex",
+    "name": {
+      "en": "Sylveon ex",
+      "fr": "Nymphali-ex"
+    },
     "image": "cPK_20_008280_01_NYMPHIAex_SAR.webp",
     "packs": [
       "Eevee"
@@ -893,7 +1160,10 @@
     "set": "A3b",
     "number": 90,
     "rarity": "SAR",
-    "name": "Dragonite ex",
+    "name": {
+      "en": "Dragonite ex",
+      "fr": "Dracolosse-ex"
+    },
     "image": "cPK_20_008450_01_KAIRYUex_SAR.webp",
     "packs": [
       "Eevee"
@@ -903,7 +1173,10 @@
     "set": "A3b",
     "number": 91,
     "rarity": "SAR",
-    "name": "Snorlax ex",
+    "name": {
+      "en": "Snorlax ex",
+      "fr": "Ronflex-ex"
+    },
     "image": "cPK_20_008490_01_KABIGONex_SAR.webp",
     "packs": [
       "Eevee"
@@ -913,7 +1186,10 @@
     "set": "A3b",
     "number": 92,
     "rarity": "IM",
-    "name": "Eevee ex",
+    "name": {
+      "en": "Eevee ex",
+      "fr": "Évoli-ex"
+    },
     "image": "cPK_20_008480_01_EIEVUIex_IM.webp",
     "packs": [
       "Eevee"
@@ -923,7 +1199,10 @@
     "set": "A3b",
     "number": 93,
     "rarity": "S",
-    "name": "Pinsir",
+    "name": {
+      "en": "Pinsir",
+      "fr": "Scarabrute"
+    },
     "image": "cPK_20_005240_00_KAILIOS_S.webp",
     "packs": [
       "Eevee"
@@ -933,7 +1212,10 @@
     "set": "A3b",
     "number": 94,
     "rarity": "S",
-    "name": "Lapras",
+    "name": {
+      "en": "Lapras",
+      "fr": "Lokhlass"
+    },
     "image": "cPK_20_000790_01_LAPLACE_S.webp",
     "packs": [
       "Eevee"
@@ -943,7 +1225,10 @@
     "set": "A3b",
     "number": 95,
     "rarity": "S",
-    "name": "Voltorb",
+    "name": {
+      "en": "Voltorb",
+      "fr": "Voltorbe"
+    },
     "image": "cPK_20_003350_00_BIRIRIDAMA_S.webp",
     "packs": [
       "Eevee"
@@ -953,7 +1238,10 @@
     "set": "A3b",
     "number": 96,
     "rarity": "S",
-    "name": "Electrode",
+    "name": {
+      "en": "Electrode",
+      "fr": "Électrode"
+    },
     "image": "cPK_20_003360_00_MARUMINE_S.webp",
     "packs": [
       "Eevee"
@@ -963,7 +1251,10 @@
     "set": "A3b",
     "number": 97,
     "rarity": "S",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "image": "cPK_20_003490_00_RALTS_S.webp",
     "packs": [
       "Eevee"
@@ -973,7 +1264,10 @@
     "set": "A3b",
     "number": 98,
     "rarity": "S",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "image": "cPK_20_003500_00_KIRLIA_S.webp",
     "packs": [
       "Eevee"
@@ -983,7 +1277,10 @@
     "set": "A3b",
     "number": 99,
     "rarity": "S",
-    "name": "Gardevoir",
+    "name": {
+      "en": "Gardevoir",
+      "fr": "Gardevoir"
+    },
     "image": "cPK_20_001320_00_SIRNIGHT_S.webp",
     "packs": [
       "Eevee"
@@ -993,7 +1290,10 @@
     "set": "A3b",
     "number": 100,
     "rarity": "S",
-    "name": "Ekans",
+    "name": {
+      "en": "Ekans",
+      "fr": "Abo"
+    },
     "image": "cPK_20_001640_00_ARBO_S.webp",
     "packs": [
       "Eevee"
@@ -1003,7 +1303,10 @@
     "set": "A3b",
     "number": 101,
     "rarity": "S",
-    "name": "Arbok",
+    "name": {
+      "en": "Arbok",
+      "fr": "Arbok"
+    },
     "image": "cPK_20_001650_00_ARBOK_S.webp",
     "packs": [
       "Eevee"
@@ -1013,7 +1316,10 @@
     "set": "A3b",
     "number": 102,
     "rarity": "S",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_20_001980_00_KAMONEGI_S.webp",
     "packs": [
       "Eevee"
@@ -1023,7 +1329,10 @@
     "set": "A3b",
     "number": 103,
     "rarity": "SSR",
-    "name": "Moltres ex",
+    "name": {
+      "en": "Moltres ex",
+      "fr": "Sulfura-ex"
+    },
     "image": "cPK_20_000470_02_FIREex_SSR.webp",
     "packs": [
       "Eevee"
@@ -1033,7 +1342,10 @@
     "set": "A3b",
     "number": 104,
     "rarity": "SSR",
-    "name": "Articuno ex",
+    "name": {
+      "en": "Articuno ex",
+      "fr": "Artikodin-ex"
+    },
     "image": "cPK_20_000840_02_FREEZERex_SSR.webp",
     "packs": [
       "Eevee"
@@ -1043,7 +1355,10 @@
     "set": "A3b",
     "number": 105,
     "rarity": "SSR",
-    "name": "Zapdos ex",
+    "name": {
+      "en": "Zapdos ex",
+      "fr": "Électhor-ex"
+    },
     "image": "cPK_20_001040_02_THUNDERex_SSR.webp",
     "packs": [
       "Eevee"
@@ -1053,7 +1368,10 @@
     "set": "A3b",
     "number": 106,
     "rarity": "SSR",
-    "name": "Gallade ex",
+    "name": {
+      "en": "Gallade ex",
+      "fr": "Gallame-ex"
+    },
     "image": "cPK_20_003760_02_ERUREIDOex_SSR.webp",
     "packs": [
       "Eevee"
@@ -1063,7 +1381,10 @@
     "set": "A3b",
     "number": 107,
     "rarity": "UR",
-    "name": "Eevee Bag",
+    "name": {
+      "en": "Eevee Bag",
+      "fr": "Sac Évoli"
+    },
     "image": "cTR_20_000670_00_IIBUINOBAKKU_UR.webp",
     "packs": [
       "Eevee"

--- a/dist/cards/A4.json
+++ b/dist/cards/A4.json
@@ -3,7 +3,10 @@
     "set": "A4",
     "number": 1,
     "rarity": "C",
-    "name": "Oddish",
+    "name": {
+      "en": "Oddish",
+      "fr": "Mystherbe"
+    },
     "image": "cPK_10_008570_00_NAZONOKUSA_C.webp",
     "packs": [
       "Lugia"
@@ -13,7 +16,10 @@
     "set": "A4",
     "number": 2,
     "rarity": "U",
-    "name": "Gloom",
+    "name": {
+      "en": "Gloom",
+      "fr": "Ortide"
+    },
     "image": "cPK_10_008580_00_KUSAIHANA_U.webp",
     "packs": [
       "Lugia"
@@ -23,7 +29,10 @@
     "set": "A4",
     "number": 3,
     "rarity": "R",
-    "name": "Bellossom",
+    "name": {
+      "en": "Bellossom",
+      "fr": "Joliflor"
+    },
     "image": "cPK_10_008590_00_KIREIHANA_R.webp",
     "packs": [
       "Lugia"
@@ -33,7 +42,10 @@
     "set": "A4",
     "number": 4,
     "rarity": "C",
-    "name": "Tangela",
+    "name": {
+      "en": "Tangela",
+      "fr": "Saquedeneu"
+    },
     "image": "cPK_10_008600_00_MONJARA_C.webp",
     "packs": [
       "Ho-Oh"
@@ -43,7 +55,10 @@
     "set": "A4",
     "number": 5,
     "rarity": "R",
-    "name": "Tangrowth",
+    "name": {
+      "en": "Tangrowth",
+      "fr": "Bouldeneu"
+    },
     "image": "cPK_10_008610_00_MOJUMBO_R.webp",
     "packs": [
       "Ho-Oh"
@@ -53,7 +68,10 @@
     "set": "A4",
     "number": 6,
     "rarity": "C",
-    "name": "Scyther",
+    "name": {
+      "en": "Scyther",
+      "fr": "Insécateur"
+    },
     "image": "cPK_10_008620_00_STRIKE_C.webp",
     "packs": [
       "Lugia"
@@ -63,7 +81,10 @@
     "set": "A4",
     "number": 7,
     "rarity": "C",
-    "name": "Pinsir",
+    "name": {
+      "en": "Pinsir",
+      "fr": "Scarabrute"
+    },
     "image": "cPK_10_008630_00_KAILIOS_C.webp",
     "packs": [
       "Lugia"
@@ -73,7 +94,10 @@
     "set": "A4",
     "number": 8,
     "rarity": "C",
-    "name": "Chikorita",
+    "name": {
+      "en": "Chikorita",
+      "fr": "Germignon"
+    },
     "image": "cPK_10_008640_00_CHICORITA_C.webp",
     "packs": [
       "Lugia"
@@ -83,7 +107,10 @@
     "set": "A4",
     "number": 9,
     "rarity": "U",
-    "name": "Bayleef",
+    "name": {
+      "en": "Bayleef",
+      "fr": "Macronium"
+    },
     "image": "cPK_10_008650_00_BAYLEAF_U.webp",
     "packs": [
       "Lugia"
@@ -93,7 +120,10 @@
     "set": "A4",
     "number": 10,
     "rarity": "R",
-    "name": "Meganium",
+    "name": {
+      "en": "Meganium",
+      "fr": "Méganium"
+    },
     "image": "cPK_10_008660_00_MEGANIUM_R.webp",
     "packs": [
       "Lugia"
@@ -103,7 +133,10 @@
     "set": "A4",
     "number": 11,
     "rarity": "C",
-    "name": "Ledyba",
+    "name": {
+      "en": "Ledyba",
+      "fr": "Coxy"
+    },
     "image": "cPK_10_008670_00_REDIBA_C.webp",
     "packs": [
       "Lugia"
@@ -113,7 +146,10 @@
     "set": "A4",
     "number": 12,
     "rarity": "C",
-    "name": "Ledian",
+    "name": {
+      "en": "Ledian",
+      "fr": "Coxyclaque"
+    },
     "image": "cPK_10_008680_00_REDIAN_C.webp",
     "packs": [
       "Lugia"
@@ -123,7 +159,10 @@
     "set": "A4",
     "number": 13,
     "rarity": "C",
-    "name": "Hoppip",
+    "name": {
+      "en": "Hoppip",
+      "fr": "Granivol"
+    },
     "image": "cPK_10_008690_00_HANECCO_C.webp",
     "packs": [
       "Ho-Oh"
@@ -133,7 +172,10 @@
     "set": "A4",
     "number": 14,
     "rarity": "U",
-    "name": "Skiploom",
+    "name": {
+      "en": "Skiploom",
+      "fr": "Floravol"
+    },
     "image": "cPK_10_008700_00_POPOCCO_U.webp",
     "packs": [
       "Ho-Oh"
@@ -143,7 +185,10 @@
     "set": "A4",
     "number": 15,
     "rarity": "R",
-    "name": "Jumpluff",
+    "name": {
+      "en": "Jumpluff",
+      "fr": "Cotovol"
+    },
     "image": "cPK_10_008710_00_WATACCO_R.webp",
     "packs": [
       "Ho-Oh"
@@ -153,7 +198,10 @@
     "set": "A4",
     "number": 16,
     "rarity": "C",
-    "name": "Sunkern",
+    "name": {
+      "en": "Sunkern",
+      "fr": "Tournegrin"
+    },
     "image": "cPK_10_008720_00_HIMANUTS_C.webp",
     "packs": [
       "Lugia",
@@ -164,7 +212,10 @@
     "set": "A4",
     "number": 17,
     "rarity": "U",
-    "name": "Sunflora",
+    "name": {
+      "en": "Sunflora",
+      "fr": "Héliatronc"
+    },
     "image": "cPK_10_008730_00_KIMAWARI_U.webp",
     "packs": [
       "Lugia",
@@ -175,7 +226,10 @@
     "set": "A4",
     "number": 18,
     "rarity": "C",
-    "name": "Yanma",
+    "name": {
+      "en": "Yanma",
+      "fr": "Yanma"
+    },
     "image": "cPK_10_008740_00_YANYANMA_C.webp",
     "packs": [
       "Lugia",
@@ -186,7 +240,10 @@
     "set": "A4",
     "number": 19,
     "rarity": "U",
-    "name": "Yanmega",
+    "name": {
+      "en": "Yanmega",
+      "fr": "Yanmega"
+    },
     "image": "cPK_10_008750_00_MEGAYANMA_U.webp",
     "packs": [
       "Lugia",
@@ -197,7 +254,10 @@
     "set": "A4",
     "number": 20,
     "rarity": "C",
-    "name": "Pineco",
+    "name": {
+      "en": "Pineco",
+      "fr": "Pomdepik"
+    },
     "image": "cPK_10_008760_00_KUNUGIDAMA_C.webp",
     "packs": [
       "Lugia",
@@ -208,7 +268,10 @@
     "set": "A4",
     "number": 21,
     "rarity": "RR",
-    "name": "Shuckle ex",
+    "name": {
+      "en": "Shuckle ex",
+      "fr": "Caratroc-ex"
+    },
     "image": "cPK_10_008770_00_TSUBOTSUBOex_RR.webp",
     "packs": [
       "Lugia"
@@ -218,7 +281,10 @@
     "set": "A4",
     "number": 22,
     "rarity": "R",
-    "name": "Heracross",
+    "name": {
+      "en": "Heracross",
+      "fr": "Scarhino"
+    },
     "image": "cPK_10_008780_00_HERACROS_R.webp",
     "packs": [
       "Ho-Oh"
@@ -228,7 +294,10 @@
     "set": "A4",
     "number": 23,
     "rarity": "C",
-    "name": "Cherubi",
+    "name": {
+      "en": "Cherubi",
+      "fr": "Ceribou"
+    },
     "image": "cPK_10_008790_00_CHERINBO_C.webp",
     "packs": [
       "Lugia",
@@ -239,7 +308,10 @@
     "set": "A4",
     "number": 24,
     "rarity": "U",
-    "name": "Cherrim",
+    "name": {
+      "en": "Cherrim",
+      "fr": "Ceriflor"
+    },
     "image": "cPK_10_008800_00_CHERRIM_U.webp",
     "packs": [
       "Lugia",
@@ -250,7 +322,10 @@
     "set": "A4",
     "number": 25,
     "rarity": "C",
-    "name": "Vulpix",
+    "name": {
+      "en": "Vulpix",
+      "fr": "Goupix"
+    },
     "image": "cPK_10_008810_00_ROKON_C.webp",
     "packs": [
       "Lugia"
@@ -260,7 +335,10 @@
     "set": "A4",
     "number": 26,
     "rarity": "R",
-    "name": "Ninetales",
+    "name": {
+      "en": "Ninetales",
+      "fr": "Feunard"
+    },
     "image": "cPK_10_008820_00_KYUKON_R.webp",
     "packs": [
       "Lugia"
@@ -270,7 +348,10 @@
     "set": "A4",
     "number": 27,
     "rarity": "C",
-    "name": "Cyndaquil",
+    "name": {
+      "en": "Cyndaquil",
+      "fr": "Héricendre"
+    },
     "image": "cPK_10_008830_00_HINOARASHI_C.webp",
     "packs": [
       "Lugia"
@@ -280,7 +361,10 @@
     "set": "A4",
     "number": 28,
     "rarity": "U",
-    "name": "Quilava",
+    "name": {
+      "en": "Quilava",
+      "fr": "Feurisson"
+    },
     "image": "cPK_10_008840_00_MAGMARASHI_U.webp",
     "packs": [
       "Lugia"
@@ -290,7 +374,10 @@
     "set": "A4",
     "number": 29,
     "rarity": "R",
-    "name": "Typhlosion",
+    "name": {
+      "en": "Typhlosion",
+      "fr": "Typhlosion"
+    },
     "image": "cPK_10_008850_00_BAKPHOON_R.webp",
     "packs": [
       "Lugia"
@@ -300,7 +387,10 @@
     "set": "A4",
     "number": 30,
     "rarity": "C",
-    "name": "Slugma",
+    "name": {
+      "en": "Slugma",
+      "fr": "Limagma"
+    },
     "image": "cPK_10_008860_00_MAGMAG_C.webp",
     "packs": [
       "Ho-Oh"
@@ -310,7 +400,10 @@
     "set": "A4",
     "number": 31,
     "rarity": "U",
-    "name": "Magcargo",
+    "name": {
+      "en": "Magcargo",
+      "fr": "Volcaropod"
+    },
     "image": "cPK_10_008870_00_MAGCARGOT_U.webp",
     "packs": [
       "Ho-Oh"
@@ -320,7 +413,10 @@
     "set": "A4",
     "number": 32,
     "rarity": "R",
-    "name": "Magby",
+    "name": {
+      "en": "Magby",
+      "fr": "Magby"
+    },
     "image": "cPK_10_008880_00_BUBY_R.webp",
     "packs": [
       "Ho-Oh"
@@ -330,7 +426,10 @@
     "set": "A4",
     "number": 33,
     "rarity": "R",
-    "name": "Entei",
+    "name": {
+      "en": "Entei",
+      "fr": "Entei"
+    },
     "image": "cPK_10_008890_00_ENTEI_R.webp",
     "packs": [
       "Ho-Oh"
@@ -340,7 +439,10 @@
     "set": "A4",
     "number": 34,
     "rarity": "RR",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "image": "cPK_10_008900_00_HOUOUex_RR.webp",
     "packs": [
       "Ho-Oh"
@@ -350,7 +452,10 @@
     "set": "A4",
     "number": 35,
     "rarity": "C",
-    "name": "Darumaka",
+    "name": {
+      "en": "Darumaka",
+      "fr": "Darumarond"
+    },
     "image": "cPK_10_008910_00_DARUMAKKA_C.webp",
     "packs": [
       "Lugia",
@@ -361,7 +466,10 @@
     "set": "A4",
     "number": 36,
     "rarity": "U",
-    "name": "Darmanitan",
+    "name": {
+      "en": "Darmanitan",
+      "fr": "Darumacho"
+    },
     "image": "cPK_10_008920_00_HIHIDARUMA_U.webp",
     "packs": [
       "Lugia",
@@ -372,7 +480,10 @@
     "set": "A4",
     "number": 37,
     "rarity": "C",
-    "name": "Heatmor",
+    "name": {
+      "en": "Heatmor",
+      "fr": "Aflamanoir"
+    },
     "image": "cPK_10_008930_00_KUITARAN_C.webp",
     "packs": [
       "Lugia",
@@ -383,7 +494,10 @@
     "set": "A4",
     "number": 38,
     "rarity": "C",
-    "name": "Poliwag",
+    "name": {
+      "en": "Poliwag",
+      "fr": "Ptitard"
+    },
     "image": "cPK_10_008940_00_NYOROMO_C.webp",
     "packs": [
       "Lugia"
@@ -393,7 +507,10 @@
     "set": "A4",
     "number": 39,
     "rarity": "U",
-    "name": "Poliwhirl",
+    "name": {
+      "en": "Poliwhirl",
+      "fr": "Têtarte"
+    },
     "image": "cPK_10_008950_00_NYOROZO_U.webp",
     "packs": [
       "Lugia"
@@ -403,7 +520,10 @@
     "set": "A4",
     "number": 40,
     "rarity": "R",
-    "name": "Politoed",
+    "name": {
+      "en": "Politoed",
+      "fr": "Tarpaud"
+    },
     "image": "cPK_10_008960_00_NYOROTONO_R.webp",
     "packs": [
       "Lugia"
@@ -413,7 +533,10 @@
     "set": "A4",
     "number": 41,
     "rarity": "C",
-    "name": "Horsea",
+    "name": {
+      "en": "Horsea",
+      "fr": "Hypotrempe"
+    },
     "image": "cPK_10_008970_00_TATTU_C.webp",
     "packs": [
       "Lugia"
@@ -423,7 +546,10 @@
     "set": "A4",
     "number": 42,
     "rarity": "U",
-    "name": "Seadra",
+    "name": {
+      "en": "Seadra",
+      "fr": "Hypocéan"
+    },
     "image": "cPK_10_008980_00_SEADRA_U.webp",
     "packs": [
       "Lugia"
@@ -433,7 +559,10 @@
     "set": "A4",
     "number": 43,
     "rarity": "RR",
-    "name": "Kingdra ex",
+    "name": {
+      "en": "Kingdra ex",
+      "fr": "Hyporoi-ex"
+    },
     "image": "cPK_10_008990_00_KINGDRAex_RR.webp",
     "packs": [
       "Lugia"
@@ -443,7 +572,10 @@
     "set": "A4",
     "number": 44,
     "rarity": "C",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_10_009000_00_KOIKING_C.webp",
     "packs": [
       "Lugia"
@@ -453,7 +585,10 @@
     "set": "A4",
     "number": 45,
     "rarity": "R",
-    "name": "Gyarados",
+    "name": {
+      "en": "Gyarados",
+      "fr": "Léviator"
+    },
     "image": "cPK_10_009010_00_GYARADOS_R.webp",
     "packs": [
       "Lugia"
@@ -463,7 +598,10 @@
     "set": "A4",
     "number": 46,
     "rarity": "C",
-    "name": "Totodile",
+    "name": {
+      "en": "Totodile",
+      "fr": "Kaiminus"
+    },
     "image": "cPK_10_009020_00_WANINOKO_C.webp",
     "packs": [
       "Ho-Oh"
@@ -473,7 +611,10 @@
     "set": "A4",
     "number": 47,
     "rarity": "U",
-    "name": "Croconaw",
+    "name": {
+      "en": "Croconaw",
+      "fr": "Crocrodil"
+    },
     "image": "cPK_10_009030_00_ALLIGATES_U.webp",
     "packs": [
       "Ho-Oh"
@@ -483,7 +624,10 @@
     "set": "A4",
     "number": 48,
     "rarity": "R",
-    "name": "Feraligatr",
+    "name": {
+      "en": "Feraligatr",
+      "fr": "Aligatueur"
+    },
     "image": "cPK_10_009040_00_ORDILE_R.webp",
     "packs": [
       "Ho-Oh"
@@ -493,7 +637,10 @@
     "set": "A4",
     "number": 49,
     "rarity": "C",
-    "name": "Marill",
+    "name": {
+      "en": "Marill",
+      "fr": "Marill"
+    },
     "image": "cPK_10_009050_00_MARIL_C.webp",
     "packs": [
       "Ho-Oh"
@@ -503,7 +650,10 @@
     "set": "A4",
     "number": 50,
     "rarity": "U",
-    "name": "Azumarill",
+    "name": {
+      "en": "Azumarill",
+      "fr": "Azumarill"
+    },
     "image": "cPK_10_009060_00_MARILLI_U.webp",
     "packs": [
       "Ho-Oh"
@@ -513,7 +663,10 @@
     "set": "A4",
     "number": 51,
     "rarity": "C",
-    "name": "Wooper",
+    "name": {
+      "en": "Wooper",
+      "fr": "Axoloto"
+    },
     "image": "cPK_10_009070_00_UPAH_C.webp",
     "packs": [
       "Lugia"
@@ -523,7 +676,10 @@
     "set": "A4",
     "number": 52,
     "rarity": "U",
-    "name": "Quagsire",
+    "name": {
+      "en": "Quagsire",
+      "fr": "Maraiste"
+    },
     "image": "cPK_10_009080_00_NUOH_U.webp",
     "packs": [
       "Lugia"
@@ -533,7 +689,10 @@
     "set": "A4",
     "number": 53,
     "rarity": "U",
-    "name": "Qwilfish",
+    "name": {
+      "en": "Qwilfish",
+      "fr": "Qwilfish"
+    },
     "image": "cPK_10_009090_00_HARYSEN_U.webp",
     "packs": [
       "Lugia"
@@ -543,7 +702,10 @@
     "set": "A4",
     "number": 54,
     "rarity": "C",
-    "name": "Corsola",
+    "name": {
+      "en": "Corsola",
+      "fr": "Corayon"
+    },
     "image": "cPK_10_009100_00_SUNNYGO_C.webp",
     "packs": [
       "Lugia"
@@ -553,7 +715,10 @@
     "set": "A4",
     "number": 55,
     "rarity": "C",
-    "name": "Remoraid",
+    "name": {
+      "en": "Remoraid",
+      "fr": "Rémoraid"
+    },
     "image": "cPK_10_009110_00_TEPPOUO_C.webp",
     "packs": [
       "Lugia"
@@ -563,7 +728,10 @@
     "set": "A4",
     "number": 56,
     "rarity": "R",
-    "name": "Octillery",
+    "name": {
+      "en": "Octillery",
+      "fr": "Octillery"
+    },
     "image": "cPK_10_009120_00_OKUTANK_R.webp",
     "packs": [
       "Lugia"
@@ -573,7 +741,10 @@
     "set": "A4",
     "number": 57,
     "rarity": "U",
-    "name": "Delibird",
+    "name": {
+      "en": "Delibird",
+      "fr": "Cadoizo"
+    },
     "image": "cPK_10_009130_00_DELIBIRD_U.webp",
     "packs": [
       "Ho-Oh"
@@ -583,7 +754,10 @@
     "set": "A4",
     "number": 58,
     "rarity": "U",
-    "name": "Mantine",
+    "name": {
+      "en": "Mantine",
+      "fr": "Démanta"
+    },
     "image": "cPK_10_009140_00_MANTAIN_U.webp",
     "packs": [
       "Lugia"
@@ -593,7 +767,10 @@
     "set": "A4",
     "number": 59,
     "rarity": "R",
-    "name": "Suicune",
+    "name": {
+      "en": "Suicune",
+      "fr": "Suicune"
+    },
     "image": "cPK_10_009150_00_SUICUNE_R.webp",
     "packs": [
       "Lugia"
@@ -603,7 +780,10 @@
     "set": "A4",
     "number": 60,
     "rarity": "C",
-    "name": "Corphish",
+    "name": {
+      "en": "Corphish",
+      "fr": "Écrapince"
+    },
     "image": "cPK_10_009160_00_HEIGANI_C.webp",
     "packs": [
       "Lugia"
@@ -613,7 +793,10 @@
     "set": "A4",
     "number": 61,
     "rarity": "R",
-    "name": "Crawdaunt",
+    "name": {
+      "en": "Crawdaunt",
+      "fr": "Colhomard"
+    },
     "image": "cPK_10_009170_00_SHIZARIGER_R.webp",
     "packs": [
       "Lugia"
@@ -623,7 +806,10 @@
     "set": "A4",
     "number": 62,
     "rarity": "C",
-    "name": "Ducklett",
+    "name": {
+      "en": "Ducklett",
+      "fr": "Couaneton"
+    },
     "image": "cPK_10_009180_00_KOARUHIE_C.webp",
     "packs": [
       "Ho-Oh"
@@ -633,7 +819,10 @@
     "set": "A4",
     "number": 63,
     "rarity": "U",
-    "name": "Swanna",
+    "name": {
+      "en": "Swanna",
+      "fr": "Lakmécygne"
+    },
     "image": "cPK_10_009190_00_SWANNA_U.webp",
     "packs": [
       "Ho-Oh"
@@ -643,7 +832,10 @@
     "set": "A4",
     "number": 64,
     "rarity": "C",
-    "name": "Chinchou",
+    "name": {
+      "en": "Chinchou",
+      "fr": "Loupio"
+    },
     "image": "cPK_10_009200_00_CHONCHIE_C.webp",
     "packs": [
       "Lugia"
@@ -653,7 +845,10 @@
     "set": "A4",
     "number": 65,
     "rarity": "RR",
-    "name": "Lanturn ex",
+    "name": {
+      "en": "Lanturn ex",
+      "fr": "Lanturn-ex"
+    },
     "image": "cPK_10_009210_00_LANTERNex_RR.webp",
     "packs": [
       "Lugia"
@@ -663,7 +858,10 @@
     "set": "A4",
     "number": 66,
     "rarity": "R",
-    "name": "Pichu",
+    "name": {
+      "en": "Pichu",
+      "fr": "Pichu"
+    },
     "image": "cPK_10_009220_00_PICHU_R.webp",
     "packs": [
       "Lugia"
@@ -673,7 +871,10 @@
     "set": "A4",
     "number": 67,
     "rarity": "C",
-    "name": "Mareep",
+    "name": {
+      "en": "Mareep",
+      "fr": "Wattouat"
+    },
     "image": "cPK_10_009230_00_MERRIEP_C.webp",
     "packs": [
       "Lugia"
@@ -683,7 +884,10 @@
     "set": "A4",
     "number": 68,
     "rarity": "U",
-    "name": "Flaaffy",
+    "name": {
+      "en": "Flaaffy",
+      "fr": "Lainergie"
+    },
     "image": "cPK_10_009240_00_MOKOKO_U.webp",
     "packs": [
       "Lugia"
@@ -693,7 +897,10 @@
     "set": "A4",
     "number": 69,
     "rarity": "R",
-    "name": "Ampharos",
+    "name": {
+      "en": "Ampharos",
+      "fr": "Pharamp"
+    },
     "image": "cPK_10_009250_00_DENRYU_R.webp",
     "packs": [
       "Lugia"
@@ -703,7 +910,10 @@
     "set": "A4",
     "number": 70,
     "rarity": "R",
-    "name": "Elekid",
+    "name": {
+      "en": "Elekid",
+      "fr": "Élekid"
+    },
     "image": "cPK_10_009260_00_ELEKID_R.webp",
     "packs": [
       "Lugia"
@@ -713,7 +923,10 @@
     "set": "A4",
     "number": 71,
     "rarity": "R",
-    "name": "Raikou",
+    "name": {
+      "en": "Raikou",
+      "fr": "Raikou"
+    },
     "image": "cPK_10_009270_00_RAIKOU_R.webp",
     "packs": [
       "Ho-Oh"
@@ -723,7 +936,10 @@
     "set": "A4",
     "number": 72,
     "rarity": "C",
-    "name": "Emolga",
+    "name": {
+      "en": "Emolga",
+      "fr": "Emolga"
+    },
     "image": "cPK_10_009280_00_EMOLGA_C.webp",
     "packs": [
       "Lugia",
@@ -734,7 +950,10 @@
     "set": "A4",
     "number": 73,
     "rarity": "C",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "image": "cPK_10_009290_00_YADON_C.webp",
     "packs": [
       "Lugia"
@@ -744,7 +963,10 @@
     "set": "A4",
     "number": 74,
     "rarity": "U",
-    "name": "Slowking",
+    "name": {
+      "en": "Slowking",
+      "fr": "Roigada"
+    },
     "image": "cPK_10_009300_00_YADOKING_U.webp",
     "packs": [
       "Lugia"
@@ -754,7 +976,10 @@
     "set": "A4",
     "number": 75,
     "rarity": "R",
-    "name": "Smoochum",
+    "name": {
+      "en": "Smoochum",
+      "fr": "Lippouti"
+    },
     "image": "cPK_10_009310_00_MUCHUL_R.webp",
     "packs": [
       "Ho-Oh"
@@ -764,7 +989,10 @@
     "set": "A4",
     "number": 76,
     "rarity": "C",
-    "name": "Jynx",
+    "name": {
+      "en": "Jynx",
+      "fr": "Lippoutou"
+    },
     "image": "cPK_10_009320_00_ROUGELA_C.webp",
     "packs": [
       "Lugia",
@@ -775,7 +1003,10 @@
     "set": "A4",
     "number": 77,
     "rarity": "R",
-    "name": "Cleffa",
+    "name": {
+      "en": "Cleffa",
+      "fr": "Mélo"
+    },
     "image": "cPK_10_009330_00_PY_R.webp",
     "packs": [
       "Lugia"
@@ -785,7 +1016,10 @@
     "set": "A4",
     "number": 78,
     "rarity": "C",
-    "name": "Togepi",
+    "name": {
+      "en": "Togepi",
+      "fr": "Togepi"
+    },
     "image": "cPK_10_009340_00_TOGEPY_C.webp",
     "packs": [
       "Ho-Oh"
@@ -795,7 +1029,10 @@
     "set": "A4",
     "number": 79,
     "rarity": "U",
-    "name": "Togetic",
+    "name": {
+      "en": "Togetic",
+      "fr": "Togetic"
+    },
     "image": "cPK_10_009350_00_TOGECHICK_U.webp",
     "packs": [
       "Ho-Oh"
@@ -805,7 +1042,10 @@
     "set": "A4",
     "number": 80,
     "rarity": "R",
-    "name": "Togekiss",
+    "name": {
+      "en": "Togekiss",
+      "fr": "Togekiss"
+    },
     "image": "cPK_10_009360_00_TOGEKISS_R.webp",
     "packs": [
       "Ho-Oh"
@@ -815,7 +1055,10 @@
     "set": "A4",
     "number": 81,
     "rarity": "C",
-    "name": "Natu",
+    "name": {
+      "en": "Natu",
+      "fr": "Natu"
+    },
     "image": "cPK_10_009370_00_NATY_C.webp",
     "packs": [
       "Lugia"
@@ -825,7 +1068,10 @@
     "set": "A4",
     "number": 82,
     "rarity": "R",
-    "name": "Xatu",
+    "name": {
+      "en": "Xatu",
+      "fr": "Xatu"
+    },
     "image": "cPK_10_009380_00_NATIO_R.webp",
     "packs": [
       "Lugia"
@@ -835,7 +1081,10 @@
     "set": "A4",
     "number": 83,
     "rarity": "RR",
-    "name": "Espeon ex",
+    "name": {
+      "en": "Espeon ex",
+      "fr": "Mentali-ex"
+    },
     "image": "cPK_10_009390_00_EIFIEex_RR.webp",
     "packs": [
       "Lugia"
@@ -845,7 +1094,10 @@
     "set": "A4",
     "number": 84,
     "rarity": "R",
-    "name": "Unown",
+    "name": {
+      "en": "Unown",
+      "fr": "Zarbi"
+    },
     "image": "cPK_10_009400_00_UNKNOWN_R.webp",
     "packs": [
       "Ho-Oh"
@@ -855,7 +1107,10 @@
     "set": "A4",
     "number": 85,
     "rarity": "R",
-    "name": "Unown",
+    "name": {
+      "en": "Unown",
+      "fr": "Zarbi"
+    },
     "image": "cPK_10_009410_00_UNKNOWN_R.webp",
     "packs": [
       "Lugia"
@@ -865,7 +1120,10 @@
     "set": "A4",
     "number": 86,
     "rarity": "C",
-    "name": "Wobbuffet",
+    "name": {
+      "en": "Wobbuffet",
+      "fr": "Qulbutoké"
+    },
     "image": "cPK_10_009420_00_SONANS_C.webp",
     "packs": [
       "Lugia"
@@ -875,7 +1133,10 @@
     "set": "A4",
     "number": 87,
     "rarity": "C",
-    "name": "Girafarig",
+    "name": {
+      "en": "Girafarig",
+      "fr": "Girafarig"
+    },
     "image": "cPK_10_009430_00_KIRINRIKI_C.webp",
     "packs": [
       "Ho-Oh"
@@ -885,7 +1146,10 @@
     "set": "A4",
     "number": 88,
     "rarity": "C",
-    "name": "Snubbull",
+    "name": {
+      "en": "Snubbull",
+      "fr": "Snubbull"
+    },
     "image": "cPK_10_009440_00_BULU_C.webp",
     "packs": [
       "Lugia",
@@ -896,7 +1160,10 @@
     "set": "A4",
     "number": 89,
     "rarity": "U",
-    "name": "Granbull",
+    "name": {
+      "en": "Granbull",
+      "fr": "Granbull"
+    },
     "image": "cPK_10_009450_00_GRANBULU_U.webp",
     "packs": [
       "Lugia",
@@ -907,7 +1174,10 @@
     "set": "A4",
     "number": 90,
     "rarity": "C",
-    "name": "Munna",
+    "name": {
+      "en": "Munna",
+      "fr": "Munna"
+    },
     "image": "cPK_10_009460_00_MUNNA_C.webp",
     "packs": [
       "Lugia",
@@ -918,7 +1188,10 @@
     "set": "A4",
     "number": 91,
     "rarity": "U",
-    "name": "Musharna",
+    "name": {
+      "en": "Musharna",
+      "fr": "Mushana"
+    },
     "image": "cPK_10_009470_00_MUSHARNA_U.webp",
     "packs": [
       "Lugia",
@@ -929,7 +1202,10 @@
     "set": "A4",
     "number": 92,
     "rarity": "C",
-    "name": "Onix",
+    "name": {
+      "en": "Onix",
+      "fr": "Onix"
+    },
     "image": "cPK_10_009480_00_IWARK_C.webp",
     "packs": [
       "Ho-Oh"
@@ -939,7 +1215,10 @@
     "set": "A4",
     "number": 93,
     "rarity": "C",
-    "name": "Sudowoodo",
+    "name": {
+      "en": "Sudowoodo",
+      "fr": "Simularbre"
+    },
     "image": "cPK_10_009490_00_USOKKIE_C.webp",
     "packs": [
       "Lugia",
@@ -950,7 +1229,10 @@
     "set": "A4",
     "number": 94,
     "rarity": "C",
-    "name": "Gligar",
+    "name": {
+      "en": "Gligar",
+      "fr": "Scorplane"
+    },
     "image": "cPK_10_009500_00_GLIGER_C.webp",
     "packs": [
       "Ho-Oh"
@@ -960,7 +1242,10 @@
     "set": "A4",
     "number": 95,
     "rarity": "U",
-    "name": "Gliscor",
+    "name": {
+      "en": "Gliscor",
+      "fr": "Scorvol"
+    },
     "image": "cPK_10_009510_00_GLION_U.webp",
     "packs": [
       "Ho-Oh"
@@ -970,7 +1255,10 @@
     "set": "A4",
     "number": 96,
     "rarity": "C",
-    "name": "Swinub",
+    "name": {
+      "en": "Swinub",
+      "fr": "Marcacrin"
+    },
     "image": "cPK_10_009520_00_URIMOO_C.webp",
     "packs": [
       "Ho-Oh"
@@ -980,7 +1268,10 @@
     "set": "A4",
     "number": 97,
     "rarity": "U",
-    "name": "Piloswine",
+    "name": {
+      "en": "Piloswine",
+      "fr": "Cochignon"
+    },
     "image": "cPK_10_009530_00_INOMOO_U.webp",
     "packs": [
       "Ho-Oh"
@@ -990,7 +1281,10 @@
     "set": "A4",
     "number": 98,
     "rarity": "R",
-    "name": "Mamoswine",
+    "name": {
+      "en": "Mamoswine",
+      "fr": "Mammochon"
+    },
     "image": "cPK_10_009540_00_MAMMOO_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1000,7 +1294,10 @@
     "set": "A4",
     "number": 99,
     "rarity": "C",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_10_009550_00_GOMAZOU_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1010,7 +1307,10 @@
     "set": "A4",
     "number": 100,
     "rarity": "RR",
-    "name": "Donphan ex",
+    "name": {
+      "en": "Donphan ex",
+      "fr": "Donphan-ex"
+    },
     "image": "cPK_10_009560_00_DONFANex_RR.webp",
     "packs": [
       "Ho-Oh"
@@ -1020,7 +1320,10 @@
     "set": "A4",
     "number": 101,
     "rarity": "R",
-    "name": "Tyrogue",
+    "name": {
+      "en": "Tyrogue",
+      "fr": "Debugant"
+    },
     "image": "cPK_10_009570_00_BALKIE_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1030,7 +1333,10 @@
     "set": "A4",
     "number": 102,
     "rarity": "C",
-    "name": "Hitmontop",
+    "name": {
+      "en": "Hitmontop",
+      "fr": "Kapoera"
+    },
     "image": "cPK_10_009580_00_KAPOERER_C.webp",
     "packs": [
       "Lugia",
@@ -1041,7 +1347,10 @@
     "set": "A4",
     "number": 103,
     "rarity": "C",
-    "name": "Larvitar",
+    "name": {
+      "en": "Larvitar",
+      "fr": "Embrylex"
+    },
     "image": "cPK_10_009590_00_YOGIRAS_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1051,7 +1360,10 @@
     "set": "A4",
     "number": 104,
     "rarity": "U",
-    "name": "Pupitar",
+    "name": {
+      "en": "Pupitar",
+      "fr": "Ymphect"
+    },
     "image": "cPK_10_009600_00_SANAGIRAS_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1061,7 +1373,10 @@
     "set": "A4",
     "number": 105,
     "rarity": "C",
-    "name": "Binacle",
+    "name": {
+      "en": "Binacle",
+      "fr": "Opermine"
+    },
     "image": "cPK_10_009610_00_KAMETETE_C.webp",
     "packs": [
       "Lugia"
@@ -1071,7 +1386,10 @@
     "set": "A4",
     "number": 106,
     "rarity": "U",
-    "name": "Barbaracle",
+    "name": {
+      "en": "Barbaracle",
+      "fr": "Golgopathe"
+    },
     "image": "cPK_10_009620_00_GAMENODES_U.webp",
     "packs": [
       "Lugia"
@@ -1081,7 +1399,10 @@
     "set": "A4",
     "number": 107,
     "rarity": "C",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "image": "cPK_10_009630_00_ZUBAT_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1091,7 +1412,10 @@
     "set": "A4",
     "number": 108,
     "rarity": "U",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "image": "cPK_10_009640_00_GOLBAT_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1101,7 +1425,10 @@
     "set": "A4",
     "number": 109,
     "rarity": "RR",
-    "name": "Crobat ex",
+    "name": {
+      "en": "Crobat ex",
+      "fr": "Nostenfer-ex"
+    },
     "image": "cPK_10_009650_00_CROBATex_RR.webp",
     "packs": [
       "Ho-Oh"
@@ -1111,7 +1438,10 @@
     "set": "A4",
     "number": 110,
     "rarity": "C",
-    "name": "Spinarak",
+    "name": {
+      "en": "Spinarak",
+      "fr": "Mimigal"
+    },
     "image": "cPK_10_009660_00_ITOMARU_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1121,7 +1451,10 @@
     "set": "A4",
     "number": 111,
     "rarity": "U",
-    "name": "Ariados",
+    "name": {
+      "en": "Ariados",
+      "fr": "Migalos"
+    },
     "image": "cPK_10_009670_00_ARIADOS_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1131,7 +1464,10 @@
     "set": "A4",
     "number": 112,
     "rarity": "RR",
-    "name": "Umbreon ex",
+    "name": {
+      "en": "Umbreon ex",
+      "fr": "Noctali-ex"
+    },
     "image": "cPK_10_009680_00_BRACKYex_RR.webp",
     "packs": [
       "Ho-Oh"
@@ -1141,7 +1477,10 @@
     "set": "A4",
     "number": 113,
     "rarity": "C",
-    "name": "Murkrow",
+    "name": {
+      "en": "Murkrow",
+      "fr": "Cornèbre"
+    },
     "image": "cPK_10_009690_00_YAMIKARASU_C.webp",
     "packs": [
       "Lugia"
@@ -1151,7 +1490,10 @@
     "set": "A4",
     "number": 114,
     "rarity": "U",
-    "name": "Honchkrow",
+    "name": {
+      "en": "Honchkrow",
+      "fr": "Corboss"
+    },
     "image": "cPK_10_009700_00_DONGKARASU_U.webp",
     "packs": [
       "Lugia"
@@ -1161,7 +1503,10 @@
     "set": "A4",
     "number": 115,
     "rarity": "C",
-    "name": "Sneasel",
+    "name": {
+      "en": "Sneasel",
+      "fr": "Farfuret"
+    },
     "image": "cPK_10_009710_00_NYULA_C.webp",
     "packs": [
       "Lugia"
@@ -1171,7 +1516,10 @@
     "set": "A4",
     "number": 116,
     "rarity": "U",
-    "name": "Weavile",
+    "name": {
+      "en": "Weavile",
+      "fr": "Dimoret"
+    },
     "image": "cPK_10_009720_00_MANYULA_U.webp",
     "packs": [
       "Lugia"
@@ -1181,7 +1529,10 @@
     "set": "A4",
     "number": 117,
     "rarity": "C",
-    "name": "Houndour",
+    "name": {
+      "en": "Houndour",
+      "fr": "Malosse"
+    },
     "image": "cPK_10_009730_00_DELVIL_C.webp",
     "packs": [
       "Lugia",
@@ -1192,7 +1543,10 @@
     "set": "A4",
     "number": 118,
     "rarity": "U",
-    "name": "Houndoom",
+    "name": {
+      "en": "Houndoom",
+      "fr": "Démolosse"
+    },
     "image": "cPK_10_009740_00_HELLGAR_U.webp",
     "packs": [
       "Lugia",
@@ -1203,7 +1557,10 @@
     "set": "A4",
     "number": 119,
     "rarity": "R",
-    "name": "Tyranitar",
+    "name": {
+      "en": "Tyranitar",
+      "fr": "Tyranocif"
+    },
     "image": "cPK_10_009750_00_BANGIRAS_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1213,7 +1570,10 @@
     "set": "A4",
     "number": 120,
     "rarity": "U",
-    "name": "Absol",
+    "name": {
+      "en": "Absol",
+      "fr": "Absol"
+    },
     "image": "cPK_10_009760_00_ABSOL_U.webp",
     "packs": [
       "Lugia",
@@ -1224,7 +1584,10 @@
     "set": "A4",
     "number": 121,
     "rarity": "U",
-    "name": "Forretress",
+    "name": {
+      "en": "Forretress",
+      "fr": "Foretress"
+    },
     "image": "cPK_10_009770_00_FORETOS_U.webp",
     "packs": [
       "Lugia",
@@ -1235,7 +1598,10 @@
     "set": "A4",
     "number": 122,
     "rarity": "R",
-    "name": "Steelix",
+    "name": {
+      "en": "Steelix",
+      "fr": "Steelix"
+    },
     "image": "cPK_10_009780_00_HAGANEIL_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1245,7 +1611,10 @@
     "set": "A4",
     "number": 123,
     "rarity": "R",
-    "name": "Scizor",
+    "name": {
+      "en": "Scizor",
+      "fr": "Cizayox"
+    },
     "image": "cPK_10_009790_00_HASSAM_R.webp",
     "packs": [
       "Lugia"
@@ -1255,7 +1624,10 @@
     "set": "A4",
     "number": 124,
     "rarity": "RR",
-    "name": "Skarmory ex",
+    "name": {
+      "en": "Skarmory ex",
+      "fr": "Airmure-ex"
+    },
     "image": "cPK_10_009800_00_AIRMDex_RR.webp",
     "packs": [
       "Ho-Oh"
@@ -1265,7 +1637,10 @@
     "set": "A4",
     "number": 125,
     "rarity": "C",
-    "name": "Mawile",
+    "name": {
+      "en": "Mawile",
+      "fr": "Mysdibule"
+    },
     "image": "cPK_10_009810_00_KUCHEAT_C.webp",
     "packs": [
       "Lugia",
@@ -1276,7 +1651,10 @@
     "set": "A4",
     "number": 126,
     "rarity": "C",
-    "name": "Klink",
+    "name": {
+      "en": "Klink",
+      "fr": "Tic"
+    },
     "image": "cPK_10_009820_00_GIARU_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1286,7 +1664,10 @@
     "set": "A4",
     "number": 127,
     "rarity": "U",
-    "name": "Klang",
+    "name": {
+      "en": "Klang",
+      "fr": "Clic"
+    },
     "image": "cPK_10_009830_00_GIGIARU_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1296,7 +1677,10 @@
     "set": "A4",
     "number": 128,
     "rarity": "R",
-    "name": "Klinklang",
+    "name": {
+      "en": "Klinklang",
+      "fr": "Cliticlic"
+    },
     "image": "cPK_10_009840_00_GIGIGIARU_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1306,7 +1690,10 @@
     "set": "A4",
     "number": 129,
     "rarity": "C",
-    "name": "Spearow",
+    "name": {
+      "en": "Spearow",
+      "fr": "Piafabec"
+    },
     "image": "cPK_10_009850_00_ONISUZUME_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1316,7 +1703,10 @@
     "set": "A4",
     "number": 130,
     "rarity": "C",
-    "name": "Fearow",
+    "name": {
+      "en": "Fearow",
+      "fr": "Rapasdepic"
+    },
     "image": "cPK_10_009860_00_ONIDRILL_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1326,7 +1716,10 @@
     "set": "A4",
     "number": 131,
     "rarity": "C",
-    "name": "Chansey",
+    "name": {
+      "en": "Chansey",
+      "fr": "Leveinard"
+    },
     "image": "cPK_10_009870_00_LUCKY_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1336,7 +1729,10 @@
     "set": "A4",
     "number": 132,
     "rarity": "R",
-    "name": "Blissey",
+    "name": {
+      "en": "Blissey",
+      "fr": "Leuphorie"
+    },
     "image": "cPK_10_009880_00_HAPPINAS_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1346,7 +1742,10 @@
     "set": "A4",
     "number": 133,
     "rarity": "R",
-    "name": "Kangaskhan",
+    "name": {
+      "en": "Kangaskhan",
+      "fr": "Kangourex"
+    },
     "image": "cPK_10_009890_00_GARURA_R.webp",
     "packs": [
       "Ho-Oh"
@@ -1356,7 +1755,10 @@
     "set": "A4",
     "number": 134,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_009900_00_EIEVUI_C.webp",
     "packs": [
       "Lugia",
@@ -1367,7 +1769,10 @@
     "set": "A4",
     "number": 135,
     "rarity": "C",
-    "name": "Porygon",
+    "name": {
+      "en": "Porygon",
+      "fr": "Porygon"
+    },
     "image": "cPK_10_009910_00_PORYGON_C.webp",
     "packs": [
       "Lugia"
@@ -1377,7 +1782,10 @@
     "set": "A4",
     "number": 136,
     "rarity": "U",
-    "name": "Porygon2",
+    "name": {
+      "en": "Porygon2",
+      "fr": "Porygon2"
+    },
     "image": "cPK_10_009920_00_PORYGON2_U.webp",
     "packs": [
       "Lugia"
@@ -1387,7 +1795,10 @@
     "set": "A4",
     "number": 137,
     "rarity": "R",
-    "name": "Porygon-Z",
+    "name": {
+      "en": "Porygon-Z",
+      "fr": "Porygon-Z"
+    },
     "image": "cPK_10_009930_00_PORYGON-Z_R.webp",
     "packs": [
       "Lugia"
@@ -1397,7 +1808,10 @@
     "set": "A4",
     "number": 138,
     "rarity": "C",
-    "name": "Sentret",
+    "name": {
+      "en": "Sentret",
+      "fr": "Fouinette"
+    },
     "image": "cPK_10_009940_00_OTACHI_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1407,7 +1821,10 @@
     "set": "A4",
     "number": 139,
     "rarity": "C",
-    "name": "Furret",
+    "name": {
+      "en": "Furret",
+      "fr": "Fouinar"
+    },
     "image": "cPK_10_009950_00_OOTACHI_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1417,7 +1834,10 @@
     "set": "A4",
     "number": 140,
     "rarity": "C",
-    "name": "Hoothoot",
+    "name": {
+      "en": "Hoothoot",
+      "fr": "Hoothoot"
+    },
     "image": "cPK_10_009960_00_HOHO_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1427,7 +1847,10 @@
     "set": "A4",
     "number": 141,
     "rarity": "C",
-    "name": "Noctowl",
+    "name": {
+      "en": "Noctowl",
+      "fr": "Noarfang"
+    },
     "image": "cPK_10_009970_00_YORUNOZUKU_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1437,7 +1860,10 @@
     "set": "A4",
     "number": 142,
     "rarity": "C",
-    "name": "Aipom",
+    "name": {
+      "en": "Aipom",
+      "fr": "Capumain"
+    },
     "image": "cPK_10_009980_00_EIPAM_C.webp",
     "packs": [
       "Lugia",
@@ -1448,7 +1874,10 @@
     "set": "A4",
     "number": 143,
     "rarity": "C",
-    "name": "Ambipom",
+    "name": {
+      "en": "Ambipom",
+      "fr": "Capidextre"
+    },
     "image": "cPK_10_009990_00_ETEBOTH_C.webp",
     "packs": [
       "Lugia",
@@ -1459,7 +1888,10 @@
     "set": "A4",
     "number": 144,
     "rarity": "C",
-    "name": "Dunsparce",
+    "name": {
+      "en": "Dunsparce",
+      "fr": "Insolourdo"
+    },
     "image": "cPK_10_010000_00_NOKOCCHI_C.webp",
     "packs": [
       "Lugia",
@@ -1470,7 +1902,10 @@
     "set": "A4",
     "number": 145,
     "rarity": "C",
-    "name": "Teddiursa",
+    "name": {
+      "en": "Teddiursa",
+      "fr": "Teddiursa"
+    },
     "image": "cPK_10_010010_00_HIMEGUMA_C.webp",
     "packs": [
       "Ho-Oh"
@@ -1480,7 +1915,10 @@
     "set": "A4",
     "number": 146,
     "rarity": "U",
-    "name": "Ursaring",
+    "name": {
+      "en": "Ursaring",
+      "fr": "Ursaring"
+    },
     "image": "cPK_10_010020_00_RINGUMA_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1490,7 +1928,10 @@
     "set": "A4",
     "number": 147,
     "rarity": "U",
-    "name": "Stantler",
+    "name": {
+      "en": "Stantler",
+      "fr": "Cerfrousse"
+    },
     "image": "cPK_10_010030_00_ODOSHISHI_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1500,7 +1941,10 @@
     "set": "A4",
     "number": 148,
     "rarity": "U",
-    "name": "Smeargle",
+    "name": {
+      "en": "Smeargle",
+      "fr": "Queulorior"
+    },
     "image": "cPK_10_010040_00_DOBLE_U.webp",
     "packs": [
       "Lugia"
@@ -1510,7 +1954,10 @@
     "set": "A4",
     "number": 149,
     "rarity": "RR",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "image": "cPK_10_010050_00_LUGIAex_RR.webp",
     "packs": [
       "Lugia"
@@ -1520,7 +1967,10 @@
     "set": "A4",
     "number": 150,
     "rarity": "U",
-    "name": "Bouffalant",
+    "name": {
+      "en": "Bouffalant",
+      "fr": "Frison"
+    },
     "image": "cPK_10_010060_00_BUFFRON_U.webp",
     "packs": [
       "Lugia",
@@ -1531,7 +1981,10 @@
     "set": "A4",
     "number": 151,
     "rarity": "U",
-    "name": "Elemental Switch",
+    "name": {
+      "en": "Elemental Switch",
+      "fr": "Échange Élémentaire"
+    },
     "image": "cTR_10_000710_00_EREMENTARUTSUKEKAE_U.webp",
     "packs": [
       "Lugia"
@@ -1541,7 +1994,10 @@
     "set": "A4",
     "number": 152,
     "rarity": "U",
-    "name": "Squirt Bottle",
+    "name": {
+      "en": "Squirt Bottle",
+      "fr": "Carapuce à O"
+    },
     "image": "cTR_10_000720_00_ZEHIGAMEJOURO_U.webp",
     "packs": [
       "Lugia"
@@ -1551,7 +2007,10 @@
     "set": "A4",
     "number": 153,
     "rarity": "U",
-    "name": "Steel Apron",
+    "name": {
+      "en": "Steel Apron",
+      "fr": "Tablier d'Acier"
+    },
     "image": "cTR_10_000730_00_GOUTETUNOMAEKAKE_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1561,7 +2020,10 @@
     "set": "A4",
     "number": 154,
     "rarity": "U",
-    "name": "Dark Pendant",
+    "name": {
+      "en": "Dark Pendant",
+      "fr": "Pendentif des Ténèbres"
+    },
     "image": "cTR_10_000740_00_DARKPENDANTO_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1571,7 +2033,10 @@
     "set": "A4",
     "number": 155,
     "rarity": "U",
-    "name": "Rescue Scarf",
+    "name": {
+      "en": "Rescue Scarf",
+      "fr": "Foulard de Sauvetage"
+    },
     "image": "cTR_10_000750_00_RESUKYUSUKAFU_U.webp",
     "packs": [
       "Lugia",
@@ -1582,7 +2047,10 @@
     "set": "A4",
     "number": 156,
     "rarity": "U",
-    "name": "Will",
+    "name": {
+      "en": "Will",
+      "fr": "Clément"
+    },
     "image": "cTR_10_000760_00_ITSUKI_U.webp",
     "packs": [
       "Lugia"
@@ -1592,7 +2060,10 @@
     "set": "A4",
     "number": 157,
     "rarity": "U",
-    "name": "Lyra",
+    "name": {
+      "en": "Lyra",
+      "fr": "Célesta"
+    },
     "image": "cTR_10_000770_00_KOTONE_U.webp",
     "packs": [
       "Lugia"
@@ -1602,7 +2073,10 @@
     "set": "A4",
     "number": 158,
     "rarity": "U",
-    "name": "Silver",
+    "name": {
+      "en": "Silver",
+      "fr": "Silver"
+    },
     "image": "cTR_10_000780_00_SILVER_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1612,7 +2086,10 @@
     "set": "A4",
     "number": 159,
     "rarity": "U",
-    "name": "Fisher",
+    "name": {
+      "en": "Fisher",
+      "fr": "Pêcheur"
+    },
     "image": "cTR_10_000790_00_FISHER_U.webp",
     "packs": [
       "Lugia"
@@ -1622,7 +2099,10 @@
     "set": "A4",
     "number": 160,
     "rarity": "U",
-    "name": "Jasmine",
+    "name": {
+      "en": "Jasmine",
+      "fr": "Jasmine"
+    },
     "image": "cTR_10_000800_00_MIKAN_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1632,7 +2112,10 @@
     "set": "A4",
     "number": 161,
     "rarity": "U",
-    "name": "Hiker",
+    "name": {
+      "en": "Hiker",
+      "fr": "Montagnard"
+    },
     "image": "cTR_10_000810_00_HIKER_U.webp",
     "packs": [
       "Ho-Oh"
@@ -1642,7 +2125,10 @@
     "set": "A4",
     "number": 162,
     "rarity": "AR",
-    "name": "Chikorita",
+    "name": {
+      "en": "Chikorita",
+      "fr": "Germignon"
+    },
     "image": "cPK_20_008640_00_CHICORITA_AR.webp",
     "packs": [
       "Lugia"
@@ -1652,7 +2138,10 @@
     "set": "A4",
     "number": 163,
     "rarity": "AR",
-    "name": "Bellossom",
+    "name": {
+      "en": "Bellossom",
+      "fr": "Joliflor"
+    },
     "image": "cPK_20_008590_00_KIREIHANA_AR.webp",
     "packs": [
       "Lugia"
@@ -1662,7 +2151,10 @@
     "set": "A4",
     "number": 164,
     "rarity": "AR",
-    "name": "Heracross",
+    "name": {
+      "en": "Heracross",
+      "fr": "Scarhino"
+    },
     "image": "cPK_20_008780_00_HERACROS_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1672,7 +2164,10 @@
     "set": "A4",
     "number": 165,
     "rarity": "AR",
-    "name": "Cyndaquil",
+    "name": {
+      "en": "Cyndaquil",
+      "fr": "Héricendre"
+    },
     "image": "cPK_20_008830_00_HINOARASHI_AR.webp",
     "packs": [
       "Lugia"
@@ -1682,7 +2177,10 @@
     "set": "A4",
     "number": 166,
     "rarity": "AR",
-    "name": "Magby",
+    "name": {
+      "en": "Magby",
+      "fr": "Magby"
+    },
     "image": "cPK_20_008880_00_BUBY_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1692,7 +2190,10 @@
     "set": "A4",
     "number": 167,
     "rarity": "AR",
-    "name": "Totodile",
+    "name": {
+      "en": "Totodile",
+      "fr": "Kaiminus"
+    },
     "image": "cPK_20_009020_00_WANINOKO_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1702,7 +2203,10 @@
     "set": "A4",
     "number": 168,
     "rarity": "AR",
-    "name": "Qwilfish",
+    "name": {
+      "en": "Qwilfish",
+      "fr": "Qwilfish"
+    },
     "image": "cPK_20_009090_00_HARYSEN_AR.webp",
     "packs": [
       "Lugia"
@@ -1712,7 +2216,10 @@
     "set": "A4",
     "number": 169,
     "rarity": "AR",
-    "name": "Octillery",
+    "name": {
+      "en": "Octillery",
+      "fr": "Octillery"
+    },
     "image": "cPK_20_009120_00_OKUTANK_AR.webp",
     "packs": [
       "Lugia"
@@ -1722,7 +2229,10 @@
     "set": "A4",
     "number": 170,
     "rarity": "AR",
-    "name": "Delibird",
+    "name": {
+      "en": "Delibird",
+      "fr": "Cadoizo"
+    },
     "image": "cPK_20_009130_00_DELIBIRD_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1732,7 +2242,10 @@
     "set": "A4",
     "number": 171,
     "rarity": "AR",
-    "name": "Pichu",
+    "name": {
+      "en": "Pichu",
+      "fr": "Pichu"
+    },
     "image": "cPK_20_009220_00_PICHU_AR.webp",
     "packs": [
       "Lugia"
@@ -1742,7 +2255,10 @@
     "set": "A4",
     "number": 172,
     "rarity": "AR",
-    "name": "Ampharos",
+    "name": {
+      "en": "Ampharos",
+      "fr": "Pharamp"
+    },
     "image": "cPK_20_009250_00_DENRYU_AR.webp",
     "packs": [
       "Lugia"
@@ -1752,7 +2268,10 @@
     "set": "A4",
     "number": 173,
     "rarity": "AR",
-    "name": "Togepi",
+    "name": {
+      "en": "Togepi",
+      "fr": "Togepi"
+    },
     "image": "cPK_20_009340_00_TOGEPY_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1762,7 +2281,10 @@
     "set": "A4",
     "number": 174,
     "rarity": "AR",
-    "name": "Xatu",
+    "name": {
+      "en": "Xatu",
+      "fr": "Xatu"
+    },
     "image": "cPK_20_009380_00_NATIO_AR.webp",
     "packs": [
       "Lugia"
@@ -1772,7 +2294,10 @@
     "set": "A4",
     "number": 175,
     "rarity": "AR",
-    "name": "Wobbuffet",
+    "name": {
+      "en": "Wobbuffet",
+      "fr": "Qulbutoké"
+    },
     "image": "cPK_20_009420_00_SONANS_AR.webp",
     "packs": [
       "Lugia"
@@ -1782,7 +2307,10 @@
     "set": "A4",
     "number": 176,
     "rarity": "AR",
-    "name": "Gligar",
+    "name": {
+      "en": "Gligar",
+      "fr": "Scorplane"
+    },
     "image": "cPK_20_009500_00_GLIGER_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1792,7 +2320,10 @@
     "set": "A4",
     "number": 177,
     "rarity": "AR",
-    "name": "Spinarak",
+    "name": {
+      "en": "Spinarak",
+      "fr": "Mimigal"
+    },
     "image": "cPK_20_009660_00_ITOMARU_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1802,7 +2333,10 @@
     "set": "A4",
     "number": 178,
     "rarity": "AR",
-    "name": "Murkrow",
+    "name": {
+      "en": "Murkrow",
+      "fr": "Cornèbre"
+    },
     "image": "cPK_20_009690_00_YAMIKARASU_AR.webp",
     "packs": [
       "Lugia"
@@ -1812,7 +2346,10 @@
     "set": "A4",
     "number": 179,
     "rarity": "AR",
-    "name": "Tyranitar",
+    "name": {
+      "en": "Tyranitar",
+      "fr": "Tyranocif"
+    },
     "image": "cPK_20_009750_00_BANGIRAS_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1822,7 +2359,10 @@
     "set": "A4",
     "number": 180,
     "rarity": "AR",
-    "name": "Scizor",
+    "name": {
+      "en": "Scizor",
+      "fr": "Cizayox"
+    },
     "image": "cPK_20_009790_00_HASSAM_AR.webp",
     "packs": [
       "Lugia"
@@ -1832,7 +2372,10 @@
     "set": "A4",
     "number": 181,
     "rarity": "AR",
-    "name": "Sentret",
+    "name": {
+      "en": "Sentret",
+      "fr": "Fouinette"
+    },
     "image": "cPK_20_009940_00_OTACHI_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1842,7 +2385,10 @@
     "set": "A4",
     "number": 182,
     "rarity": "AR",
-    "name": "Hoothoot",
+    "name": {
+      "en": "Hoothoot",
+      "fr": "Hoothoot"
+    },
     "image": "cPK_20_009960_00_HOHO_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1852,7 +2398,10 @@
     "set": "A4",
     "number": 183,
     "rarity": "AR",
-    "name": "Stantler",
+    "name": {
+      "en": "Stantler",
+      "fr": "Cerfrousse"
+    },
     "image": "cPK_20_010030_00_ODOSHISHI_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1862,7 +2411,10 @@
     "set": "A4",
     "number": 184,
     "rarity": "AR",
-    "name": "Smeargle",
+    "name": {
+      "en": "Smeargle",
+      "fr": "Queulorior"
+    },
     "image": "cPK_20_010040_00_DOBLE_AR.webp",
     "packs": [
       "Lugia"
@@ -1872,7 +2424,10 @@
     "set": "A4",
     "number": 185,
     "rarity": "AR",
-    "name": "Blissey",
+    "name": {
+      "en": "Blissey",
+      "fr": "Leuphorie"
+    },
     "image": "cPK_20_009880_00_HAPPINAS_AR.webp",
     "packs": [
       "Ho-Oh"
@@ -1882,7 +2437,10 @@
     "set": "A4",
     "number": 186,
     "rarity": "SR",
-    "name": "Shuckle ex",
+    "name": {
+      "en": "Shuckle ex",
+      "fr": "Caratroc-ex"
+    },
     "image": "cPK_20_008770_00_TSUBOTSUBOex_SR.webp",
     "packs": [
       "Lugia"
@@ -1892,7 +2450,10 @@
     "set": "A4",
     "number": 187,
     "rarity": "SR",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "image": "cPK_20_008900_00_HOUOUex_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -1902,7 +2463,10 @@
     "set": "A4",
     "number": 188,
     "rarity": "SR",
-    "name": "Kingdra ex",
+    "name": {
+      "en": "Kingdra ex",
+      "fr": "Hyporoi-ex"
+    },
     "image": "cPK_20_008990_00_KINGDRAex_SR.webp",
     "packs": [
       "Lugia"
@@ -1912,7 +2476,10 @@
     "set": "A4",
     "number": 189,
     "rarity": "SR",
-    "name": "Lanturn ex",
+    "name": {
+      "en": "Lanturn ex",
+      "fr": "Lanturn-ex"
+    },
     "image": "cPK_20_009210_00_LANTERNex_SR.webp",
     "packs": [
       "Lugia"
@@ -1922,7 +2489,10 @@
     "set": "A4",
     "number": 190,
     "rarity": "SR",
-    "name": "Espeon ex",
+    "name": {
+      "en": "Espeon ex",
+      "fr": "Mentali-ex"
+    },
     "image": "cPK_20_009390_00_EIFIEex_SR.webp",
     "packs": [
       "Lugia"
@@ -1932,7 +2502,10 @@
     "set": "A4",
     "number": 191,
     "rarity": "SR",
-    "name": "Donphan ex",
+    "name": {
+      "en": "Donphan ex",
+      "fr": "Donphan-ex"
+    },
     "image": "cPK_20_009560_00_DONFANex_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -1942,7 +2515,10 @@
     "set": "A4",
     "number": 192,
     "rarity": "SR",
-    "name": "Crobat ex",
+    "name": {
+      "en": "Crobat ex",
+      "fr": "Nostenfer-ex"
+    },
     "image": "cPK_20_009650_00_CROBATex_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -1952,7 +2528,10 @@
     "set": "A4",
     "number": 193,
     "rarity": "SR",
-    "name": "Umbreon ex",
+    "name": {
+      "en": "Umbreon ex",
+      "fr": "Noctali-ex"
+    },
     "image": "cPK_20_009680_00_BRACKYex_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -1962,7 +2541,10 @@
     "set": "A4",
     "number": 194,
     "rarity": "SR",
-    "name": "Skarmory ex",
+    "name": {
+      "en": "Skarmory ex",
+      "fr": "Airmure-ex"
+    },
     "image": "cPK_20_009800_00_AIRMDex_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -1972,7 +2554,10 @@
     "set": "A4",
     "number": 195,
     "rarity": "SR",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "image": "cPK_20_010050_00_LUGIAex_SR.webp",
     "packs": [
       "Lugia"
@@ -1982,7 +2567,10 @@
     "set": "A4",
     "number": 196,
     "rarity": "SR",
-    "name": "Will",
+    "name": {
+      "en": "Will",
+      "fr": "Clément"
+    },
     "image": "cTR_20_000760_00_ITSUKI_SR.webp",
     "packs": [
       "Lugia"
@@ -1992,7 +2580,10 @@
     "set": "A4",
     "number": 197,
     "rarity": "SR",
-    "name": "Lyra",
+    "name": {
+      "en": "Lyra",
+      "fr": "Célesta"
+    },
     "image": "cTR_20_000770_00_KOTONE_SR.webp",
     "packs": [
       "Lugia"
@@ -2002,7 +2593,10 @@
     "set": "A4",
     "number": 198,
     "rarity": "SR",
-    "name": "Silver",
+    "name": {
+      "en": "Silver",
+      "fr": "Silver"
+    },
     "image": "cTR_20_000780_00_SILVER_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -2012,7 +2606,10 @@
     "set": "A4",
     "number": 199,
     "rarity": "SR",
-    "name": "Fisher",
+    "name": {
+      "en": "Fisher",
+      "fr": "Pêcheur"
+    },
     "image": "cTR_20_000790_00_FISHER_SR.webp",
     "packs": [
       "Lugia"
@@ -2022,7 +2619,10 @@
     "set": "A4",
     "number": 200,
     "rarity": "SR",
-    "name": "Jasmine",
+    "name": {
+      "en": "Jasmine",
+      "fr": "Jasmine"
+    },
     "image": "cTR_20_000800_00_MIKAN_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -2032,7 +2632,10 @@
     "set": "A4",
     "number": 201,
     "rarity": "SR",
-    "name": "Hiker",
+    "name": {
+      "en": "Hiker",
+      "fr": "Montagnard"
+    },
     "image": "cTR_20_000810_00_HIKER_SR.webp",
     "packs": [
       "Ho-Oh"
@@ -2042,7 +2645,10 @@
     "set": "A4",
     "number": 202,
     "rarity": "SAR",
-    "name": "Shuckle ex",
+    "name": {
+      "en": "Shuckle ex",
+      "fr": "Caratroc-ex"
+    },
     "image": "cPK_20_008770_01_TSUBOTSUBOex_SAR.webp",
     "packs": [
       "Lugia"
@@ -2052,7 +2658,10 @@
     "set": "A4",
     "number": 203,
     "rarity": "SAR",
-    "name": "Kingdra ex",
+    "name": {
+      "en": "Kingdra ex",
+      "fr": "Hyporoi-ex"
+    },
     "image": "cPK_20_008990_01_KINGDRAex_SAR.webp",
     "packs": [
       "Lugia"
@@ -2062,7 +2671,10 @@
     "set": "A4",
     "number": 204,
     "rarity": "SAR",
-    "name": "Lanturn ex",
+    "name": {
+      "en": "Lanturn ex",
+      "fr": "Lanturn-ex"
+    },
     "image": "cPK_20_009210_01_LANTERNex_SAR.webp",
     "packs": [
       "Lugia"
@@ -2072,7 +2684,10 @@
     "set": "A4",
     "number": 205,
     "rarity": "SAR",
-    "name": "Espeon ex",
+    "name": {
+      "en": "Espeon ex",
+      "fr": "Mentali-ex"
+    },
     "image": "cPK_20_009390_01_EIFIEex_SAR.webp",
     "packs": [
       "Lugia"
@@ -2082,7 +2697,10 @@
     "set": "A4",
     "number": 206,
     "rarity": "SAR",
-    "name": "Donphan ex",
+    "name": {
+      "en": "Donphan ex",
+      "fr": "Donphan-ex"
+    },
     "image": "cPK_20_009560_01_DONFANex_SAR.webp",
     "packs": [
       "Ho-Oh"
@@ -2092,7 +2710,10 @@
     "set": "A4",
     "number": 207,
     "rarity": "SAR",
-    "name": "Crobat ex",
+    "name": {
+      "en": "Crobat ex",
+      "fr": "Nostenfer-ex"
+    },
     "image": "cPK_20_009650_01_CROBATex_SAR.webp",
     "packs": [
       "Ho-Oh"
@@ -2102,7 +2723,10 @@
     "set": "A4",
     "number": 208,
     "rarity": "SAR",
-    "name": "Umbreon ex",
+    "name": {
+      "en": "Umbreon ex",
+      "fr": "Noctali-ex"
+    },
     "image": "cPK_20_009680_01_BRACKYex_SAR.webp",
     "packs": [
       "Ho-Oh"
@@ -2112,7 +2736,10 @@
     "set": "A4",
     "number": 209,
     "rarity": "SAR",
-    "name": "Skarmory ex",
+    "name": {
+      "en": "Skarmory ex",
+      "fr": "Airmure-ex"
+    },
     "image": "cPK_20_009800_01_AIRMDex_SAR.webp",
     "packs": [
       "Ho-Oh"
@@ -2122,7 +2749,10 @@
     "set": "A4",
     "number": 210,
     "rarity": "IM",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "image": "cPK_20_008900_01_HOUOUex_IM.webp",
     "packs": [
       "Ho-Oh"
@@ -2132,7 +2762,10 @@
     "set": "A4",
     "number": 211,
     "rarity": "IM",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "image": "cPK_20_010050_01_LUGIAex_IM.webp",
     "packs": [
       "Lugia"
@@ -2142,7 +2775,10 @@
     "set": "A4",
     "number": 212,
     "rarity": "S",
-    "name": "Yanma",
+    "name": {
+      "en": "Yanma",
+      "fr": "Yanma"
+    },
     "image": "cPK_20_008740_00_YANYANMA_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2152,7 +2788,10 @@
     "set": "A4",
     "number": 213,
     "rarity": "S",
-    "name": "Flareon",
+    "name": {
+      "en": "Flareon",
+      "fr": "Pyroli"
+    },
     "image": "cPK_20_008040_01_BOOSTER_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2162,7 +2801,10 @@
     "set": "A4",
     "number": 214,
     "rarity": "S",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_20_002310_00_KOIKING_S.webp",
     "packs": [
       "Lugia"
@@ -2172,7 +2814,10 @@
     "set": "A4",
     "number": 215,
     "rarity": "S",
-    "name": "Gyarados",
+    "name": {
+      "en": "Gyarados",
+      "fr": "Léviator"
+    },
     "image": "cPK_20_009010_00_GYARADOS_S.webp",
     "packs": [
       "Lugia"
@@ -2182,7 +2827,10 @@
     "set": "A4",
     "number": 216,
     "rarity": "S",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_20_000800_00_SHOWERS_S.webp",
     "packs": [
       "Lugia"
@@ -2192,7 +2840,10 @@
     "set": "A4",
     "number": 217,
     "rarity": "S",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_20_000970_00_COIL_S.webp",
     "packs": [
       "Lugia"
@@ -2202,7 +2853,10 @@
     "set": "A4",
     "number": 218,
     "rarity": "S",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "image": "cPK_20_000980_00_RARECOIL_S.webp",
     "packs": [
       "Lugia"
@@ -2212,7 +2866,10 @@
     "set": "A4",
     "number": 219,
     "rarity": "S",
-    "name": "Jolteon",
+    "name": {
+      "en": "Jolteon",
+      "fr": "Voltali"
+    },
     "image": "cPK_20_007330_01_THUNDERS_S.webp",
     "packs": [
       "Lugia"
@@ -2222,7 +2879,10 @@
     "set": "A4",
     "number": 220,
     "rarity": "S",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_20_003470_00_MUMA_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2232,7 +2892,10 @@
     "set": "A4",
     "number": 221,
     "rarity": "S",
-    "name": "Mankey",
+    "name": {
+      "en": "Mankey",
+      "fr": "Férosinge"
+    },
     "image": "cPK_20_002540_00_MANKEY_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2242,7 +2905,10 @@
     "set": "A4",
     "number": 222,
     "rarity": "S",
-    "name": "Primeape",
+    "name": {
+      "en": "Primeape",
+      "fr": "Colossinge"
+    },
     "image": "cPK_20_001420_00_OKORIZARU_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2252,7 +2918,10 @@
     "set": "A4",
     "number": 223,
     "rarity": "S",
-    "name": "Nidoran♀",
+    "name": {
+      "en": "Nidoran♀",
+      "fr": "Nidoran♀"
+    },
     "image": "cPK_20_001660_00_NIDORAN%E2%99%80_S.webp",
     "packs": [
       "Lugia"
@@ -2262,7 +2931,10 @@
     "set": "A4",
     "number": 224,
     "rarity": "S",
-    "name": "Nidorina",
+    "name": {
+      "en": "Nidorina",
+      "fr": "Nidorina"
+    },
     "image": "cPK_20_001670_00_NIDORINA_S.webp",
     "packs": [
       "Lugia"
@@ -2272,7 +2944,10 @@
     "set": "A4",
     "number": 225,
     "rarity": "S",
-    "name": "Nidoqueen",
+    "name": {
+      "en": "Nidoqueen",
+      "fr": "Nidoqueen"
+    },
     "image": "cPK_20_001680_01_NIDOQUEEN_S.webp",
     "packs": [
       "Lugia"
@@ -2282,7 +2957,10 @@
     "set": "A4",
     "number": 226,
     "rarity": "S",
-    "name": "Nidoran♂",
+    "name": {
+      "en": "Nidoran♂",
+      "fr": "Nidoran♂"
+    },
     "image": "cPK_20_001690_00_NIDORAN%E2%99%82_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2292,7 +2970,10 @@
     "set": "A4",
     "number": 227,
     "rarity": "S",
-    "name": "Nidorino",
+    "name": {
+      "en": "Nidorino",
+      "fr": "Nidorino"
+    },
     "image": "cPK_20_001700_00_NIDORINO_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2302,7 +2983,10 @@
     "set": "A4",
     "number": 228,
     "rarity": "S",
-    "name": "Nidoking",
+    "name": {
+      "en": "Nidoking",
+      "fr": "Nidoking"
+    },
     "image": "cPK_20_001710_01_NIDOKING_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2312,7 +2996,10 @@
     "set": "A4",
     "number": 229,
     "rarity": "S",
-    "name": "Sneasel",
+    "name": {
+      "en": "Sneasel",
+      "fr": "Farfuret"
+    },
     "image": "cPK_20_009710_00_NYULA_S.webp",
     "packs": [
       "Lugia"
@@ -2322,7 +3009,10 @@
     "set": "A4",
     "number": 230,
     "rarity": "S",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_20_004050_00_BERORINGA_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2332,7 +3022,10 @@
     "set": "A4",
     "number": 231,
     "rarity": "S",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_20_009900_00_EIEVUI_S.webp",
     "packs": [
       "Ho-Oh"
@@ -2342,7 +3035,10 @@
     "set": "A4",
     "number": 232,
     "rarity": "SSR",
-    "name": "Yanmega ex",
+    "name": {
+      "en": "Yanmega ex",
+      "fr": "Yanmega-ex"
+    },
     "image": "cPK_20_002880_02_MEGAYANMAex_SSR.webp",
     "packs": [
       "Ho-Oh"
@@ -2352,7 +3048,10 @@
     "set": "A4",
     "number": 233,
     "rarity": "SSR",
-    "name": "Leafeon ex",
+    "name": {
+      "en": "Leafeon ex",
+      "fr": "Phyllali-ex"
+    },
     "image": "cPK_20_004340_02_LEAFIAex_SSR.webp",
     "packs": [
       "Ho-Oh"
@@ -2362,7 +3061,10 @@
     "set": "A4",
     "number": 234,
     "rarity": "SSR",
-    "name": "Gyarados ex",
+    "name": {
+      "en": "Gyarados ex",
+      "fr": "Léviator-ex"
+    },
     "image": "cPK_20_002320_01_GYARADOSex_SSR.webp",
     "packs": [
       "Lugia"
@@ -2372,7 +3074,10 @@
     "set": "A4",
     "number": 235,
     "rarity": "SSR",
-    "name": "Glaceon ex",
+    "name": {
+      "en": "Glaceon ex",
+      "fr": "Givrali-ex"
+    },
     "image": "cPK_20_004460_02_GLACIAex_SSR.webp",
     "packs": [
       "Lugia"
@@ -2382,7 +3087,10 @@
     "set": "A4",
     "number": 236,
     "rarity": "SSR",
-    "name": "Pachirisu ex",
+    "name": {
+      "en": "Pachirisu ex",
+      "fr": "Pachirisu-ex"
+    },
     "image": "cPK_20_003420_02_PACHIRISUex_SSR.webp",
     "packs": [
       "Lugia"
@@ -2392,7 +3100,10 @@
     "set": "A4",
     "number": 237,
     "rarity": "SSR",
-    "name": "Mismagius ex",
+    "name": {
+      "en": "Mismagius ex",
+      "fr": "Magirêve-ex"
+    },
     "image": "cPK_20_003480_02_MUMARGIex_SSR.webp",
     "packs": [
       "Ho-Oh"
@@ -2402,7 +3113,10 @@
     "set": "A4",
     "number": 238,
     "rarity": "SSR",
-    "name": "Weavile ex",
+    "name": {
+      "en": "Weavile ex",
+      "fr": "Dimoret-ex"
+    },
     "image": "cPK_20_003800_02_MANYULAex_SSR.webp",
     "packs": [
       "Lugia"
@@ -2412,7 +3126,10 @@
     "set": "A4",
     "number": 239,
     "rarity": "SSR",
-    "name": "Lickilicky ex",
+    "name": {
+      "en": "Lickilicky ex",
+      "fr": "Coudlangue-ex"
+    },
     "image": "cPK_20_004060_02_BEROBELTex_SSR.webp",
     "packs": [
       "Ho-Oh"
@@ -2422,7 +3139,10 @@
     "set": "A4",
     "number": 240,
     "rarity": "UR",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "image": "cPK_20_008900_02_HOUOUex_UR.webp",
     "packs": [
       "Lugia",
@@ -2433,7 +3153,10 @@
     "set": "A4",
     "number": 241,
     "rarity": "UR",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "image": "cPK_20_010050_02_LUGIAex_UR.webp",
     "packs": [
       "Lugia",

--- a/dist/cards/A4a.json
+++ b/dist/cards/A4a.json
@@ -3,7 +3,10 @@
     "set": "A4a",
     "number": 1,
     "rarity": "C",
-    "name": "Hoppip",
+    "name": {
+      "en": "Hoppip",
+      "fr": "Granivol"
+    },
     "image": "cPK_10_010220_00_HANECCO_C.webp",
     "packs": [
       "Secluded"
@@ -13,7 +16,10 @@
     "set": "A4a",
     "number": 2,
     "rarity": "U",
-    "name": "Skiploom",
+    "name": {
+      "en": "Skiploom",
+      "fr": "Floravol"
+    },
     "image": "cPK_10_010230_00_POPOCCO_U.webp",
     "packs": [
       "Secluded"
@@ -23,7 +29,10 @@
     "set": "A4a",
     "number": 3,
     "rarity": "RR",
-    "name": "Jumpluff ex",
+    "name": {
+      "en": "Jumpluff ex",
+      "fr": "Cotovol-ex"
+    },
     "image": "cPK_10_010240_00_WATACCOex_RR.webp",
     "packs": [
       "Secluded"
@@ -33,7 +42,10 @@
     "set": "A4a",
     "number": 4,
     "rarity": "C",
-    "name": "Sunkern",
+    "name": {
+      "en": "Sunkern",
+      "fr": "Tournegrin"
+    },
     "image": "cPK_10_010250_00_HIMANUTS_C.webp",
     "packs": [
       "Secluded"
@@ -43,7 +55,10 @@
     "set": "A4a",
     "number": 5,
     "rarity": "U",
-    "name": "Sunflora",
+    "name": {
+      "en": "Sunflora",
+      "fr": "Héliatronc"
+    },
     "image": "cPK_10_010260_00_KIMAWARI_U.webp",
     "packs": [
       "Secluded"
@@ -53,7 +68,10 @@
     "set": "A4a",
     "number": 6,
     "rarity": "R",
-    "name": "Celebi",
+    "name": {
+      "en": "Celebi",
+      "fr": "Celebi"
+    },
     "image": "cPK_10_010270_00_CELEBI_R.webp",
     "packs": [
       "Secluded"
@@ -63,7 +81,10 @@
     "set": "A4a",
     "number": 7,
     "rarity": "C",
-    "name": "Durant",
+    "name": {
+      "en": "Durant",
+      "fr": "Fermite"
+    },
     "image": "cPK_10_010280_00_AIANT_C.webp",
     "packs": [
       "Secluded"
@@ -73,7 +94,10 @@
     "set": "A4a",
     "number": 8,
     "rarity": "C",
-    "name": "Slugma",
+    "name": {
+      "en": "Slugma",
+      "fr": "Limagma"
+    },
     "image": "cPK_10_010290_00_MAGMAG_C.webp",
     "packs": [
       "Secluded"
@@ -83,7 +107,10 @@
     "set": "A4a",
     "number": 9,
     "rarity": "U",
-    "name": "Magcargo",
+    "name": {
+      "en": "Magcargo",
+      "fr": "Volcaropod"
+    },
     "image": "cPK_10_010300_00_MAGCARGOT_U.webp",
     "packs": [
       "Secluded"
@@ -93,7 +120,10 @@
     "set": "A4a",
     "number": 10,
     "rarity": "RR",
-    "name": "Entei ex",
+    "name": {
+      "en": "Entei ex",
+      "fr": "Entei-ex"
+    },
     "image": "cPK_10_010210_00_ENTEIex_RR.webp",
     "packs": [
       "Secluded"
@@ -103,7 +133,10 @@
     "set": "A4a",
     "number": 11,
     "rarity": "C",
-    "name": "Fletchinder",
+    "name": {
+      "en": "Fletchinder",
+      "fr": "Braisillon"
+    },
     "image": "cPK_10_010310_00_HINOYAKOMA_C.webp",
     "packs": [
       "Secluded"
@@ -113,7 +146,10 @@
     "set": "A4a",
     "number": 12,
     "rarity": "U",
-    "name": "Talonflame",
+    "name": {
+      "en": "Talonflame",
+      "fr": "Flambusard"
+    },
     "image": "cPK_10_010320_00_FIARROW_U.webp",
     "packs": [
       "Secluded"
@@ -123,7 +159,10 @@
     "set": "A4a",
     "number": 13,
     "rarity": "C",
-    "name": "Poliwag",
+    "name": {
+      "en": "Poliwag",
+      "fr": "Ptitard"
+    },
     "image": "cPK_10_010330_00_NYOROMO_C.webp",
     "packs": [
       "Secluded"
@@ -133,7 +172,10 @@
     "set": "A4a",
     "number": 14,
     "rarity": "U",
-    "name": "Poliwhirl",
+    "name": {
+      "en": "Poliwhirl",
+      "fr": "Têtarte"
+    },
     "image": "cPK_10_010340_00_NYOROZO_U.webp",
     "packs": [
       "Secluded"
@@ -143,7 +185,10 @@
     "set": "A4a",
     "number": 15,
     "rarity": "C",
-    "name": "Tentacool",
+    "name": {
+      "en": "Tentacool",
+      "fr": "Tentacool"
+    },
     "image": "cPK_10_010350_00_MENOKURAGE_C.webp",
     "packs": [
       "Secluded"
@@ -153,7 +198,10 @@
     "set": "A4a",
     "number": 16,
     "rarity": "U",
-    "name": "Tentacruel",
+    "name": {
+      "en": "Tentacruel",
+      "fr": "Tentacruel"
+    },
     "image": "cPK_10_010360_00_DOKUKURAGE_U.webp",
     "packs": [
       "Secluded"
@@ -163,7 +211,10 @@
     "set": "A4a",
     "number": 17,
     "rarity": "C",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "image": "cPK_10_010370_00_YADON_C.webp",
     "packs": [
       "Secluded"
@@ -173,7 +224,10 @@
     "set": "A4a",
     "number": 18,
     "rarity": "U",
-    "name": "Slowking",
+    "name": {
+      "en": "Slowking",
+      "fr": "Roigada"
+    },
     "image": "cPK_10_010380_00_YADOKING_U.webp",
     "packs": [
       "Secluded"
@@ -183,7 +237,10 @@
     "set": "A4a",
     "number": 19,
     "rarity": "C",
-    "name": "Jynx",
+    "name": {
+      "en": "Jynx",
+      "fr": "Lippoutou"
+    },
     "image": "cPK_10_010390_00_ROUGELA_C.webp",
     "packs": [
       "Secluded"
@@ -193,7 +250,10 @@
     "set": "A4a",
     "number": 20,
     "rarity": "RR",
-    "name": "Suicune ex",
+    "name": {
+      "en": "Suicune ex",
+      "fr": "Suicune-ex"
+    },
     "image": "cPK_10_010400_00_SUICUNEex_RR.webp",
     "packs": [
       "Secluded"
@@ -203,7 +263,10 @@
     "set": "A4a",
     "number": 21,
     "rarity": "C",
-    "name": "Feebas",
+    "name": {
+      "en": "Feebas",
+      "fr": "Barpau"
+    },
     "image": "cPK_10_010410_00_HINBASS_C.webp",
     "packs": [
       "Secluded"
@@ -213,7 +276,10 @@
     "set": "A4a",
     "number": 22,
     "rarity": "R",
-    "name": "Milotic",
+    "name": {
+      "en": "Milotic",
+      "fr": "Milobellus"
+    },
     "image": "cPK_10_010120_00_MILOKAROSS_R.webp",
     "packs": [
       "Secluded"
@@ -223,7 +289,10 @@
     "set": "A4a",
     "number": 23,
     "rarity": "R",
-    "name": "Mantyke",
+    "name": {
+      "en": "Mantyke",
+      "fr": "Babimanta"
+    },
     "image": "cPK_10_010420_00_TAMANTA_R.webp",
     "packs": [
       "Secluded"
@@ -233,7 +302,10 @@
     "set": "A4a",
     "number": 24,
     "rarity": "C",
-    "name": "Cryogonal",
+    "name": {
+      "en": "Cryogonal",
+      "fr": "Hexagel"
+    },
     "image": "cPK_10_010430_00_FREEGEO_C.webp",
     "packs": [
       "Secluded"
@@ -243,7 +315,10 @@
     "set": "A4a",
     "number": 25,
     "rarity": "RR",
-    "name": "Raikou ex",
+    "name": {
+      "en": "Raikou ex",
+      "fr": "Raikou-ex"
+    },
     "image": "cPK_10_010440_00_RAIKOUex_RR.webp",
     "packs": [
       "Secluded"
@@ -253,7 +328,10 @@
     "set": "A4a",
     "number": 26,
     "rarity": "C",
-    "name": "Tynamo",
+    "name": {
+      "en": "Tynamo",
+      "fr": "Anchwatt"
+    },
     "image": "cPK_10_010450_00_SHIBISHIRASU_C.webp",
     "packs": [
       "Secluded"
@@ -263,7 +341,10 @@
     "set": "A4a",
     "number": 27,
     "rarity": "C",
-    "name": "Eelektrik",
+    "name": {
+      "en": "Eelektrik",
+      "fr": "Lampéroie"
+    },
     "image": "cPK_10_010460_00_SHIBIBEEL_C.webp",
     "packs": [
       "Secluded"
@@ -273,7 +354,10 @@
     "set": "A4a",
     "number": 28,
     "rarity": "U",
-    "name": "Eelektross",
+    "name": {
+      "en": "Eelektross",
+      "fr": "Ohmassacre"
+    },
     "image": "cPK_10_010470_00_SHIBIRUDON_U.webp",
     "packs": [
       "Secluded"
@@ -283,7 +367,10 @@
     "set": "A4a",
     "number": 29,
     "rarity": "C",
-    "name": "Stunfisk",
+    "name": {
+      "en": "Stunfisk",
+      "fr": "Limonde"
+    },
     "image": "cPK_10_010480_00_MAGGYO_C.webp",
     "packs": [
       "Secluded"
@@ -293,7 +380,10 @@
     "set": "A4a",
     "number": 30,
     "rarity": "C",
-    "name": "Yamper",
+    "name": {
+      "en": "Yamper",
+      "fr": "Voltoutou"
+    },
     "image": "cPK_10_010490_00_WANPACHI_C.webp",
     "packs": [
       "Secluded"
@@ -303,7 +393,10 @@
     "set": "A4a",
     "number": 31,
     "rarity": "R",
-    "name": "Boltund",
+    "name": {
+      "en": "Boltund",
+      "fr": "Fulgudog"
+    },
     "image": "cPK_10_010500_00_PULSEWAN_R.webp",
     "packs": [
       "Secluded"
@@ -313,7 +406,10 @@
     "set": "A4a",
     "number": 32,
     "rarity": "C",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_10_010510_00_MUMA_C.webp",
     "packs": [
       "Secluded"
@@ -323,7 +419,10 @@
     "set": "A4a",
     "number": 33,
     "rarity": "U",
-    "name": "Mismagius",
+    "name": {
+      "en": "Mismagius",
+      "fr": "Magirêve"
+    },
     "image": "cPK_10_010520_00_MUMARGI_U.webp",
     "packs": [
       "Secluded"
@@ -333,7 +432,10 @@
     "set": "A4a",
     "number": 34,
     "rarity": "C",
-    "name": "Galarian Corsola",
+    "name": {
+      "en": "Galarian Corsola",
+      "fr": "Corayon de Galar"
+    },
     "image": "cPK_10_010530_00_GALARSUNNYGO_C.webp",
     "packs": [
       "Secluded"
@@ -343,7 +445,10 @@
     "set": "A4a",
     "number": 35,
     "rarity": "R",
-    "name": "Galarian Cursola",
+    "name": {
+      "en": "Galarian Cursola",
+      "fr": "Corayôme de Galar"
+    },
     "image": "cPK_10_010540_00_GALARSUNIGOON_R.webp",
     "packs": [
       "Secluded"
@@ -353,7 +458,10 @@
     "set": "A4a",
     "number": 36,
     "rarity": "R",
-    "name": "Latias",
+    "name": {
+      "en": "Latias",
+      "fr": "Latias"
+    },
     "image": "cPK_10_010200_00_LATIAS_R.webp",
     "packs": [
       "Secluded"
@@ -363,7 +471,10 @@
     "set": "A4a",
     "number": 37,
     "rarity": "R",
-    "name": "Latios",
+    "name": {
+      "en": "Latios",
+      "fr": "Latios"
+    },
     "image": "cPK_10_010550_00_LATIOS_R.webp",
     "packs": [
       "Secluded"
@@ -373,7 +484,10 @@
     "set": "A4a",
     "number": 38,
     "rarity": "C",
-    "name": "Frillish",
+    "name": {
+      "en": "Frillish",
+      "fr": "Viskuse"
+    },
     "image": "cPK_10_010560_00_PURURILL_C.webp",
     "packs": [
       "Secluded"
@@ -383,7 +497,10 @@
     "set": "A4a",
     "number": 39,
     "rarity": "U",
-    "name": "Jellicent",
+    "name": {
+      "en": "Jellicent",
+      "fr": "Moyade"
+    },
     "image": "cPK_10_010570_00_BURUNGEL_U.webp",
     "packs": [
       "Secluded"
@@ -393,7 +510,10 @@
     "set": "A4a",
     "number": 40,
     "rarity": "C",
-    "name": "Diglett",
+    "name": {
+      "en": "Diglett",
+      "fr": "Taupiqueur"
+    },
     "image": "cPK_10_010580_00_DIGDA_C.webp",
     "packs": [
       "Secluded"
@@ -403,7 +523,10 @@
     "set": "A4a",
     "number": 41,
     "rarity": "U",
-    "name": "Dugtrio",
+    "name": {
+      "en": "Dugtrio",
+      "fr": "Triopikeur"
+    },
     "image": "cPK_10_010590_00_DUGTRIO_U.webp",
     "packs": [
       "Secluded"
@@ -413,7 +536,10 @@
     "set": "A4a",
     "number": 42,
     "rarity": "RR",
-    "name": "Poliwrath ex",
+    "name": {
+      "en": "Poliwrath ex",
+      "fr": "Tartard-ex"
+    },
     "image": "cPK_10_010600_00_NYOROBONex_RR.webp",
     "packs": [
       "Secluded"
@@ -423,7 +549,10 @@
     "set": "A4a",
     "number": 43,
     "rarity": "C",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_10_010190_00_GOMAZOU_C.webp",
     "packs": [
       "Secluded"
@@ -433,7 +562,10 @@
     "set": "A4a",
     "number": 44,
     "rarity": "U",
-    "name": "Donphan",
+    "name": {
+      "en": "Donphan",
+      "fr": "Donphan"
+    },
     "image": "cPK_10_010610_00_DONFAN_U.webp",
     "packs": [
       "Secluded"
@@ -443,7 +575,10 @@
     "set": "A4a",
     "number": 45,
     "rarity": "C",
-    "name": "Relicanth",
+    "name": {
+      "en": "Relicanth",
+      "fr": "Relicanth"
+    },
     "image": "cPK_10_010620_00_GLANTH_C.webp",
     "packs": [
       "Secluded"
@@ -453,7 +588,10 @@
     "set": "A4a",
     "number": 46,
     "rarity": "C",
-    "name": "Dwebble",
+    "name": {
+      "en": "Dwebble",
+      "fr": "Crabicoque"
+    },
     "image": "cPK_10_010630_00_ISHIZUMAI_C.webp",
     "packs": [
       "Secluded"
@@ -463,7 +601,10 @@
     "set": "A4a",
     "number": 47,
     "rarity": "U",
-    "name": "Crustle",
+    "name": {
+      "en": "Crustle",
+      "fr": "Crabaraque"
+    },
     "image": "cPK_10_010640_00_IWAPALACE_U.webp",
     "packs": [
       "Secluded"
@@ -473,7 +614,10 @@
     "set": "A4a",
     "number": 48,
     "rarity": "C",
-    "name": "Seviper",
+    "name": {
+      "en": "Seviper",
+      "fr": "Séviper"
+    },
     "image": "cPK_10_010650_00_HABUNAKE_C.webp",
     "packs": [
       "Secluded"
@@ -483,7 +627,10 @@
     "set": "A4a",
     "number": 49,
     "rarity": "C",
-    "name": "Zorua",
+    "name": {
+      "en": "Zorua",
+      "fr": "Zorua"
+    },
     "image": "cPK_10_010130_00_ZORUA_C.webp",
     "packs": [
       "Secluded"
@@ -493,7 +640,10 @@
     "set": "A4a",
     "number": 50,
     "rarity": "R",
-    "name": "Zoroark",
+    "name": {
+      "en": "Zoroark",
+      "fr": "Zoroark"
+    },
     "image": "cPK_10_010140_00_ZOROARK_R.webp",
     "packs": [
       "Secluded"
@@ -503,7 +653,10 @@
     "set": "A4a",
     "number": 51,
     "rarity": "C",
-    "name": "Inkay",
+    "name": {
+      "en": "Inkay",
+      "fr": "Sepiatop"
+    },
     "image": "cPK_10_010660_00_MAAIIKA_C.webp",
     "packs": [
       "Secluded"
@@ -513,7 +666,10 @@
     "set": "A4a",
     "number": 52,
     "rarity": "U",
-    "name": "Malamar",
+    "name": {
+      "en": "Malamar",
+      "fr": "Sepiatroce"
+    },
     "image": "cPK_10_010670_00_CALAMANERO_U.webp",
     "packs": [
       "Secluded"
@@ -523,7 +679,10 @@
     "set": "A4a",
     "number": 53,
     "rarity": "C",
-    "name": "Skrelp",
+    "name": {
+      "en": "Skrelp",
+      "fr": "Venalgue"
+    },
     "image": "cPK_10_010680_00_KUZUMO_C.webp",
     "packs": [
       "Secluded"
@@ -533,7 +692,10 @@
     "set": "A4a",
     "number": 54,
     "rarity": "C",
-    "name": "Dragalge",
+    "name": {
+      "en": "Dragalge",
+      "fr": "Kravarech"
+    },
     "image": "cPK_10_010690_00_DRAMIDORO_C.webp",
     "packs": [
       "Secluded"
@@ -543,7 +705,10 @@
     "set": "A4a",
     "number": 55,
     "rarity": "R",
-    "name": "Altaria",
+    "name": {
+      "en": "Altaria",
+      "fr": "Altaria"
+    },
     "image": "cPK_10_010700_00_TYLTALIS_R.webp",
     "packs": [
       "Secluded"
@@ -553,7 +718,10 @@
     "set": "A4a",
     "number": 56,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_10_010710_00_KAMONEGI_C.webp",
     "packs": [
       "Secluded"
@@ -563,7 +731,10 @@
     "set": "A4a",
     "number": 57,
     "rarity": "C",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_10_010720_00_BERORINGA_C.webp",
     "packs": [
       "Secluded"
@@ -573,7 +744,10 @@
     "set": "A4a",
     "number": 58,
     "rarity": "U",
-    "name": "Lickilicky",
+    "name": {
+      "en": "Lickilicky",
+      "fr": "Coudlangue"
+    },
     "image": "cPK_10_010730_00_BEROBELT_U.webp",
     "packs": [
       "Secluded"
@@ -583,7 +757,10 @@
     "set": "A4a",
     "number": 59,
     "rarity": "R",
-    "name": "Igglybuff",
+    "name": {
+      "en": "Igglybuff",
+      "fr": "Toudoudou"
+    },
     "image": "cPK_10_010740_00_PUPURIN_R.webp",
     "packs": [
       "Secluded"
@@ -593,7 +770,10 @@
     "set": "A4a",
     "number": 60,
     "rarity": "C",
-    "name": "Teddiursa",
+    "name": {
+      "en": "Teddiursa",
+      "fr": "Teddiursa"
+    },
     "image": "cPK_10_010750_00_HIMEGUMA_C.webp",
     "packs": [
       "Secluded"
@@ -603,7 +783,10 @@
     "set": "A4a",
     "number": 61,
     "rarity": "U",
-    "name": "Ursaring",
+    "name": {
+      "en": "Ursaring",
+      "fr": "Ursaring"
+    },
     "image": "cPK_10_010760_00_RINGUMA_U.webp",
     "packs": [
       "Secluded"
@@ -613,7 +796,10 @@
     "set": "A4a",
     "number": 62,
     "rarity": "U",
-    "name": "Miltank",
+    "name": {
+      "en": "Miltank",
+      "fr": "Écrémeuh"
+    },
     "image": "cPK_10_010180_00_MILTANK_U.webp",
     "packs": [
       "Secluded"
@@ -623,7 +809,10 @@
     "set": "A4a",
     "number": 63,
     "rarity": "R",
-    "name": "Azurill",
+    "name": {
+      "en": "Azurill",
+      "fr": "Azurill"
+    },
     "image": "cPK_10_010770_00_RURIRI_R.webp",
     "packs": [
       "Secluded"
@@ -633,7 +822,10 @@
     "set": "A4a",
     "number": 64,
     "rarity": "C",
-    "name": "Swablu",
+    "name": {
+      "en": "Swablu",
+      "fr": "Tylton"
+    },
     "image": "cPK_10_010780_00_TYLTTO_C.webp",
     "packs": [
       "Secluded"
@@ -643,7 +835,10 @@
     "set": "A4a",
     "number": 65,
     "rarity": "U",
-    "name": "Zangoose",
+    "name": {
+      "en": "Zangoose",
+      "fr": "Mangriff"
+    },
     "image": "cPK_10_010790_00_ZANGOOSE_U.webp",
     "packs": [
       "Secluded"
@@ -653,7 +848,10 @@
     "set": "A4a",
     "number": 66,
     "rarity": "C",
-    "name": "Fletchling",
+    "name": {
+      "en": "Fletchling",
+      "fr": "Passerouge"
+    },
     "image": "cPK_10_010800_00_YAYAKOMA_C.webp",
     "packs": [
       "Secluded"
@@ -663,7 +861,10 @@
     "set": "A4a",
     "number": 67,
     "rarity": "U",
-    "name": "Inflatable Boat",
+    "name": {
+      "en": "Inflatable Boat",
+      "fr": "Canot Gonflable"
+    },
     "image": "cTR_10_000820_00_WHOTABOTO_U.webp",
     "packs": [
       "Secluded"
@@ -673,7 +874,10 @@
     "set": "A4a",
     "number": 68,
     "rarity": "U",
-    "name": "Memory Light",
+    "name": {
+      "en": "Memory Light",
+      "fr": "Lumière Mémoire"
+    },
     "image": "cTR_10_000830_00_MEMORYLIGHT_U.webp",
     "packs": [
       "Secluded"
@@ -683,7 +887,10 @@
     "set": "A4a",
     "number": 69,
     "rarity": "U",
-    "name": "Whitney",
+    "name": {
+      "en": "Whitney",
+      "fr": "Blanche"
+    },
     "image": "cTR_10_000840_00_AKANE_U.webp",
     "packs": [
       "Secluded"
@@ -693,7 +900,10 @@
     "set": "A4a",
     "number": 70,
     "rarity": "U",
-    "name": "Traveling Merchant",
+    "name": {
+      "en": "Traveling Merchant",
+      "fr": "Marchande Ambulante"
+    },
     "image": "cTR_10_000850_00_TABINOGYOUSHOUNIN_U.webp",
     "packs": [
       "Secluded"
@@ -703,7 +913,10 @@
     "set": "A4a",
     "number": 71,
     "rarity": "U",
-    "name": "Morty",
+    "name": {
+      "en": "Morty",
+      "fr": "Mortimer"
+    },
     "image": "cTR_10_000860_00_MATSUBA_U.webp",
     "packs": [
       "Secluded"
@@ -713,7 +926,10 @@
     "set": "A4a",
     "number": 72,
     "rarity": "AR",
-    "name": "Milotic",
+    "name": {
+      "en": "Milotic",
+      "fr": "Milobellus"
+    },
     "image": "cPK_20_010120_00_MILOKAROSS_AR.webp",
     "packs": [
       "Secluded"
@@ -723,7 +939,10 @@
     "set": "A4a",
     "number": 73,
     "rarity": "AR",
-    "name": "Stunfisk",
+    "name": {
+      "en": "Stunfisk",
+      "fr": "Limonde"
+    },
     "image": "cPK_20_010480_00_MAGGYO_AR.webp",
     "packs": [
       "Secluded"
@@ -733,7 +952,10 @@
     "set": "A4a",
     "number": 74,
     "rarity": "AR",
-    "name": "Yamper",
+    "name": {
+      "en": "Yamper",
+      "fr": "Voltoutou"
+    },
     "image": "cPK_20_010490_00_WANPACHI_AR.webp",
     "packs": [
       "Secluded"
@@ -743,7 +965,10 @@
     "set": "A4a",
     "number": 75,
     "rarity": "AR",
-    "name": "Latios",
+    "name": {
+      "en": "Latios",
+      "fr": "Latios"
+    },
     "image": "cPK_20_010550_00_LATIOS_AR.webp",
     "packs": [
       "Secluded"
@@ -753,7 +978,10 @@
     "set": "A4a",
     "number": 76,
     "rarity": "AR",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_20_010190_00_GOMAZOU_AR.webp",
     "packs": [
       "Secluded"
@@ -763,7 +991,10 @@
     "set": "A4a",
     "number": 77,
     "rarity": "AR",
-    "name": "Azurill",
+    "name": {
+      "en": "Azurill",
+      "fr": "Azurill"
+    },
     "image": "cPK_20_010770_00_RURIRI_AR.webp",
     "packs": [
       "Secluded"
@@ -773,7 +1004,10 @@
     "set": "A4a",
     "number": 78,
     "rarity": "SR",
-    "name": "Jumpluff ex",
+    "name": {
+      "en": "Jumpluff ex",
+      "fr": "Cotovol-ex"
+    },
     "image": "cPK_20_010240_00_WATACCOex_SR.webp",
     "packs": [
       "Secluded"
@@ -783,7 +1017,10 @@
     "set": "A4a",
     "number": 79,
     "rarity": "SR",
-    "name": "Entei ex",
+    "name": {
+      "en": "Entei ex",
+      "fr": "Entei-ex"
+    },
     "image": "cPK_20_010210_00_ENTEIex_SR.webp",
     "packs": [
       "Secluded"
@@ -793,7 +1030,10 @@
     "set": "A4a",
     "number": 80,
     "rarity": "SR",
-    "name": "Suicune ex",
+    "name": {
+      "en": "Suicune ex",
+      "fr": "Suicune-ex"
+    },
     "image": "cPK_20_010400_00_SUICUNEex_SR.webp",
     "packs": [
       "Secluded"
@@ -803,7 +1043,10 @@
     "set": "A4a",
     "number": 81,
     "rarity": "SR",
-    "name": "Raikou ex",
+    "name": {
+      "en": "Raikou ex",
+      "fr": "Raikou-ex"
+    },
     "image": "cPK_20_010440_00_RAIKOUex_SR.webp",
     "packs": [
       "Secluded"
@@ -813,7 +1056,10 @@
     "set": "A4a",
     "number": 82,
     "rarity": "SR",
-    "name": "Poliwrath ex",
+    "name": {
+      "en": "Poliwrath ex",
+      "fr": "Tartard-ex"
+    },
     "image": "cPK_20_010600_00_NYOROBONex_SR.webp",
     "packs": [
       "Secluded"
@@ -823,7 +1069,10 @@
     "set": "A4a",
     "number": 83,
     "rarity": "SR",
-    "name": "Whitney",
+    "name": {
+      "en": "Whitney",
+      "fr": "Blanche"
+    },
     "image": "cTR_20_000840_00_AKANE_SR.webp",
     "packs": [
       "Secluded"
@@ -833,7 +1082,10 @@
     "set": "A4a",
     "number": 84,
     "rarity": "SR",
-    "name": "Traveling Merchant",
+    "name": {
+      "en": "Traveling Merchant",
+      "fr": "Marchande Ambulante"
+    },
     "image": "cTR_20_000850_00_TABINOGYOUSHOUNIN_SR.webp",
     "packs": [
       "Secluded"
@@ -843,7 +1095,10 @@
     "set": "A4a",
     "number": 85,
     "rarity": "SR",
-    "name": "Morty",
+    "name": {
+      "en": "Morty",
+      "fr": "Mortimer"
+    },
     "image": "cTR_20_000860_00_MATSUBA_SR.webp",
     "packs": [
       "Secluded"
@@ -853,7 +1108,10 @@
     "set": "A4a",
     "number": 86,
     "rarity": "SAR",
-    "name": "Jumpluff ex",
+    "name": {
+      "en": "Jumpluff ex",
+      "fr": "Cotovol-ex"
+    },
     "image": "cPK_20_010240_01_WATACCOex_SAR.webp",
     "packs": [
       "Secluded"
@@ -863,7 +1121,10 @@
     "set": "A4a",
     "number": 87,
     "rarity": "SAR",
-    "name": "Entei ex",
+    "name": {
+      "en": "Entei ex",
+      "fr": "Entei-ex"
+    },
     "image": "cPK_20_010210_01_ENTEIex_SAR.webp",
     "packs": [
       "Secluded"
@@ -873,7 +1134,10 @@
     "set": "A4a",
     "number": 88,
     "rarity": "SAR",
-    "name": "Raikou ex",
+    "name": {
+      "en": "Raikou ex",
+      "fr": "Raikou-ex"
+    },
     "image": "cPK_20_010440_01_RAIKOUex_SAR.webp",
     "packs": [
       "Secluded"
@@ -883,7 +1147,10 @@
     "set": "A4a",
     "number": 89,
     "rarity": "SAR",
-    "name": "Poliwrath ex",
+    "name": {
+      "en": "Poliwrath ex",
+      "fr": "Tartard-ex"
+    },
     "image": "cPK_20_010600_01_NYOROBONex_SAR.webp",
     "packs": [
       "Secluded"
@@ -893,7 +1160,10 @@
     "set": "A4a",
     "number": 90,
     "rarity": "IM",
-    "name": "Suicune ex",
+    "name": {
+      "en": "Suicune ex",
+      "fr": "Suicune-ex"
+    },
     "image": "cPK_20_010400_01_SUICUNEex_IM.webp",
     "packs": [
       "Secluded"
@@ -903,7 +1173,10 @@
     "set": "A4a",
     "number": 91,
     "rarity": "S",
-    "name": "Chimchar",
+    "name": {
+      "en": "Chimchar",
+      "fr": "Ouisticram"
+    },
     "image": "cPK_20_003080_00_HIKOZARU_S.webp",
     "packs": [
       "Secluded"
@@ -913,7 +1186,10 @@
     "set": "A4a",
     "number": 92,
     "rarity": "S",
-    "name": "Monferno",
+    "name": {
+      "en": "Monferno",
+      "fr": "Chimpenfeu"
+    },
     "image": "cPK_20_003090_00_MOUKAZARU_S.webp",
     "packs": [
       "Secluded"
@@ -923,7 +1199,10 @@
     "set": "A4a",
     "number": 93,
     "rarity": "S",
-    "name": "Psyduck",
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    },
     "image": "cPK_20_000570_00_KODUCK_S.webp",
     "packs": [
       "Secluded"
@@ -933,7 +1212,10 @@
     "set": "A4a",
     "number": 94,
     "rarity": "S",
-    "name": "Golduck",
+    "name": {
+      "en": "Golduck",
+      "fr": "Akwakwak"
+    },
     "image": "cPK_20_000580_00_GOLDUCK_S.webp",
     "packs": [
       "Secluded"
@@ -943,7 +1225,10 @@
     "set": "A4a",
     "number": 95,
     "rarity": "S",
-    "name": "Krabby",
+    "name": {
+      "en": "Krabby",
+      "fr": "Krabby"
+    },
     "image": "cPK_20_000680_00_CRAB_S.webp",
     "packs": [
       "Secluded"
@@ -953,7 +1238,10 @@
     "set": "A4a",
     "number": 96,
     "rarity": "S",
-    "name": "Kingler",
+    "name": {
+      "en": "Kingler",
+      "fr": "Krabboss"
+    },
     "image": "cPK_20_000690_00_KINGLER_S.webp",
     "packs": [
       "Secluded"
@@ -963,7 +1251,10 @@
     "set": "A4a",
     "number": 97,
     "rarity": "S",
-    "name": "Pyukumuku",
+    "name": {
+      "en": "Pyukumuku",
+      "fr": "Concombaffe"
+    },
     "image": "cPK_20_006350_01_NAMAKOBUSHI_S.webp",
     "packs": [
       "Secluded"
@@ -973,7 +1264,10 @@
     "set": "A4a",
     "number": 98,
     "rarity": "S",
-    "name": "Gible",
+    "name": {
+      "en": "Gible",
+      "fr": "Griknot"
+    },
     "image": "cPK_20_004690_00_FUKAMARU_S.webp",
     "packs": [
       "Secluded"
@@ -983,7 +1277,10 @@
     "set": "A4a",
     "number": 99,
     "rarity": "S",
-    "name": "Gabite",
+    "name": {
+      "en": "Gabite",
+      "fr": "Carmache"
+    },
     "image": "cPK_20_004700_00_GABITE_S.webp",
     "packs": [
       "Secluded"
@@ -993,7 +1290,10 @@
     "set": "A4a",
     "number": 100,
     "rarity": "S",
-    "name": "Paldean Wooper",
+    "name": {
+      "en": "Paldean Wooper",
+      "fr": "Axoloto de Paldea"
+    },
     "image": "cPK_20_005620_00_PALDEAUPAH_S.webp",
     "packs": [
       "Secluded"
@@ -1003,7 +1303,10 @@
     "set": "A4a",
     "number": 101,
     "rarity": "SSR",
-    "name": "Infernape ex",
+    "name": {
+      "en": "Infernape ex",
+      "fr": "Simiabraz-ex"
+    },
     "image": "cPK_20_003100_02_GOUKAZARUex_SSR.webp",
     "packs": [
       "Secluded"
@@ -1013,7 +1316,10 @@
     "set": "A4a",
     "number": 102,
     "rarity": "SSR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_20_002450_03_MEWex_SSR.webp",
     "packs": [
       "Secluded"
@@ -1023,7 +1329,10 @@
     "set": "A4a",
     "number": 103,
     "rarity": "SSR",
-    "name": "Garchomp ex",
+    "name": {
+      "en": "Garchomp ex",
+      "fr": "Carchacrok-ex"
+    },
     "image": "cPK_20_004710_02_GABURIASex_SSR.webp",
     "packs": [
       "Secluded"
@@ -1033,7 +1342,10 @@
     "set": "A4a",
     "number": 104,
     "rarity": "SSR",
-    "name": "Paldean Clodsire ex",
+    "name": {
+      "en": "Paldean Clodsire ex",
+      "fr": "Terraiste de Paldea-ex"
+    },
     "image": "cPK_20_005630_02_PALDEADOOHex_SSR.webp",
     "packs": [
       "Secluded"
@@ -1043,7 +1355,10 @@
     "set": "A4a",
     "number": 105,
     "rarity": "UR",
-    "name": "Mantyke",
+    "name": {
+      "en": "Mantyke",
+      "fr": "Babimanta"
+    },
     "image": "cPK_20_010420_00_TAMANTA_UR.webp",
     "packs": [
       "Secluded"

--- a/dist/cards/A4b.json
+++ b/dist/cards/A4b.json
@@ -3,7 +3,10 @@
     "set": "A4b",
     "number": 1,
     "rarity": "C",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "image": "cPK_10_000010_00_FUSHIGIDANE_C.webp",
     "packs": [
       "Deluxe"
@@ -13,7 +16,10 @@
     "set": "A4b",
     "number": 2,
     "rarity": "C",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "image": "cPK_10_000010_01_FUSHIGIDANE_C.webp",
     "packs": [
       "Deluxe"
@@ -23,7 +29,10 @@
     "set": "A4b",
     "number": 3,
     "rarity": "U",
-    "name": "Ivysaur",
+    "name": {
+      "en": "Ivysaur",
+      "fr": "Herbizarre"
+    },
     "image": "cPK_10_000020_00_FUSHIGISOU_U.webp",
     "packs": [
       "Deluxe"
@@ -33,7 +42,10 @@
     "set": "A4b",
     "number": 4,
     "rarity": "U",
-    "name": "Ivysaur",
+    "name": {
+      "en": "Ivysaur",
+      "fr": "Herbizarre"
+    },
     "image": "cPK_10_000020_01_FUSHIGISOU_U.webp",
     "packs": [
       "Deluxe"
@@ -43,7 +55,10 @@
     "set": "A4b",
     "number": 5,
     "rarity": "RR",
-    "name": "Venusaur ex",
+    "name": {
+      "en": "Venusaur ex",
+      "fr": "Florizarre-ex"
+    },
     "image": "cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -53,7 +68,10 @@
     "set": "A4b",
     "number": 6,
     "rarity": "C",
-    "name": "Weedle",
+    "name": {
+      "en": "Weedle",
+      "fr": "Aspicot"
+    },
     "image": "cPK_10_005210_00_BEEDLE_C.webp",
     "packs": [
       "Deluxe"
@@ -63,7 +81,10 @@
     "set": "A4b",
     "number": 7,
     "rarity": "C",
-    "name": "Weedle",
+    "name": {
+      "en": "Weedle",
+      "fr": "Aspicot"
+    },
     "image": "cPK_10_005210_01_BEEDLE_C.webp",
     "packs": [
       "Deluxe"
@@ -73,7 +94,10 @@
     "set": "A4b",
     "number": 8,
     "rarity": "U",
-    "name": "Kakuna",
+    "name": {
+      "en": "Kakuna",
+      "fr": "Coconfort"
+    },
     "image": "cPK_10_005220_00_COCOON_U.webp",
     "packs": [
       "Deluxe"
@@ -83,7 +107,10 @@
     "set": "A4b",
     "number": 9,
     "rarity": "U",
-    "name": "Kakuna",
+    "name": {
+      "en": "Kakuna",
+      "fr": "Coconfort"
+    },
     "image": "cPK_10_005220_01_COCOON_U.webp",
     "packs": [
       "Deluxe"
@@ -93,7 +120,10 @@
     "set": "A4b",
     "number": 10,
     "rarity": "RR",
-    "name": "Beedrill ex",
+    "name": {
+      "en": "Beedrill ex",
+      "fr": "Dardargnan-ex"
+    },
     "image": "cPK_10_005230_00_SPEARex_RR.webp",
     "packs": [
       "Deluxe"
@@ -103,7 +133,10 @@
     "set": "A4b",
     "number": 11,
     "rarity": "C",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_10_000210_00_TAMATAMA_C.webp",
     "packs": [
       "Deluxe"
@@ -113,7 +146,10 @@
     "set": "A4b",
     "number": 12,
     "rarity": "C",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_10_000210_01_TAMATAMA_C.webp",
     "packs": [
       "Deluxe"
@@ -123,7 +159,10 @@
     "set": "A4b",
     "number": 13,
     "rarity": "RR",
-    "name": "Exeggutor ex",
+    "name": {
+      "en": "Exeggutor ex",
+      "fr": "Noadkoko-ex"
+    },
     "image": "cPK_10_000230_00_NASSYex_RR.webp",
     "packs": [
       "Deluxe"
@@ -133,7 +172,10 @@
     "set": "A4b",
     "number": 14,
     "rarity": "C",
-    "name": "Hoppip",
+    "name": {
+      "en": "Hoppip",
+      "fr": "Granivol"
+    },
     "image": "cPK_10_008690_00_HANECCO_C.webp",
     "packs": [
       "Deluxe"
@@ -143,7 +185,10 @@
     "set": "A4b",
     "number": 15,
     "rarity": "C",
-    "name": "Hoppip",
+    "name": {
+      "en": "Hoppip",
+      "fr": "Granivol"
+    },
     "image": "cPK_10_008690_01_HANECCO_C.webp",
     "packs": [
       "Deluxe"
@@ -153,7 +198,10 @@
     "set": "A4b",
     "number": 16,
     "rarity": "U",
-    "name": "Skiploom",
+    "name": {
+      "en": "Skiploom",
+      "fr": "Floravol"
+    },
     "image": "cPK_10_008700_00_POPOCCO_U.webp",
     "packs": [
       "Deluxe"
@@ -163,7 +211,10 @@
     "set": "A4b",
     "number": 17,
     "rarity": "U",
-    "name": "Skiploom",
+    "name": {
+      "en": "Skiploom",
+      "fr": "Floravol"
+    },
     "image": "cPK_10_008700_01_POPOCCO_U.webp",
     "packs": [
       "Deluxe"
@@ -173,7 +224,10 @@
     "set": "A4b",
     "number": 18,
     "rarity": "R",
-    "name": "Jumpluff",
+    "name": {
+      "en": "Jumpluff",
+      "fr": "Cotovol"
+    },
     "image": "cPK_10_008710_00_WATACCO_R.webp",
     "packs": [
       "Deluxe"
@@ -183,7 +237,10 @@
     "set": "A4b",
     "number": 19,
     "rarity": "R",
-    "name": "Jumpluff",
+    "name": {
+      "en": "Jumpluff",
+      "fr": "Cotovol"
+    },
     "image": "cPK_10_008710_01_WATACCO_R.webp",
     "packs": [
       "Deluxe"
@@ -193,7 +250,10 @@
     "set": "A4b",
     "number": 20,
     "rarity": "C",
-    "name": "Yanma",
+    "name": {
+      "en": "Yanma",
+      "fr": "Yanma"
+    },
     "image": "cPK_10_002870_00_YANYANMA_C.webp",
     "packs": [
       "Deluxe"
@@ -203,7 +263,10 @@
     "set": "A4b",
     "number": 21,
     "rarity": "C",
-    "name": "Yanma",
+    "name": {
+      "en": "Yanma",
+      "fr": "Yanma"
+    },
     "image": "cPK_10_002870_01_YANYANMA_C.webp",
     "packs": [
       "Deluxe"
@@ -213,7 +276,10 @@
     "set": "A4b",
     "number": 22,
     "rarity": "RR",
-    "name": "Yanmega ex",
+    "name": {
+      "en": "Yanmega ex",
+      "fr": "Yanmega-ex"
+    },
     "image": "cPK_10_002880_00_MEGAYANMAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -223,7 +289,10 @@
     "set": "A4b",
     "number": 23,
     "rarity": "RR",
-    "name": "Shuckle ex",
+    "name": {
+      "en": "Shuckle ex",
+      "fr": "Caratroc-ex"
+    },
     "image": "cPK_10_008770_00_TSUBOTSUBOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -233,7 +302,10 @@
     "set": "A4b",
     "number": 24,
     "rarity": "RR",
-    "name": "Celebi ex",
+    "name": {
+      "en": "Celebi ex",
+      "fr": "Celebi-ex"
+    },
     "image": "cPK_10_002170_00_CELEBIex_RR.webp",
     "packs": [
       "Deluxe"
@@ -243,7 +315,10 @@
     "set": "A4b",
     "number": 25,
     "rarity": "C",
-    "name": "Cherubi",
+    "name": {
+      "en": "Cherubi",
+      "fr": "Ceribou"
+    },
     "image": "cPK_10_008790_00_CHERINBO_C.webp",
     "packs": [
       "Deluxe"
@@ -253,7 +328,10 @@
     "set": "A4b",
     "number": 26,
     "rarity": "C",
-    "name": "Cherubi",
+    "name": {
+      "en": "Cherubi",
+      "fr": "Ceribou"
+    },
     "image": "cPK_10_008790_01_CHERINBO_C.webp",
     "packs": [
       "Deluxe"
@@ -263,7 +341,10 @@
     "set": "A4b",
     "number": 27,
     "rarity": "U",
-    "name": "Cherrim",
+    "name": {
+      "en": "Cherrim",
+      "fr": "Ceriflor"
+    },
     "image": "cPK_10_008800_00_CHERRIM_U.webp",
     "packs": [
       "Deluxe"
@@ -273,7 +354,10 @@
     "set": "A4b",
     "number": 28,
     "rarity": "U",
-    "name": "Cherrim",
+    "name": {
+      "en": "Cherrim",
+      "fr": "Ceriflor"
+    },
     "image": "cPK_10_008800_01_CHERRIM_U.webp",
     "packs": [
       "Deluxe"
@@ -283,7 +367,10 @@
     "set": "A4b",
     "number": 29,
     "rarity": "RR",
-    "name": "Leafeon ex",
+    "name": {
+      "en": "Leafeon ex",
+      "fr": "Phyllali-ex"
+    },
     "image": "cPK_10_004340_00_LEAFIAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -293,7 +380,10 @@
     "set": "A4b",
     "number": 30,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_10_003030_00_SHAYMIN_R.webp",
     "packs": [
       "Deluxe"
@@ -303,7 +393,10 @@
     "set": "A4b",
     "number": 31,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_10_003030_01_SHAYMIN_R.webp",
     "packs": [
       "Deluxe"
@@ -313,7 +406,10 @@
     "set": "A4b",
     "number": 32,
     "rarity": "C",
-    "name": "Snivy",
+    "name": {
+      "en": "Snivy",
+      "fr": "Vipélierre"
+    },
     "image": "cPK_10_002180_00_TSUTARJA_C.webp",
     "packs": [
       "Deluxe"
@@ -323,7 +419,10 @@
     "set": "A4b",
     "number": 33,
     "rarity": "C",
-    "name": "Snivy",
+    "name": {
+      "en": "Snivy",
+      "fr": "Vipélierre"
+    },
     "image": "cPK_10_002180_01_TSUTARJA_C.webp",
     "packs": [
       "Deluxe"
@@ -333,7 +432,10 @@
     "set": "A4b",
     "number": 34,
     "rarity": "U",
-    "name": "Servine",
+    "name": {
+      "en": "Servine",
+      "fr": "Lianaja"
+    },
     "image": "cPK_10_002190_00_JANOVY_U.webp",
     "packs": [
       "Deluxe"
@@ -343,7 +445,10 @@
     "set": "A4b",
     "number": 35,
     "rarity": "U",
-    "name": "Servine",
+    "name": {
+      "en": "Servine",
+      "fr": "Lianaja"
+    },
     "image": "cPK_10_002190_01_JANOVY_U.webp",
     "packs": [
       "Deluxe"
@@ -353,7 +458,10 @@
     "set": "A4b",
     "number": 36,
     "rarity": "R",
-    "name": "Serperior",
+    "name": {
+      "en": "Serperior",
+      "fr": "Majaspic"
+    },
     "image": "cPK_10_002200_00_JALORDA_R.webp",
     "packs": [
       "Deluxe"
@@ -363,7 +471,10 @@
     "set": "A4b",
     "number": 37,
     "rarity": "R",
-    "name": "Serperior",
+    "name": {
+      "en": "Serperior",
+      "fr": "Majaspic"
+    },
     "image": "cPK_10_002200_01_JALORDA_R.webp",
     "packs": [
       "Deluxe"
@@ -373,7 +484,10 @@
     "set": "A4b",
     "number": 38,
     "rarity": "C",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_10_005910_00_MOKUROH_C.webp",
     "packs": [
       "Deluxe"
@@ -383,7 +497,10 @@
     "set": "A4b",
     "number": 39,
     "rarity": "C",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_10_005910_01_MOKUROH_C.webp",
     "packs": [
       "Deluxe"
@@ -393,7 +510,10 @@
     "set": "A4b",
     "number": 40,
     "rarity": "U",
-    "name": "Dartrix",
+    "name": {
+      "en": "Dartrix",
+      "fr": "Efflèche"
+    },
     "image": "cPK_10_005920_00_FUKUTHROW_U.webp",
     "packs": [
       "Deluxe"
@@ -403,7 +523,10 @@
     "set": "A4b",
     "number": 41,
     "rarity": "U",
-    "name": "Dartrix",
+    "name": {
+      "en": "Dartrix",
+      "fr": "Efflèche"
+    },
     "image": "cPK_10_005920_01_FUKUTHROW_U.webp",
     "packs": [
       "Deluxe"
@@ -413,7 +536,10 @@
     "set": "A4b",
     "number": 42,
     "rarity": "RR",
-    "name": "Decidueye ex",
+    "name": {
+      "en": "Decidueye ex",
+      "fr": "Archéduc-ex"
+    },
     "image": "cPK_10_005930_00_JUNAIPERex_RR.webp",
     "packs": [
       "Deluxe"
@@ -423,7 +549,10 @@
     "set": "A4b",
     "number": 43,
     "rarity": "RR",
-    "name": "Dhelmise ex",
+    "name": {
+      "en": "Dhelmise ex",
+      "fr": "Sinistrail-ex"
+    },
     "image": "cPK_10_006040_00_DADARINex_RR.webp",
     "packs": [
       "Deluxe"
@@ -433,7 +562,10 @@
     "set": "A4b",
     "number": 44,
     "rarity": "RR",
-    "name": "Buzzwole ex",
+    "name": {
+      "en": "Buzzwole ex",
+      "fr": "Mouscoto-ex"
+    },
     "image": "cPK_10_007480_00_MASSIVOONex_RR.webp",
     "packs": [
       "Deluxe"
@@ -443,7 +575,10 @@
     "set": "A4b",
     "number": 45,
     "rarity": "U",
-    "name": "Pheromosa",
+    "name": {
+      "en": "Pheromosa",
+      "fr": "Cancrelove"
+    },
     "image": "cPK_10_007490_00_PHEROACHE_U.webp",
     "packs": [
       "Deluxe"
@@ -453,7 +588,10 @@
     "set": "A4b",
     "number": 46,
     "rarity": "U",
-    "name": "Pheromosa",
+    "name": {
+      "en": "Pheromosa",
+      "fr": "Cancrelove"
+    },
     "image": "cPK_10_007490_01_PHEROACHE_U.webp",
     "packs": [
       "Deluxe"
@@ -463,7 +601,10 @@
     "set": "A4b",
     "number": 47,
     "rarity": "C",
-    "name": "Kartana",
+    "name": {
+      "en": "Kartana",
+      "fr": "Katagami"
+    },
     "image": "cPK_10_007250_00_KAMITURUGI_C.webp",
     "packs": [
       "Deluxe"
@@ -473,7 +614,10 @@
     "set": "A4b",
     "number": 48,
     "rarity": "C",
-    "name": "Kartana",
+    "name": {
+      "en": "Kartana",
+      "fr": "Katagami"
+    },
     "image": "cPK_10_007250_01_KAMITURUGI_C.webp",
     "packs": [
       "Deluxe"
@@ -483,7 +627,10 @@
     "set": "A4b",
     "number": 49,
     "rarity": "C",
-    "name": "Sprigatito",
+    "name": {
+      "en": "Sprigatito",
+      "fr": "Poussacha"
+    },
     "image": "cPK_10_005080_00_NYAHOJA_C.webp",
     "packs": [
       "Deluxe"
@@ -493,7 +640,10 @@
     "set": "A4b",
     "number": 50,
     "rarity": "C",
-    "name": "Sprigatito",
+    "name": {
+      "en": "Sprigatito",
+      "fr": "Poussacha"
+    },
     "image": "cPK_10_005080_01_NYAHOJA_C.webp",
     "packs": [
       "Deluxe"
@@ -503,7 +653,10 @@
     "set": "A4b",
     "number": 51,
     "rarity": "U",
-    "name": "Floragato",
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    },
     "image": "cPK_10_005250_00_NYAROTE_U.webp",
     "packs": [
       "Deluxe"
@@ -513,7 +666,10 @@
     "set": "A4b",
     "number": 52,
     "rarity": "U",
-    "name": "Floragato",
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    },
     "image": "cPK_10_005250_01_NYAROTE_U.webp",
     "packs": [
       "Deluxe"
@@ -523,7 +679,10 @@
     "set": "A4b",
     "number": 53,
     "rarity": "R",
-    "name": "Meowscarada",
+    "name": {
+      "en": "Meowscarada",
+      "fr": "Miascarade"
+    },
     "image": "cPK_10_005260_00_MASQUERNYA_R.webp",
     "packs": [
       "Deluxe"
@@ -533,7 +692,10 @@
     "set": "A4b",
     "number": 54,
     "rarity": "R",
-    "name": "Meowscarada",
+    "name": {
+      "en": "Meowscarada",
+      "fr": "Miascarade"
+    },
     "image": "cPK_10_005260_01_MASQUERNYA_R.webp",
     "packs": [
       "Deluxe"
@@ -543,7 +705,10 @@
     "set": "A4b",
     "number": 55,
     "rarity": "C",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_10_000330_00_HITOKAGE_C.webp",
     "packs": [
       "Deluxe"
@@ -553,7 +718,10 @@
     "set": "A4b",
     "number": 56,
     "rarity": "C",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_10_000330_01_HITOKAGE_C.webp",
     "packs": [
       "Deluxe"
@@ -563,7 +731,10 @@
     "set": "A4b",
     "number": 57,
     "rarity": "U",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "image": "cPK_10_000340_00_LIZARDO_U.webp",
     "packs": [
       "Deluxe"
@@ -573,7 +744,10 @@
     "set": "A4b",
     "number": 58,
     "rarity": "U",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "image": "cPK_10_000340_01_LIZARDO_U.webp",
     "packs": [
       "Deluxe"
@@ -583,7 +757,10 @@
     "set": "A4b",
     "number": 59,
     "rarity": "RR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_10_000360_00_LIZARDONex_RR.webp",
     "packs": [
       "Deluxe"
@@ -593,7 +770,10 @@
     "set": "A4b",
     "number": 60,
     "rarity": "RR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_10_005290_00_LIZARDONex_RR.webp",
     "packs": [
       "Deluxe"
@@ -603,7 +783,10 @@
     "set": "A4b",
     "number": 61,
     "rarity": "C",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_10_000390_00_GARDIE_C.webp",
     "packs": [
       "Deluxe"
@@ -613,7 +796,10 @@
     "set": "A4b",
     "number": 62,
     "rarity": "C",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_10_000390_01_GARDIE_C.webp",
     "packs": [
       "Deluxe"
@@ -623,7 +809,10 @@
     "set": "A4b",
     "number": 63,
     "rarity": "RR",
-    "name": "Arcanine ex",
+    "name": {
+      "en": "Arcanine ex",
+      "fr": "Arcanin-ex"
+    },
     "image": "cPK_10_000410_00_WINDIEex_RR.webp",
     "packs": [
       "Deluxe"
@@ -633,7 +822,10 @@
     "set": "A4b",
     "number": 64,
     "rarity": "R",
-    "name": "Flareon",
+    "name": {
+      "en": "Flareon",
+      "fr": "Pyroli"
+    },
     "image": "cPK_10_008040_00_BOOSTER_R.webp",
     "packs": [
       "Deluxe"
@@ -643,7 +835,10 @@
     "set": "A4b",
     "number": 65,
     "rarity": "R",
-    "name": "Flareon",
+    "name": {
+      "en": "Flareon",
+      "fr": "Pyroli"
+    },
     "image": "cPK_10_008040_01_BOOSTER_R.webp",
     "packs": [
       "Deluxe"
@@ -653,7 +848,10 @@
     "set": "A4b",
     "number": 66,
     "rarity": "RR",
-    "name": "Flareon ex",
+    "name": {
+      "en": "Flareon ex",
+      "fr": "Pyroli-ex"
+    },
     "image": "cPK_10_008050_00_BOOSTERex_RR.webp",
     "packs": [
       "Deluxe"
@@ -663,7 +861,10 @@
     "set": "A4b",
     "number": 67,
     "rarity": "RR",
-    "name": "Moltres ex",
+    "name": {
+      "en": "Moltres ex",
+      "fr": "Sulfura-ex"
+    },
     "image": "cPK_10_000470_00_FIREex_RR.webp",
     "packs": [
       "Deluxe"
@@ -673,7 +874,10 @@
     "set": "A4b",
     "number": 68,
     "rarity": "RR",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "image": "cPK_10_008900_00_HOUOUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -683,7 +887,10 @@
     "set": "A4b",
     "number": 69,
     "rarity": "C",
-    "name": "Torkoal",
+    "name": {
+      "en": "Torkoal",
+      "fr": "Chartor"
+    },
     "image": "cPK_10_008060_00_COTOISE_C.webp",
     "packs": [
       "Deluxe"
@@ -693,7 +900,10 @@
     "set": "A4b",
     "number": 70,
     "rarity": "C",
-    "name": "Torkoal",
+    "name": {
+      "en": "Torkoal",
+      "fr": "Chartor"
+    },
     "image": "cPK_10_008060_01_COTOISE_C.webp",
     "packs": [
       "Deluxe"
@@ -703,7 +913,10 @@
     "set": "A4b",
     "number": 71,
     "rarity": "C",
-    "name": "Chimchar",
+    "name": {
+      "en": "Chimchar",
+      "fr": "Ouisticram"
+    },
     "image": "cPK_10_003080_00_HIKOZARU_C.webp",
     "packs": [
       "Deluxe"
@@ -713,7 +926,10 @@
     "set": "A4b",
     "number": 72,
     "rarity": "C",
-    "name": "Chimchar",
+    "name": {
+      "en": "Chimchar",
+      "fr": "Ouisticram"
+    },
     "image": "cPK_10_003080_01_HIKOZARU_C.webp",
     "packs": [
       "Deluxe"
@@ -723,7 +939,10 @@
     "set": "A4b",
     "number": 73,
     "rarity": "U",
-    "name": "Monferno",
+    "name": {
+      "en": "Monferno",
+      "fr": "Chimpenfeu"
+    },
     "image": "cPK_10_003090_00_MOUKAZARU_U.webp",
     "packs": [
       "Deluxe"
@@ -733,7 +952,10 @@
     "set": "A4b",
     "number": 74,
     "rarity": "U",
-    "name": "Monferno",
+    "name": {
+      "en": "Monferno",
+      "fr": "Chimpenfeu"
+    },
     "image": "cPK_10_003090_01_MOUKAZARU_U.webp",
     "packs": [
       "Deluxe"
@@ -743,7 +965,10 @@
     "set": "A4b",
     "number": 75,
     "rarity": "RR",
-    "name": "Infernape ex",
+    "name": {
+      "en": "Infernape ex",
+      "fr": "Simiabraz-ex"
+    },
     "image": "cPK_10_003100_00_GOUKAZARUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -753,7 +978,10 @@
     "set": "A4b",
     "number": 76,
     "rarity": "R",
-    "name": "Heatran",
+    "name": {
+      "en": "Heatran",
+      "fr": "Heatran"
+    },
     "image": "cPK_10_004370_00_HEATRAN_R.webp",
     "packs": [
       "Deluxe"
@@ -763,7 +991,10 @@
     "set": "A4b",
     "number": 77,
     "rarity": "R",
-    "name": "Heatran",
+    "name": {
+      "en": "Heatran",
+      "fr": "Heatran"
+    },
     "image": "cPK_10_004370_01_HEATRAN_R.webp",
     "packs": [
       "Deluxe"
@@ -773,7 +1004,10 @@
     "set": "A4b",
     "number": 78,
     "rarity": "C",
-    "name": "Litten",
+    "name": {
+      "en": "Litten",
+      "fr": "Flamiaou"
+    },
     "image": "cPK_10_006110_00_NYABBY_C.webp",
     "packs": [
       "Deluxe"
@@ -783,7 +1017,10 @@
     "set": "A4b",
     "number": 79,
     "rarity": "C",
-    "name": "Litten",
+    "name": {
+      "en": "Litten",
+      "fr": "Flamiaou"
+    },
     "image": "cPK_10_006110_01_NYABBY_C.webp",
     "packs": [
       "Deluxe"
@@ -793,7 +1030,10 @@
     "set": "A4b",
     "number": 80,
     "rarity": "U",
-    "name": "Torracat",
+    "name": {
+      "en": "Torracat",
+      "fr": "Matoufeu"
+    },
     "image": "cPK_10_006130_00_NYAHEAT_U.webp",
     "packs": [
       "Deluxe"
@@ -803,7 +1043,10 @@
     "set": "A4b",
     "number": 81,
     "rarity": "U",
-    "name": "Torracat",
+    "name": {
+      "en": "Torracat",
+      "fr": "Matoufeu"
+    },
     "image": "cPK_10_006130_01_NYAHEAT_U.webp",
     "packs": [
       "Deluxe"
@@ -813,7 +1056,10 @@
     "set": "A4b",
     "number": 82,
     "rarity": "RR",
-    "name": "Incineroar ex",
+    "name": {
+      "en": "Incineroar ex",
+      "fr": "Félinferno-ex"
+    },
     "image": "cPK_10_006140_00_GAOGAENex_RR.webp",
     "packs": [
       "Deluxe"
@@ -823,7 +1069,10 @@
     "set": "A4b",
     "number": 83,
     "rarity": "C",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "image": "cPK_10_000530_00_ZENIGAME_C.webp",
     "packs": [
       "Deluxe"
@@ -833,7 +1082,10 @@
     "set": "A4b",
     "number": 84,
     "rarity": "C",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "image": "cPK_10_000530_01_ZENIGAME_C.webp",
     "packs": [
       "Deluxe"
@@ -843,7 +1095,10 @@
     "set": "A4b",
     "number": 85,
     "rarity": "U",
-    "name": "Wartortle",
+    "name": {
+      "en": "Wartortle",
+      "fr": "Carabaffe"
+    },
     "image": "cPK_10_000540_00_KAMEIL_U.webp",
     "packs": [
       "Deluxe"
@@ -853,7 +1108,10 @@
     "set": "A4b",
     "number": 86,
     "rarity": "U",
-    "name": "Wartortle",
+    "name": {
+      "en": "Wartortle",
+      "fr": "Carabaffe"
+    },
     "image": "cPK_10_000540_01_KAMEIL_U.webp",
     "packs": [
       "Deluxe"
@@ -863,7 +1121,10 @@
     "set": "A4b",
     "number": 87,
     "rarity": "RR",
-    "name": "Blastoise ex",
+    "name": {
+      "en": "Blastoise ex",
+      "fr": "Tortank-ex"
+    },
     "image": "cPK_10_000560_00_KAMEXex_RR.webp",
     "packs": [
       "Deluxe"
@@ -873,7 +1134,10 @@
     "set": "A4b",
     "number": 88,
     "rarity": "C",
-    "name": "Horsea",
+    "name": {
+      "en": "Horsea",
+      "fr": "Hypotrempe"
+    },
     "image": "cPK_10_008970_00_TATTU_C.webp",
     "packs": [
       "Deluxe"
@@ -883,7 +1147,10 @@
     "set": "A4b",
     "number": 89,
     "rarity": "C",
-    "name": "Horsea",
+    "name": {
+      "en": "Horsea",
+      "fr": "Hypotrempe"
+    },
     "image": "cPK_10_008970_01_TATTU_C.webp",
     "packs": [
       "Deluxe"
@@ -893,7 +1160,10 @@
     "set": "A4b",
     "number": 90,
     "rarity": "U",
-    "name": "Seadra",
+    "name": {
+      "en": "Seadra",
+      "fr": "Hypocéan"
+    },
     "image": "cPK_10_008980_00_SEADRA_U.webp",
     "packs": [
       "Deluxe"
@@ -903,7 +1173,10 @@
     "set": "A4b",
     "number": 91,
     "rarity": "U",
-    "name": "Seadra",
+    "name": {
+      "en": "Seadra",
+      "fr": "Hypocéan"
+    },
     "image": "cPK_10_008980_01_SEADRA_U.webp",
     "packs": [
       "Deluxe"
@@ -913,7 +1186,10 @@
     "set": "A4b",
     "number": 92,
     "rarity": "RR",
-    "name": "Kingdra ex",
+    "name": {
+      "en": "Kingdra ex",
+      "fr": "Hyporoi-ex"
+    },
     "image": "cPK_10_008990_00_KINGDRAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -923,7 +1199,10 @@
     "set": "A4b",
     "number": 93,
     "rarity": "C",
-    "name": "Staryu",
+    "name": {
+      "en": "Staryu",
+      "fr": "Stari"
+    },
     "image": "cPK_10_000740_00_HITODEMAN_C.webp",
     "packs": [
       "Deluxe"
@@ -933,7 +1212,10 @@
     "set": "A4b",
     "number": 94,
     "rarity": "C",
-    "name": "Staryu",
+    "name": {
+      "en": "Staryu",
+      "fr": "Stari"
+    },
     "image": "cPK_10_000740_01_HITODEMAN_C.webp",
     "packs": [
       "Deluxe"
@@ -943,7 +1225,10 @@
     "set": "A4b",
     "number": 95,
     "rarity": "RR",
-    "name": "Starmie ex",
+    "name": {
+      "en": "Starmie ex",
+      "fr": "Staross-ex"
+    },
     "image": "cPK_10_000760_00_STARMIEex_RR.webp",
     "packs": [
       "Deluxe"
@@ -953,7 +1238,10 @@
     "set": "A4b",
     "number": 96,
     "rarity": "C",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_10_002310_00_KOIKING_C.webp",
     "packs": [
       "Deluxe"
@@ -963,7 +1251,10 @@
     "set": "A4b",
     "number": 97,
     "rarity": "C",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_10_002310_01_KOIKING_C.webp",
     "packs": [
       "Deluxe"
@@ -973,7 +1264,10 @@
     "set": "A4b",
     "number": 98,
     "rarity": "RR",
-    "name": "Gyarados ex",
+    "name": {
+      "en": "Gyarados ex",
+      "fr": "Léviator-ex"
+    },
     "image": "cPK_10_002320_00_GYARADOSex_RR.webp",
     "packs": [
       "Deluxe"
@@ -983,7 +1277,10 @@
     "set": "A4b",
     "number": 99,
     "rarity": "R",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_10_002330_00_SHOWERS_R.webp",
     "packs": [
       "Deluxe"
@@ -993,7 +1290,10 @@
     "set": "A4b",
     "number": 100,
     "rarity": "R",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "image": "cPK_10_002330_01_SHOWERS_R.webp",
     "packs": [
       "Deluxe"
@@ -1003,7 +1303,10 @@
     "set": "A4b",
     "number": 101,
     "rarity": "RR",
-    "name": "Articuno ex",
+    "name": {
+      "en": "Articuno ex",
+      "fr": "Artikodin-ex"
+    },
     "image": "cPK_10_000840_00_FREEZERex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1013,7 +1316,10 @@
     "set": "A4b",
     "number": 102,
     "rarity": "C",
-    "name": "Corphish",
+    "name": {
+      "en": "Corphish",
+      "fr": "Écrapince"
+    },
     "image": "cPK_10_009160_00_HEIGANI_C.webp",
     "packs": [
       "Deluxe"
@@ -1023,7 +1329,10 @@
     "set": "A4b",
     "number": 103,
     "rarity": "C",
-    "name": "Corphish",
+    "name": {
+      "en": "Corphish",
+      "fr": "Écrapince"
+    },
     "image": "cPK_10_009160_01_HEIGANI_C.webp",
     "packs": [
       "Deluxe"
@@ -1033,7 +1342,10 @@
     "set": "A4b",
     "number": 104,
     "rarity": "R",
-    "name": "Crawdaunt",
+    "name": {
+      "en": "Crawdaunt",
+      "fr": "Colhomard"
+    },
     "image": "cPK_10_009170_00_SHIZARIGER_R.webp",
     "packs": [
       "Deluxe"
@@ -1043,7 +1355,10 @@
     "set": "A4b",
     "number": 105,
     "rarity": "R",
-    "name": "Crawdaunt",
+    "name": {
+      "en": "Crawdaunt",
+      "fr": "Colhomard"
+    },
     "image": "cPK_10_009170_01_SHIZARIGER_R.webp",
     "packs": [
       "Deluxe"
@@ -1053,7 +1368,10 @@
     "set": "A4b",
     "number": 106,
     "rarity": "RR",
-    "name": "Glaceon ex",
+    "name": {
+      "en": "Glaceon ex",
+      "fr": "Givrali-ex"
+    },
     "image": "cPK_10_004460_00_GLACIAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1063,7 +1381,10 @@
     "set": "A4b",
     "number": 107,
     "rarity": "RR",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_10_003300_00_PALKIAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1073,7 +1394,10 @@
     "set": "A4b",
     "number": 108,
     "rarity": "U",
-    "name": "Manaphy",
+    "name": {
+      "en": "Manaphy",
+      "fr": "Manaphy"
+    },
     "image": "cPK_10_003310_00_MANAPHY_U.webp",
     "packs": [
       "Deluxe"
@@ -1083,7 +1407,10 @@
     "set": "A4b",
     "number": 109,
     "rarity": "U",
-    "name": "Manaphy",
+    "name": {
+      "en": "Manaphy",
+      "fr": "Manaphy"
+    },
     "image": "cPK_10_003310_01_MANAPHY_U.webp",
     "packs": [
       "Deluxe"
@@ -1093,7 +1420,10 @@
     "set": "A4b",
     "number": 110,
     "rarity": "C",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_10_000870_00_KEROMATSU_C.webp",
     "packs": [
       "Deluxe"
@@ -1103,7 +1433,10 @@
     "set": "A4b",
     "number": 111,
     "rarity": "C",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_10_000870_01_KEROMATSU_C.webp",
     "packs": [
       "Deluxe"
@@ -1113,7 +1446,10 @@
     "set": "A4b",
     "number": 112,
     "rarity": "U",
-    "name": "Frogadier",
+    "name": {
+      "en": "Frogadier",
+      "fr": "Croâporal"
+    },
     "image": "cPK_10_000880_00_GEKOGASHIRA_U.webp",
     "packs": [
       "Deluxe"
@@ -1123,7 +1459,10 @@
     "set": "A4b",
     "number": 113,
     "rarity": "U",
-    "name": "Frogadier",
+    "name": {
+      "en": "Frogadier",
+      "fr": "Croâporal"
+    },
     "image": "cPK_10_000880_01_GEKOGASHIRA_U.webp",
     "packs": [
       "Deluxe"
@@ -1133,7 +1472,10 @@
     "set": "A4b",
     "number": 114,
     "rarity": "R",
-    "name": "Greninja",
+    "name": {
+      "en": "Greninja",
+      "fr": "Amphinobi"
+    },
     "image": "cPK_10_000890_00_GEKKOUGA_R.webp",
     "packs": [
       "Deluxe"
@@ -1143,7 +1485,10 @@
     "set": "A4b",
     "number": 115,
     "rarity": "R",
-    "name": "Greninja",
+    "name": {
+      "en": "Greninja",
+      "fr": "Amphinobi"
+    },
     "image": "cPK_10_000890_01_GEKKOUGA_R.webp",
     "packs": [
       "Deluxe"
@@ -1153,7 +1498,10 @@
     "set": "A4b",
     "number": 116,
     "rarity": "C",
-    "name": "Popplio",
+    "name": {
+      "en": "Popplio",
+      "fr": "Otaquin"
+    },
     "image": "cPK_10_008170_00_ASHIMARI_C.webp",
     "packs": [
       "Deluxe"
@@ -1163,7 +1511,10 @@
     "set": "A4b",
     "number": 117,
     "rarity": "C",
-    "name": "Popplio",
+    "name": {
+      "en": "Popplio",
+      "fr": "Otaquin"
+    },
     "image": "cPK_10_008170_01_ASHIMARI_C.webp",
     "packs": [
       "Deluxe"
@@ -1173,7 +1524,10 @@
     "set": "A4b",
     "number": 118,
     "rarity": "C",
-    "name": "Brionne",
+    "name": {
+      "en": "Brionne",
+      "fr": "Otarlette"
+    },
     "image": "cPK_10_008180_00_OSYAMARI_C.webp",
     "packs": [
       "Deluxe"
@@ -1183,7 +1537,10 @@
     "set": "A4b",
     "number": 119,
     "rarity": "C",
-    "name": "Brionne",
+    "name": {
+      "en": "Brionne",
+      "fr": "Otarlette"
+    },
     "image": "cPK_10_008180_01_OSYAMARI_C.webp",
     "packs": [
       "Deluxe"
@@ -1193,7 +1550,10 @@
     "set": "A4b",
     "number": 120,
     "rarity": "RR",
-    "name": "Primarina ex",
+    "name": {
+      "en": "Primarina ex",
+      "fr": "Oratoria-ex"
+    },
     "image": "cPK_10_008190_00_ASHIRENEex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1203,7 +1563,10 @@
     "set": "A4b",
     "number": 121,
     "rarity": "RR",
-    "name": "Crabominable ex",
+    "name": {
+      "en": "Crabominable ex",
+      "fr": "Crabominable-ex"
+    },
     "image": "cPK_10_006300_00_KEKENKANIex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1213,7 +1576,10 @@
     "set": "A4b",
     "number": 122,
     "rarity": "C",
-    "name": "Wishiwashi",
+    "name": {
+      "en": "Wishiwashi",
+      "fr": "Froussardine"
+    },
     "image": "cPK_10_006310_00_YOWASHITANDOKUNOSUGATA_C.webp",
     "packs": [
       "Deluxe"
@@ -1223,7 +1589,10 @@
     "set": "A4b",
     "number": 123,
     "rarity": "C",
-    "name": "Wishiwashi",
+    "name": {
+      "en": "Wishiwashi",
+      "fr": "Froussardine"
+    },
     "image": "cPK_10_006310_01_YOWASHITANDOKUNOSUGATA_C.webp",
     "packs": [
       "Deluxe"
@@ -1233,7 +1602,10 @@
     "set": "A4b",
     "number": 124,
     "rarity": "RR",
-    "name": "Wishiwashi ex",
+    "name": {
+      "en": "Wishiwashi ex",
+      "fr": "Froussardine-ex"
+    },
     "image": "cPK_10_006320_00_YOWASHIMURETASUGATA_RR.webp",
     "packs": [
       "Deluxe"
@@ -1243,7 +1615,10 @@
     "set": "A4b",
     "number": 125,
     "rarity": "C",
-    "name": "Wiglett",
+    "name": {
+      "en": "Wiglett",
+      "fr": "Taupikeau"
+    },
     "image": "cPK_10_005370_00_UMIDIGDA_C.webp",
     "packs": [
       "Deluxe"
@@ -1253,7 +1628,10 @@
     "set": "A4b",
     "number": 126,
     "rarity": "C",
-    "name": "Wiglett",
+    "name": {
+      "en": "Wiglett",
+      "fr": "Taupikeau"
+    },
     "image": "cPK_10_005370_01_UMIDIGDA_C.webp",
     "packs": [
       "Deluxe"
@@ -1263,7 +1641,10 @@
     "set": "A4b",
     "number": 127,
     "rarity": "RR",
-    "name": "Wugtrio ex",
+    "name": {
+      "en": "Wugtrio ex",
+      "fr": "Triopikeau-ex"
+    },
     "image": "cPK_10_005380_00_UMITRIOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1273,7 +1654,10 @@
     "set": "A4b",
     "number": 128,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_10_000940_00_PIKACHU_C.webp",
     "packs": [
       "Deluxe"
@@ -1283,7 +1667,10 @@
     "set": "A4b",
     "number": 129,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_10_000940_01_PIKACHU_C.webp",
     "packs": [
       "Deluxe"
@@ -1293,7 +1680,10 @@
     "set": "A4b",
     "number": 130,
     "rarity": "RR",
-    "name": "Alolan Raichu ex",
+    "name": {
+      "en": "Alolan Raichu ex",
+      "fr": "Raichu de Alola-ex"
+    },
     "image": "cPK_10_006390_00_ALOLARAICHUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1303,7 +1693,10 @@
     "set": "A4b",
     "number": 131,
     "rarity": "RR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_10_000960_00_PIKACHUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1313,7 +1706,10 @@
     "set": "A4b",
     "number": 132,
     "rarity": "RR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_10_005410_00_PIKACHUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1323,7 +1719,10 @@
     "set": "A4b",
     "number": 133,
     "rarity": "C",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_10_000970_00_COIL_C.webp",
     "packs": [
       "Deluxe"
@@ -1333,7 +1732,10 @@
     "set": "A4b",
     "number": 134,
     "rarity": "C",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_10_000970_01_COIL_C.webp",
     "packs": [
       "Deluxe"
@@ -1343,7 +1745,10 @@
     "set": "A4b",
     "number": 135,
     "rarity": "R",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "image": "cPK_10_000980_00_RARECOIL_R.webp",
     "packs": [
       "Deluxe"
@@ -1353,7 +1758,10 @@
     "set": "A4b",
     "number": 136,
     "rarity": "R",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "image": "cPK_10_000980_01_RARECOIL_R.webp",
     "packs": [
       "Deluxe"
@@ -1363,7 +1771,10 @@
     "set": "A4b",
     "number": 137,
     "rarity": "R",
-    "name": "Magnezone",
+    "name": {
+      "en": "Magnezone",
+      "fr": "Magnézone"
+    },
     "image": "cPK_10_003340_00_JIBACOIL_R.webp",
     "packs": [
       "Deluxe"
@@ -1373,7 +1784,10 @@
     "set": "A4b",
     "number": 138,
     "rarity": "R",
-    "name": "Magnezone",
+    "name": {
+      "en": "Magnezone",
+      "fr": "Magnézone"
+    },
     "image": "cPK_10_003340_01_JIBACOIL_R.webp",
     "packs": [
       "Deluxe"
@@ -1383,7 +1797,10 @@
     "set": "A4b",
     "number": 139,
     "rarity": "RR",
-    "name": "Zapdos ex",
+    "name": {
+      "en": "Zapdos ex",
+      "fr": "Électhor-ex"
+    },
     "image": "cPK_10_001040_00_THUNDERex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1393,7 +1810,10 @@
     "set": "A4b",
     "number": 140,
     "rarity": "C",
-    "name": "Chinchou",
+    "name": {
+      "en": "Chinchou",
+      "fr": "Loupio"
+    },
     "image": "cPK_10_009200_00_CHONCHIE_C.webp",
     "packs": [
       "Deluxe"
@@ -1403,7 +1823,10 @@
     "set": "A4b",
     "number": 141,
     "rarity": "C",
-    "name": "Chinchou",
+    "name": {
+      "en": "Chinchou",
+      "fr": "Loupio"
+    },
     "image": "cPK_10_009200_01_CHONCHIE_C.webp",
     "packs": [
       "Deluxe"
@@ -1413,7 +1836,10 @@
     "set": "A4b",
     "number": 142,
     "rarity": "RR",
-    "name": "Lanturn ex",
+    "name": {
+      "en": "Lanturn ex",
+      "fr": "Lanturn-ex"
+    },
     "image": "cPK_10_009210_00_LANTERNex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1423,7 +1849,10 @@
     "set": "A4b",
     "number": 143,
     "rarity": "U",
-    "name": "Pachirisu",
+    "name": {
+      "en": "Pachirisu",
+      "fr": "Pachirisu"
+    },
     "image": "cPK_10_005060_00_PACHIRISU_U.webp",
     "packs": [
       "Deluxe"
@@ -1433,7 +1862,10 @@
     "set": "A4b",
     "number": 144,
     "rarity": "U",
-    "name": "Pachirisu",
+    "name": {
+      "en": "Pachirisu",
+      "fr": "Pachirisu"
+    },
     "image": "cPK_10_005060_01_PACHIRISU_U.webp",
     "packs": [
       "Deluxe"
@@ -1443,7 +1875,10 @@
     "set": "A4b",
     "number": 145,
     "rarity": "RR",
-    "name": "Pachirisu ex",
+    "name": {
+      "en": "Pachirisu ex",
+      "fr": "Pachirisu-ex"
+    },
     "image": "cPK_10_003420_00_PACHIRISUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1453,7 +1888,10 @@
     "set": "A4b",
     "number": 146,
     "rarity": "R",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006470_00_ODORIDORIPACHIPACHISTYLE_R.webp",
     "packs": [
       "Deluxe"
@@ -1463,7 +1901,10 @@
     "set": "A4b",
     "number": 147,
     "rarity": "R",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006470_01_ODORIDORIPACHIPACHISTYLE_R.webp",
     "packs": [
       "Deluxe"
@@ -1473,7 +1914,10 @@
     "set": "A4b",
     "number": 148,
     "rarity": "RR",
-    "name": "Tapu Koko ex",
+    "name": {
+      "en": "Tapu Koko ex",
+      "fr": "Tokorico-ex"
+    },
     "image": "cPK_10_007420_00_KAPU-KOKEKOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1483,7 +1927,10 @@
     "set": "A4b",
     "number": 149,
     "rarity": "R",
-    "name": "Zeraora",
+    "name": {
+      "en": "Zeraora",
+      "fr": "Zeraora"
+    },
     "image": "cPK_10_007410_00_ZERAORA_R.webp",
     "packs": [
       "Deluxe"
@@ -1493,7 +1940,10 @@
     "set": "A4b",
     "number": 150,
     "rarity": "R",
-    "name": "Zeraora",
+    "name": {
+      "en": "Zeraora",
+      "fr": "Zeraora"
+    },
     "image": "cPK_10_007410_01_ZERAORA_R.webp",
     "packs": [
       "Deluxe"
@@ -1503,7 +1953,10 @@
     "set": "A4b",
     "number": 151,
     "rarity": "C",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "image": "cPK_10_001200_00_GHOS_C.webp",
     "packs": [
       "Deluxe"
@@ -1513,7 +1966,10 @@
     "set": "A4b",
     "number": 152,
     "rarity": "C",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "image": "cPK_10_001200_01_GHOS_C.webp",
     "packs": [
       "Deluxe"
@@ -1523,7 +1979,10 @@
     "set": "A4b",
     "number": 153,
     "rarity": "U",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "image": "cPK_10_001210_00_GHOST_U.webp",
     "packs": [
       "Deluxe"
@@ -1533,7 +1992,10 @@
     "set": "A4b",
     "number": 154,
     "rarity": "U",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "image": "cPK_10_001210_01_GHOST_U.webp",
     "packs": [
       "Deluxe"
@@ -1543,7 +2005,10 @@
     "set": "A4b",
     "number": 155,
     "rarity": "RR",
-    "name": "Gengar ex",
+    "name": {
+      "en": "Gengar ex",
+      "fr": "Ectoplasma-ex"
+    },
     "image": "cPK_10_001230_00_GANGARex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1553,7 +2018,10 @@
     "set": "A4b",
     "number": 156,
     "rarity": "C",
-    "name": "Jynx",
+    "name": {
+      "en": "Jynx",
+      "fr": "Lippoutou"
+    },
     "image": "cPK_10_001270_00_ROUGELA_C.webp",
     "packs": [
       "Deluxe"
@@ -1563,7 +2031,10 @@
     "set": "A4b",
     "number": 157,
     "rarity": "C",
-    "name": "Jynx",
+    "name": {
+      "en": "Jynx",
+      "fr": "Lippoutou"
+    },
     "image": "cPK_10_001270_01_ROUGELA_C.webp",
     "packs": [
       "Deluxe"
@@ -1573,7 +2044,10 @@
     "set": "A4b",
     "number": 158,
     "rarity": "RR",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_10_001290_00_MEWTWOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1583,7 +2057,10 @@
     "set": "A4b",
     "number": 159,
     "rarity": "RR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_10_002450_00_MEWex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1593,7 +2070,10 @@
     "set": "A4b",
     "number": 160,
     "rarity": "RR",
-    "name": "Espeon ex",
+    "name": {
+      "en": "Espeon ex",
+      "fr": "Mentali-ex"
+    },
     "image": "cPK_10_009390_00_EIFIEex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1603,7 +2083,10 @@
     "set": "A4b",
     "number": 161,
     "rarity": "C",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_10_003470_00_MUMA_C.webp",
     "packs": [
       "Deluxe"
@@ -1613,7 +2096,10 @@
     "set": "A4b",
     "number": 162,
     "rarity": "C",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_10_003470_01_MUMA_C.webp",
     "packs": [
       "Deluxe"
@@ -1623,7 +2109,10 @@
     "set": "A4b",
     "number": 163,
     "rarity": "RR",
-    "name": "Mismagius ex",
+    "name": {
+      "en": "Mismagius ex",
+      "fr": "Magirêve-ex"
+    },
     "image": "cPK_10_003480_00_MUMARGIex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1633,7 +2122,10 @@
     "set": "A4b",
     "number": 164,
     "rarity": "C",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "image": "cPK_10_003490_00_RALTS_C.webp",
     "packs": [
       "Deluxe"
@@ -1643,7 +2135,10 @@
     "set": "A4b",
     "number": 165,
     "rarity": "C",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "image": "cPK_10_003490_01_RALTS_C.webp",
     "packs": [
       "Deluxe"
@@ -1653,7 +2148,10 @@
     "set": "A4b",
     "number": 166,
     "rarity": "C",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "image": "cPK_10_003500_00_KIRLIA_C.webp",
     "packs": [
       "Deluxe"
@@ -1663,7 +2161,10 @@
     "set": "A4b",
     "number": 167,
     "rarity": "C",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "image": "cPK_10_003500_01_KIRLIA_C.webp",
     "packs": [
       "Deluxe"
@@ -1673,7 +2174,10 @@
     "set": "A4b",
     "number": 168,
     "rarity": "R",
-    "name": "Gardevoir",
+    "name": {
+      "en": "Gardevoir",
+      "fr": "Gardevoir"
+    },
     "image": "cPK_10_001320_00_SIRNIGHT_R.webp",
     "packs": [
       "Deluxe"
@@ -1683,7 +2187,10 @@
     "set": "A4b",
     "number": 169,
     "rarity": "R",
-    "name": "Gardevoir",
+    "name": {
+      "en": "Gardevoir",
+      "fr": "Gardevoir"
+    },
     "image": "cPK_10_001320_01_SIRNIGHT_R.webp",
     "packs": [
       "Deluxe"
@@ -1693,7 +2200,10 @@
     "set": "A4b",
     "number": 170,
     "rarity": "R",
-    "name": "Giratina",
+    "name": {
+      "en": "Giratina",
+      "fr": "Giratina"
+    },
     "image": "cPK_10_003590_00_ORIGINGIRATINA_R.webp",
     "packs": [
       "Deluxe"
@@ -1703,7 +2213,10 @@
     "set": "A4b",
     "number": 171,
     "rarity": "R",
-    "name": "Giratina",
+    "name": {
+      "en": "Giratina",
+      "fr": "Giratina"
+    },
     "image": "cPK_10_003590_01_ORIGINGIRATINA_R.webp",
     "packs": [
       "Deluxe"
@@ -1713,7 +2226,10 @@
     "set": "A4b",
     "number": 172,
     "rarity": "RR",
-    "name": "Giratina ex",
+    "name": {
+      "en": "Giratina ex",
+      "fr": "Giratina-ex"
+    },
     "image": "cPK_10_005520_00_GIRATINAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1723,7 +2239,10 @@
     "set": "A4b",
     "number": 173,
     "rarity": "C",
-    "name": "Swirlix",
+    "name": {
+      "en": "Swirlix",
+      "fr": "Sucroquin"
+    },
     "image": "cPK_10_008250_00_PEROPPAFU_C.webp",
     "packs": [
       "Deluxe"
@@ -1733,7 +2252,10 @@
     "set": "A4b",
     "number": 174,
     "rarity": "C",
-    "name": "Swirlix",
+    "name": {
+      "en": "Swirlix",
+      "fr": "Sucroquin"
+    },
     "image": "cPK_10_008250_01_PEROPPAFU_C.webp",
     "packs": [
       "Deluxe"
@@ -1743,7 +2265,10 @@
     "set": "A4b",
     "number": 175,
     "rarity": "U",
-    "name": "Slurpuff",
+    "name": {
+      "en": "Slurpuff",
+      "fr": "Cupcanaille"
+    },
     "image": "cPK_10_008260_00_PEROREAM_U.webp",
     "packs": [
       "Deluxe"
@@ -1753,7 +2278,10 @@
     "set": "A4b",
     "number": 176,
     "rarity": "U",
-    "name": "Slurpuff",
+    "name": {
+      "en": "Slurpuff",
+      "fr": "Cupcanaille"
+    },
     "image": "cPK_10_008260_01_PEROREAM_U.webp",
     "packs": [
       "Deluxe"
@@ -1763,7 +2291,10 @@
     "set": "A4b",
     "number": 177,
     "rarity": "RR",
-    "name": "Sylveon ex",
+    "name": {
+      "en": "Sylveon ex",
+      "fr": "Nymphali-ex"
+    },
     "image": "cPK_10_008280_00_NYMPHIAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1773,7 +2304,10 @@
     "set": "A4b",
     "number": 178,
     "rarity": "U",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006580_00_ODORIDORIMAIMAISTYLE_U.webp",
     "packs": [
       "Deluxe"
@@ -1783,7 +2317,10 @@
     "set": "A4b",
     "number": 179,
     "rarity": "U",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_10_006580_01_ODORIDORIMAIMAISTYLE_U.webp",
     "packs": [
       "Deluxe"
@@ -1793,7 +2330,10 @@
     "set": "A4b",
     "number": 180,
     "rarity": "C",
-    "name": "Cosmog",
+    "name": {
+      "en": "Cosmog",
+      "fr": "Cosmog"
+    },
     "image": "cPK_10_006660_00_COSMOG_C.webp",
     "packs": [
       "Deluxe"
@@ -1803,7 +2343,10 @@
     "set": "A4b",
     "number": 181,
     "rarity": "C",
-    "name": "Cosmog",
+    "name": {
+      "en": "Cosmog",
+      "fr": "Cosmog"
+    },
     "image": "cPK_10_006660_01_COSMOG_C.webp",
     "packs": [
       "Deluxe"
@@ -1813,7 +2356,10 @@
     "set": "A4b",
     "number": 182,
     "rarity": "U",
-    "name": "Cosmoem",
+    "name": {
+      "en": "Cosmoem",
+      "fr": "Cosmovum"
+    },
     "image": "cPK_10_006670_00_COSMOVUM_U.webp",
     "packs": [
       "Deluxe"
@@ -1823,7 +2369,10 @@
     "set": "A4b",
     "number": 183,
     "rarity": "U",
-    "name": "Cosmoem",
+    "name": {
+      "en": "Cosmoem",
+      "fr": "Cosmovum"
+    },
     "image": "cPK_10_006670_01_COSMOVUM_U.webp",
     "packs": [
       "Deluxe"
@@ -1833,7 +2382,10 @@
     "set": "A4b",
     "number": 184,
     "rarity": "RR",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "image": "cPK_10_006680_00_LUNALAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1843,7 +2395,10 @@
     "set": "A4b",
     "number": 185,
     "rarity": "C",
-    "name": "Milcery",
+    "name": {
+      "en": "Milcery",
+      "fr": "Crèmy"
+    },
     "image": "cPK_10_008300_00_MAHOMIL_C.webp",
     "packs": [
       "Deluxe"
@@ -1853,7 +2408,10 @@
     "set": "A4b",
     "number": 186,
     "rarity": "C",
-    "name": "Milcery",
+    "name": {
+      "en": "Milcery",
+      "fr": "Crèmy"
+    },
     "image": "cPK_10_008300_01_MAHOMIL_C.webp",
     "packs": [
       "Deluxe"
@@ -1863,7 +2421,10 @@
     "set": "A4b",
     "number": 187,
     "rarity": "U",
-    "name": "Alcremie",
+    "name": {
+      "en": "Alcremie",
+      "fr": "Charmilly"
+    },
     "image": "cPK_10_007340_00_MAWHIP_U.webp",
     "packs": [
       "Deluxe"
@@ -1873,7 +2434,10 @@
     "set": "A4b",
     "number": 188,
     "rarity": "U",
-    "name": "Alcremie",
+    "name": {
+      "en": "Alcremie",
+      "fr": "Charmilly"
+    },
     "image": "cPK_10_007340_01_MAWHIP_U.webp",
     "packs": [
       "Deluxe"
@@ -1883,7 +2447,10 @@
     "set": "A4b",
     "number": 189,
     "rarity": "C",
-    "name": "Machop",
+    "name": {
+      "en": "Machop",
+      "fr": "Machoc"
+    },
     "image": "cPK_10_001430_00_WANRIKY_C.webp",
     "packs": [
       "Deluxe"
@@ -1893,7 +2460,10 @@
     "set": "A4b",
     "number": 190,
     "rarity": "C",
-    "name": "Machop",
+    "name": {
+      "en": "Machop",
+      "fr": "Machoc"
+    },
     "image": "cPK_10_001430_01_WANRIKY_C.webp",
     "packs": [
       "Deluxe"
@@ -1903,7 +2473,10 @@
     "set": "A4b",
     "number": 191,
     "rarity": "U",
-    "name": "Machoke",
+    "name": {
+      "en": "Machoke",
+      "fr": "Machopeur"
+    },
     "image": "cPK_10_001440_00_GORIKY_U.webp",
     "packs": [
       "Deluxe"
@@ -1913,7 +2486,10 @@
     "set": "A4b",
     "number": 192,
     "rarity": "U",
-    "name": "Machoke",
+    "name": {
+      "en": "Machoke",
+      "fr": "Machopeur"
+    },
     "image": "cPK_10_001440_01_GORIKY_U.webp",
     "packs": [
       "Deluxe"
@@ -1923,7 +2499,10 @@
     "set": "A4b",
     "number": 193,
     "rarity": "RR",
-    "name": "Machamp ex",
+    "name": {
+      "en": "Machamp ex",
+      "fr": "Mackogneur-ex"
+    },
     "image": "cPK_10_001460_00_KAIRIKYex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1933,7 +2512,10 @@
     "set": "A4b",
     "number": 194,
     "rarity": "C",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "image": "cPK_10_001510_00_KARAKARA_C.webp",
     "packs": [
       "Deluxe"
@@ -1943,7 +2525,10 @@
     "set": "A4b",
     "number": 195,
     "rarity": "C",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "image": "cPK_10_001510_01_KARAKARA_C.webp",
     "packs": [
       "Deluxe"
@@ -1953,7 +2538,10 @@
     "set": "A4b",
     "number": 196,
     "rarity": "RR",
-    "name": "Marowak ex",
+    "name": {
+      "en": "Marowak ex",
+      "fr": "Ossatueur-ex"
+    },
     "image": "cPK_10_001530_00_GARAGARAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1963,7 +2551,10 @@
     "set": "A4b",
     "number": 197,
     "rarity": "RR",
-    "name": "Aerodactyl ex",
+    "name": {
+      "en": "Aerodactyl ex",
+      "fr": "Ptéra-ex"
+    },
     "image": "cPK_10_002590_00_PTERAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -1973,7 +2564,10 @@
     "set": "A4b",
     "number": 198,
     "rarity": "U",
-    "name": "Sudowoodo",
+    "name": {
+      "en": "Sudowoodo",
+      "fr": "Simularbre"
+    },
     "image": "cPK_10_004600_00_USOKKIE_U.webp",
     "packs": [
       "Deluxe"
@@ -1983,7 +2577,10 @@
     "set": "A4b",
     "number": 199,
     "rarity": "U",
-    "name": "Sudowoodo",
+    "name": {
+      "en": "Sudowoodo",
+      "fr": "Simularbre"
+    },
     "image": "cPK_10_004600_01_USOKKIE_U.webp",
     "packs": [
       "Deluxe"
@@ -1993,7 +2590,10 @@
     "set": "A4b",
     "number": 200,
     "rarity": "C",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_10_009550_00_GOMAZOU_C.webp",
     "packs": [
       "Deluxe"
@@ -2003,7 +2603,10 @@
     "set": "A4b",
     "number": 201,
     "rarity": "C",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_10_009550_01_GOMAZOU_C.webp",
     "packs": [
       "Deluxe"
@@ -2013,7 +2616,10 @@
     "set": "A4b",
     "number": 202,
     "rarity": "RR",
-    "name": "Donphan ex",
+    "name": {
+      "en": "Donphan ex",
+      "fr": "Donphan-ex"
+    },
     "image": "cPK_10_009560_00_DONFANex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2023,7 +2629,10 @@
     "set": "A4b",
     "number": 203,
     "rarity": "C",
-    "name": "Nosepass",
+    "name": {
+      "en": "Nosepass",
+      "fr": "Tarinor"
+    },
     "image": "cPK_10_004660_00_NOSEPASS_C.webp",
     "packs": [
       "Deluxe"
@@ -2033,7 +2642,10 @@
     "set": "A4b",
     "number": 204,
     "rarity": "C",
-    "name": "Nosepass",
+    "name": {
+      "en": "Nosepass",
+      "fr": "Tarinor"
+    },
     "image": "cPK_10_004660_01_NOSEPASS_C.webp",
     "packs": [
       "Deluxe"
@@ -2043,7 +2655,10 @@
     "set": "A4b",
     "number": 205,
     "rarity": "C",
-    "name": "Gible",
+    "name": {
+      "en": "Gible",
+      "fr": "Griknot"
+    },
     "image": "cPK_10_004690_00_FUKAMARU_C.webp",
     "packs": [
       "Deluxe"
@@ -2053,7 +2668,10 @@
     "set": "A4b",
     "number": 206,
     "rarity": "C",
-    "name": "Gible",
+    "name": {
+      "en": "Gible",
+      "fr": "Griknot"
+    },
     "image": "cPK_10_004690_01_FUKAMARU_C.webp",
     "packs": [
       "Deluxe"
@@ -2063,7 +2681,10 @@
     "set": "A4b",
     "number": 207,
     "rarity": "C",
-    "name": "Gabite",
+    "name": {
+      "en": "Gabite",
+      "fr": "Carmache"
+    },
     "image": "cPK_10_004700_00_GABITE_C.webp",
     "packs": [
       "Deluxe"
@@ -2073,7 +2694,10 @@
     "set": "A4b",
     "number": 208,
     "rarity": "C",
-    "name": "Gabite",
+    "name": {
+      "en": "Gabite",
+      "fr": "Carmache"
+    },
     "image": "cPK_10_004700_01_GABITE_C.webp",
     "packs": [
       "Deluxe"
@@ -2083,7 +2707,10 @@
     "set": "A4b",
     "number": 209,
     "rarity": "RR",
-    "name": "Garchomp ex",
+    "name": {
+      "en": "Garchomp ex",
+      "fr": "Carchacrok-ex"
+    },
     "image": "cPK_10_004710_00_GABURIASex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2093,7 +2720,10 @@
     "set": "A4b",
     "number": 210,
     "rarity": "C",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "image": "cPK_10_005070_00_RIOLU_C.webp",
     "packs": [
       "Deluxe"
@@ -2103,7 +2733,10 @@
     "set": "A4b",
     "number": 211,
     "rarity": "C",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "image": "cPK_10_005070_01_RIOLU_C.webp",
     "packs": [
       "Deluxe"
@@ -2113,7 +2746,10 @@
     "set": "A4b",
     "number": 212,
     "rarity": "R",
-    "name": "Lucario",
+    "name": {
+      "en": "Lucario",
+      "fr": "Lucario"
+    },
     "image": "cPK_10_003730_00_LUCARIO_R.webp",
     "packs": [
       "Deluxe"
@@ -2123,7 +2759,10 @@
     "set": "A4b",
     "number": 213,
     "rarity": "R",
-    "name": "Lucario",
+    "name": {
+      "en": "Lucario",
+      "fr": "Lucario"
+    },
     "image": "cPK_10_003730_01_LUCARIO_R.webp",
     "packs": [
       "Deluxe"
@@ -2133,7 +2772,10 @@
     "set": "A4b",
     "number": 214,
     "rarity": "RR",
-    "name": "Lucario ex",
+    "name": {
+      "en": "Lucario ex",
+      "fr": "Lucario-ex"
+    },
     "image": "cPK_10_005580_00_LUCARIOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2143,7 +2785,10 @@
     "set": "A4b",
     "number": 215,
     "rarity": "RR",
-    "name": "Gallade ex",
+    "name": {
+      "en": "Gallade ex",
+      "fr": "Gallame-ex"
+    },
     "image": "cPK_10_003760_00_ERUREIDOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2153,7 +2798,10 @@
     "set": "A4b",
     "number": 216,
     "rarity": "C",
-    "name": "Drilbur",
+    "name": {
+      "en": "Drilbur",
+      "fr": "Rototaupe"
+    },
     "image": "cPK_10_006740_00_MOGUREW_C.webp",
     "packs": [
       "Deluxe"
@@ -2163,7 +2811,10 @@
     "set": "A4b",
     "number": 217,
     "rarity": "C",
-    "name": "Drilbur",
+    "name": {
+      "en": "Drilbur",
+      "fr": "Rototaupe"
+    },
     "image": "cPK_10_006740_01_MOGUREW_C.webp",
     "packs": [
       "Deluxe"
@@ -2173,7 +2824,10 @@
     "set": "A4b",
     "number": 218,
     "rarity": "C",
-    "name": "Crabrawler",
+    "name": {
+      "en": "Crabrawler",
+      "fr": "Crabagarre"
+    },
     "image": "cPK_10_006780_00_MAKENKANI_C.webp",
     "packs": [
       "Deluxe"
@@ -2183,7 +2837,10 @@
     "set": "A4b",
     "number": 219,
     "rarity": "C",
-    "name": "Crabrawler",
+    "name": {
+      "en": "Crabrawler",
+      "fr": "Crabagarre"
+    },
     "image": "cPK_10_006780_01_MAKENKANI_C.webp",
     "packs": [
       "Deluxe"
@@ -2193,7 +2850,10 @@
     "set": "A4b",
     "number": 220,
     "rarity": "C",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_10_007690_00_IWANKO_C.webp",
     "packs": [
       "Deluxe"
@@ -2203,7 +2863,10 @@
     "set": "A4b",
     "number": 221,
     "rarity": "C",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_10_007690_01_IWANKO_C.webp",
     "packs": [
       "Deluxe"
@@ -2213,7 +2876,10 @@
     "set": "A4b",
     "number": 222,
     "rarity": "RR",
-    "name": "Lycanroc ex",
+    "name": {
+      "en": "Lycanroc ex",
+      "fr": "Lougaroc-ex"
+    },
     "image": "cPK_10_007700_00_LUGARUGANTASOGARENOSUGATA_RR.webp",
     "packs": [
       "Deluxe"
@@ -2223,7 +2889,10 @@
     "set": "A4b",
     "number": 223,
     "rarity": "RR",
-    "name": "Passimian ex",
+    "name": {
+      "en": "Passimian ex",
+      "fr": "Quartermac-ex"
+    },
     "image": "cPK_10_006850_00_NAGETUKESARUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2233,7 +2902,10 @@
     "set": "A4b",
     "number": 224,
     "rarity": "R",
-    "name": "Marshadow",
+    "name": {
+      "en": "Marshadow",
+      "fr": "Marshadow"
+    },
     "image": "cPK_10_002600_00_MARSHADOW_R.webp",
     "packs": [
       "Deluxe"
@@ -2243,7 +2915,10 @@
     "set": "A4b",
     "number": 225,
     "rarity": "R",
-    "name": "Marshadow",
+    "name": {
+      "en": "Marshadow",
+      "fr": "Marshadow"
+    },
     "image": "cPK_10_002600_01_MARSHADOW_R.webp",
     "packs": [
       "Deluxe"
@@ -2253,7 +2928,10 @@
     "set": "A4b",
     "number": 226,
     "rarity": "C",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "image": "cPK_10_004720_00_ZUBAT_C.webp",
     "packs": [
       "Deluxe"
@@ -2263,7 +2941,10 @@
     "set": "A4b",
     "number": 227,
     "rarity": "C",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "image": "cPK_10_004720_01_ZUBAT_C.webp",
     "packs": [
       "Deluxe"
@@ -2273,7 +2954,10 @@
     "set": "A4b",
     "number": 228,
     "rarity": "C",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "image": "cPK_10_004730_00_GOLBAT_C.webp",
     "packs": [
       "Deluxe"
@@ -2283,7 +2967,10 @@
     "set": "A4b",
     "number": 229,
     "rarity": "C",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "image": "cPK_10_004730_01_GOLBAT_C.webp",
     "packs": [
       "Deluxe"
@@ -2293,7 +2980,10 @@
     "set": "A4b",
     "number": 230,
     "rarity": "R",
-    "name": "Crobat",
+    "name": {
+      "en": "Crobat",
+      "fr": "Nostenfer"
+    },
     "image": "cPK_10_004740_00_CROBAT_R.webp",
     "packs": [
       "Deluxe"
@@ -2303,7 +2993,10 @@
     "set": "A4b",
     "number": 231,
     "rarity": "R",
-    "name": "Crobat",
+    "name": {
+      "en": "Crobat",
+      "fr": "Nostenfer"
+    },
     "image": "cPK_10_004740_01_CROBAT_R.webp",
     "packs": [
       "Deluxe"
@@ -2313,7 +3006,10 @@
     "set": "A4b",
     "number": 232,
     "rarity": "RR",
-    "name": "Crobat ex",
+    "name": {
+      "en": "Crobat ex",
+      "fr": "Nostenfer-ex"
+    },
     "image": "cPK_10_009650_00_CROBATex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2323,7 +3019,10 @@
     "set": "A4b",
     "number": 233,
     "rarity": "C",
-    "name": "Alolan Grimer",
+    "name": {
+      "en": "Alolan Grimer",
+      "fr": "Tadmorv de Alola"
+    },
     "image": "cPK_10_006910_00_ALOLABETBETER_C.webp",
     "packs": [
       "Deluxe"
@@ -2333,7 +3032,10 @@
     "set": "A4b",
     "number": 234,
     "rarity": "C",
-    "name": "Alolan Grimer",
+    "name": {
+      "en": "Alolan Grimer",
+      "fr": "Tadmorv de Alola"
+    },
     "image": "cPK_10_006910_01_ALOLABETBETER_C.webp",
     "packs": [
       "Deluxe"
@@ -2343,7 +3045,10 @@
     "set": "A4b",
     "number": 235,
     "rarity": "RR",
-    "name": "Alolan Muk ex",
+    "name": {
+      "en": "Alolan Muk ex",
+      "fr": "Grotadmorv de Alola-ex"
+    },
     "image": "cPK_10_006920_00_ALOLABETBETONex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2353,7 +3058,10 @@
     "set": "A4b",
     "number": 236,
     "rarity": "C",
-    "name": "Paldean Wooper",
+    "name": {
+      "en": "Paldean Wooper",
+      "fr": "Axoloto de Paldea"
+    },
     "image": "cPK_10_005620_00_PALDEAUPAH_C.webp",
     "packs": [
       "Deluxe"
@@ -2363,7 +3071,10 @@
     "set": "A4b",
     "number": 237,
     "rarity": "C",
-    "name": "Paldean Wooper",
+    "name": {
+      "en": "Paldean Wooper",
+      "fr": "Axoloto de Paldea"
+    },
     "image": "cPK_10_005620_01_PALDEAUPAH_C.webp",
     "packs": [
       "Deluxe"
@@ -2373,7 +3084,10 @@
     "set": "A4b",
     "number": 238,
     "rarity": "RR",
-    "name": "Paldean Clodsire ex",
+    "name": {
+      "en": "Paldean Clodsire ex",
+      "fr": "Terraiste de Paldea-ex"
+    },
     "image": "cPK_10_005630_00_PALDEADOOHex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2383,7 +3097,10 @@
     "set": "A4b",
     "number": 239,
     "rarity": "R",
-    "name": "Umbreon",
+    "name": {
+      "en": "Umbreon",
+      "fr": "Noctali"
+    },
     "image": "cPK_10_008360_00_BRACKY_R.webp",
     "packs": [
       "Deluxe"
@@ -2393,7 +3110,10 @@
     "set": "A4b",
     "number": 240,
     "rarity": "R",
-    "name": "Umbreon",
+    "name": {
+      "en": "Umbreon",
+      "fr": "Noctali"
+    },
     "image": "cPK_10_008360_01_BRACKY_R.webp",
     "packs": [
       "Deluxe"
@@ -2403,7 +3123,10 @@
     "set": "A4b",
     "number": 241,
     "rarity": "RR",
-    "name": "Umbreon ex",
+    "name": {
+      "en": "Umbreon ex",
+      "fr": "Noctali-ex"
+    },
     "image": "cPK_10_009680_00_BRACKYex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2413,7 +3136,10 @@
     "set": "A4b",
     "number": 242,
     "rarity": "C",
-    "name": "Sneasel",
+    "name": {
+      "en": "Sneasel",
+      "fr": "Farfuret"
+    },
     "image": "cPK_10_003790_00_NYULA_C.webp",
     "packs": [
       "Deluxe"
@@ -2423,7 +3149,10 @@
     "set": "A4b",
     "number": 243,
     "rarity": "C",
-    "name": "Sneasel",
+    "name": {
+      "en": "Sneasel",
+      "fr": "Farfuret"
+    },
     "image": "cPK_10_003790_01_NYULA_C.webp",
     "packs": [
       "Deluxe"
@@ -2433,7 +3162,10 @@
     "set": "A4b",
     "number": 244,
     "rarity": "RR",
-    "name": "Weavile ex",
+    "name": {
+      "en": "Weavile ex",
+      "fr": "Dimoret-ex"
+    },
     "image": "cPK_10_003800_00_MANYULAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2443,7 +3175,10 @@
     "set": "A4b",
     "number": 245,
     "rarity": "RR",
-    "name": "Darkrai ex",
+    "name": {
+      "en": "Darkrai ex",
+      "fr": "Darkrai-ex"
+    },
     "image": "cPK_10_003910_00_DARKRAIex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2453,7 +3188,10 @@
     "set": "A4b",
     "number": 246,
     "rarity": "R",
-    "name": "Nihilego",
+    "name": {
+      "en": "Nihilego",
+      "fr": "Zéroïd"
+    },
     "image": "cPK_10_007790_00_UTUROID_R.webp",
     "packs": [
       "Deluxe"
@@ -2463,7 +3201,10 @@
     "set": "A4b",
     "number": 247,
     "rarity": "R",
-    "name": "Nihilego",
+    "name": {
+      "en": "Nihilego",
+      "fr": "Zéroïd"
+    },
     "image": "cPK_10_007790_01_UTUROID_R.webp",
     "packs": [
       "Deluxe"
@@ -2473,7 +3214,10 @@
     "set": "A4b",
     "number": 248,
     "rarity": "RR",
-    "name": "Guzzlord ex",
+    "name": {
+      "en": "Guzzlord ex",
+      "fr": "Engloutyran-ex"
+    },
     "image": "cPK_10_007800_00_AKUZIKINGex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2483,7 +3227,10 @@
     "set": "A4b",
     "number": 249,
     "rarity": "C",
-    "name": "Alolan Diglett",
+    "name": {
+      "en": "Alolan Diglett",
+      "fr": "Taupiqueur de Alola"
+    },
     "image": "cPK_10_007820_00_ALOLADIGDA_C.webp",
     "packs": [
       "Deluxe"
@@ -2493,7 +3240,10 @@
     "set": "A4b",
     "number": 250,
     "rarity": "C",
-    "name": "Alolan Diglett",
+    "name": {
+      "en": "Alolan Diglett",
+      "fr": "Taupiqueur de Alola"
+    },
     "image": "cPK_10_007820_01_ALOLADIGDA_C.webp",
     "packs": [
       "Deluxe"
@@ -2503,7 +3253,10 @@
     "set": "A4b",
     "number": 251,
     "rarity": "RR",
-    "name": "Alolan Dugtrio ex",
+    "name": {
+      "en": "Alolan Dugtrio ex",
+      "fr": "Triopikeur de Alola-ex"
+    },
     "image": "cPK_10_007830_00_ALOLADUGTRIOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2513,7 +3266,10 @@
     "set": "A4b",
     "number": 252,
     "rarity": "RR",
-    "name": "Skarmory ex",
+    "name": {
+      "en": "Skarmory ex",
+      "fr": "Airmure-ex"
+    },
     "image": "cPK_10_009800_00_AIRMDex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2523,7 +3279,10 @@
     "set": "A4b",
     "number": 253,
     "rarity": "RR",
-    "name": "Probopass ex",
+    "name": {
+      "en": "Probopass ex",
+      "fr": "Tarinorme-ex"
+    },
     "image": "cPK_10_004810_00_DAINOSEex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2533,7 +3292,10 @@
     "set": "A4b",
     "number": 254,
     "rarity": "RR",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_10_004000_00_DIALGAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2543,7 +3305,10 @@
     "set": "A4b",
     "number": 255,
     "rarity": "U",
-    "name": "Excadrill",
+    "name": {
+      "en": "Excadrill",
+      "fr": "Minotaupe"
+    },
     "image": "cPK_10_007000_00_DORYUZU_U.webp",
     "packs": [
       "Deluxe"
@@ -2553,7 +3318,10 @@
     "set": "A4b",
     "number": 256,
     "rarity": "U",
-    "name": "Excadrill",
+    "name": {
+      "en": "Excadrill",
+      "fr": "Minotaupe"
+    },
     "image": "cPK_10_007000_01_DORYUZU_U.webp",
     "packs": [
       "Deluxe"
@@ -2563,7 +3331,10 @@
     "set": "A4b",
     "number": 257,
     "rarity": "R",
-    "name": "Klefki",
+    "name": {
+      "en": "Klefki",
+      "fr": "Trousselin"
+    },
     "image": "cPK_10_007020_00_CLEFFY_R.webp",
     "packs": [
       "Deluxe"
@@ -2573,7 +3344,10 @@
     "set": "A4b",
     "number": 258,
     "rarity": "R",
-    "name": "Klefki",
+    "name": {
+      "en": "Klefki",
+      "fr": "Trousselin"
+    },
     "image": "cPK_10_007020_01_CLEFFY_R.webp",
     "packs": [
       "Deluxe"
@@ -2583,7 +3357,10 @@
     "set": "A4b",
     "number": 259,
     "rarity": "RR",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "image": "cPK_10_007030_00_SOLGALEOex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2593,7 +3370,10 @@
     "set": "A4b",
     "number": 260,
     "rarity": "R",
-    "name": "Magearna",
+    "name": {
+      "en": "Magearna",
+      "fr": "Magearna"
+    },
     "image": "cPK_10_007040_00_MAGEARNA_R.webp",
     "packs": [
       "Deluxe"
@@ -2603,7 +3383,10 @@
     "set": "A4b",
     "number": 261,
     "rarity": "R",
-    "name": "Magearna",
+    "name": {
+      "en": "Magearna",
+      "fr": "Magearna"
+    },
     "image": "cPK_10_007040_01_MAGEARNA_R.webp",
     "packs": [
       "Deluxe"
@@ -2613,7 +3396,10 @@
     "set": "A4b",
     "number": 262,
     "rarity": "C",
-    "name": "Tinkatink",
+    "name": {
+      "en": "Tinkatink",
+      "fr": "Forgerette"
+    },
     "image": "cPK_10_005670_00_KANUCHAN_C.webp",
     "packs": [
       "Deluxe"
@@ -2623,7 +3409,10 @@
     "set": "A4b",
     "number": 263,
     "rarity": "C",
-    "name": "Tinkatink",
+    "name": {
+      "en": "Tinkatink",
+      "fr": "Forgerette"
+    },
     "image": "cPK_10_005670_01_KANUCHAN_C.webp",
     "packs": [
       "Deluxe"
@@ -2633,7 +3422,10 @@
     "set": "A4b",
     "number": 264,
     "rarity": "U",
-    "name": "Tinkatuff",
+    "name": {
+      "en": "Tinkatuff",
+      "fr": "Forgella"
+    },
     "image": "cPK_10_005680_00_NAKANUCHAN_U.webp",
     "packs": [
       "Deluxe"
@@ -2643,7 +3435,10 @@
     "set": "A4b",
     "number": 265,
     "rarity": "U",
-    "name": "Tinkatuff",
+    "name": {
+      "en": "Tinkatuff",
+      "fr": "Forgella"
+    },
     "image": "cPK_10_005680_01_NAKANUCHAN_U.webp",
     "packs": [
       "Deluxe"
@@ -2653,7 +3448,10 @@
     "set": "A4b",
     "number": 266,
     "rarity": "RR",
-    "name": "Tinkaton ex",
+    "name": {
+      "en": "Tinkaton ex",
+      "fr": "Forgelina-ex"
+    },
     "image": "cPK_10_005690_00_DEKANUCHANex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2663,7 +3461,10 @@
     "set": "A4b",
     "number": 267,
     "rarity": "C",
-    "name": "Dratini",
+    "name": {
+      "en": "Dratini",
+      "fr": "Minidraco"
+    },
     "image": "cPK_10_008430_00_MINIRYU_C.webp",
     "packs": [
       "Deluxe"
@@ -2673,7 +3474,10 @@
     "set": "A4b",
     "number": 268,
     "rarity": "C",
-    "name": "Dratini",
+    "name": {
+      "en": "Dratini",
+      "fr": "Minidraco"
+    },
     "image": "cPK_10_008430_01_MINIRYU_C.webp",
     "packs": [
       "Deluxe"
@@ -2683,7 +3487,10 @@
     "set": "A4b",
     "number": 269,
     "rarity": "C",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "image": "cPK_10_008440_00_HAKURYU_C.webp",
     "packs": [
       "Deluxe"
@@ -2693,7 +3500,10 @@
     "set": "A4b",
     "number": 270,
     "rarity": "C",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "image": "cPK_10_008440_01_HAKURYU_C.webp",
     "packs": [
       "Deluxe"
@@ -2703,7 +3513,10 @@
     "set": "A4b",
     "number": 271,
     "rarity": "RR",
-    "name": "Dragonite ex",
+    "name": {
+      "en": "Dragonite ex",
+      "fr": "Dracolosse-ex"
+    },
     "image": "cPK_10_008450_00_KAIRYUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2713,7 +3526,10 @@
     "set": "A4b",
     "number": 272,
     "rarity": "C",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_10_002700_00_POPPO_C.webp",
     "packs": [
       "Deluxe"
@@ -2723,7 +3539,10 @@
     "set": "A4b",
     "number": 273,
     "rarity": "C",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_10_002700_01_POPPO_C.webp",
     "packs": [
       "Deluxe"
@@ -2733,7 +3552,10 @@
     "set": "A4b",
     "number": 274,
     "rarity": "C",
-    "name": "Pidgeotto",
+    "name": {
+      "en": "Pidgeotto",
+      "fr": "Roucoups"
+    },
     "image": "cPK_10_002710_00_PIGEON_C.webp",
     "packs": [
       "Deluxe"
@@ -2743,7 +3565,10 @@
     "set": "A4b",
     "number": 275,
     "rarity": "C",
-    "name": "Pidgeotto",
+    "name": {
+      "en": "Pidgeotto",
+      "fr": "Roucoups"
+    },
     "image": "cPK_10_002710_01_PIGEON_C.webp",
     "packs": [
       "Deluxe"
@@ -2753,7 +3578,10 @@
     "set": "A4b",
     "number": 276,
     "rarity": "RR",
-    "name": "Pidgeot ex",
+    "name": {
+      "en": "Pidgeot ex",
+      "fr": "Roucarnage-ex"
+    },
     "image": "cPK_10_002720_00_PIGEOTex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2763,7 +3591,10 @@
     "set": "A4b",
     "number": 277,
     "rarity": "C",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "image": "cPK_10_001930_00_PURIN_C.webp",
     "packs": [
       "Deluxe"
@@ -2773,7 +3604,10 @@
     "set": "A4b",
     "number": 278,
     "rarity": "C",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "image": "cPK_10_001930_01_PURIN_C.webp",
     "packs": [
       "Deluxe"
@@ -2783,7 +3617,10 @@
     "set": "A4b",
     "number": 279,
     "rarity": "RR",
-    "name": "Wigglytuff ex",
+    "name": {
+      "en": "Wigglytuff ex",
+      "fr": "Grodoudou-ex"
+    },
     "image": "cPK_10_001950_00_PUKURINex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2793,7 +3630,10 @@
     "set": "A4b",
     "number": 280,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_10_001980_00_KAMONEGI_C.webp",
     "packs": [
       "Deluxe"
@@ -2803,7 +3643,10 @@
     "set": "A4b",
     "number": 281,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_10_001980_01_KAMONEGI_C.webp",
     "packs": [
       "Deluxe"
@@ -2813,7 +3656,10 @@
     "set": "A4b",
     "number": 282,
     "rarity": "C",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_10_004050_00_BERORINGA_C.webp",
     "packs": [
       "Deluxe"
@@ -2823,7 +3669,10 @@
     "set": "A4b",
     "number": 283,
     "rarity": "C",
-    "name": "Lickitung",
+    "name": {
+      "en": "Lickitung",
+      "fr": "Excelangue"
+    },
     "image": "cPK_10_004050_01_BERORINGA_C.webp",
     "packs": [
       "Deluxe"
@@ -2833,7 +3682,10 @@
     "set": "A4b",
     "number": 284,
     "rarity": "RR",
-    "name": "Lickilicky ex",
+    "name": {
+      "en": "Lickilicky ex",
+      "fr": "Coudlangue-ex"
+    },
     "image": "cPK_10_004060_00_BEROBELTex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2843,7 +3695,10 @@
     "set": "A4b",
     "number": 285,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_008470_00_EIEVUI_C.webp",
     "packs": [
       "Deluxe"
@@ -2853,7 +3708,10 @@
     "set": "A4b",
     "number": 286,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_008470_01_EIEVUI_C.webp",
     "packs": [
       "Deluxe"
@@ -2863,7 +3721,10 @@
     "set": "A4b",
     "number": 287,
     "rarity": "RR",
-    "name": "Eevee ex",
+    "name": {
+      "en": "Eevee ex",
+      "fr": "Évoli-ex"
+    },
     "image": "cPK_10_008480_00_EIEVUIex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2873,7 +3734,10 @@
     "set": "A4b",
     "number": 288,
     "rarity": "RR",
-    "name": "Snorlax ex",
+    "name": {
+      "en": "Snorlax ex",
+      "fr": "Ronflex-ex"
+    },
     "image": "cPK_10_008490_00_KABIGONex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2883,7 +3747,10 @@
     "set": "A4b",
     "number": 289,
     "rarity": "RR",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "image": "cPK_10_010050_00_LUGIAex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2893,7 +3760,10 @@
     "set": "A4b",
     "number": 290,
     "rarity": "C",
-    "name": "Skitty",
+    "name": {
+      "en": "Skitty",
+      "fr": "Skitty"
+    },
     "image": "cPK_10_007100_00_ENECO_C.webp",
     "packs": [
       "Deluxe"
@@ -2903,7 +3773,10 @@
     "set": "A4b",
     "number": 291,
     "rarity": "C",
-    "name": "Skitty",
+    "name": {
+      "en": "Skitty",
+      "fr": "Skitty"
+    },
     "image": "cPK_10_007100_01_ENECO_C.webp",
     "packs": [
       "Deluxe"
@@ -2913,7 +3786,10 @@
     "set": "A4b",
     "number": 292,
     "rarity": "U",
-    "name": "Delcatty",
+    "name": {
+      "en": "Delcatty",
+      "fr": "Delcatty"
+    },
     "image": "cPK_10_007110_00_ENEKORORO_U.webp",
     "packs": [
       "Deluxe"
@@ -2923,7 +3799,10 @@
     "set": "A4b",
     "number": 293,
     "rarity": "U",
-    "name": "Delcatty",
+    "name": {
+      "en": "Delcatty",
+      "fr": "Delcatty"
+    },
     "image": "cPK_10_007110_01_ENEKORORO_U.webp",
     "packs": [
       "Deluxe"
@@ -2933,7 +3812,10 @@
     "set": "A4b",
     "number": 294,
     "rarity": "C",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_10_005040_00_BIPPA_C.webp",
     "packs": [
       "Deluxe"
@@ -2943,7 +3825,10 @@
     "set": "A4b",
     "number": 295,
     "rarity": "C",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_10_005040_01_BIPPA_C.webp",
     "packs": [
       "Deluxe"
@@ -2953,7 +3838,10 @@
     "set": "A4b",
     "number": 296,
     "rarity": "RR",
-    "name": "Bibarel ex",
+    "name": {
+      "en": "Bibarel ex",
+      "fr": "Castorno-ex"
+    },
     "image": "cPK_10_005790_00_BEADARUex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2963,7 +3851,10 @@
     "set": "A4b",
     "number": 297,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_10_004930_00_SHAYMIN_R.webp",
     "packs": [
       "Deluxe"
@@ -2973,7 +3864,10 @@
     "set": "A4b",
     "number": 298,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_10_004930_01_SHAYMIN_R.webp",
     "packs": [
       "Deluxe"
@@ -2983,7 +3877,10 @@
     "set": "A4b",
     "number": 299,
     "rarity": "RR",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_10_004950_00_ARCEUSex_RR.webp",
     "packs": [
       "Deluxe"
@@ -2993,7 +3890,10 @@
     "set": "A4b",
     "number": 300,
     "rarity": "U",
-    "name": "Type: Null",
+    "name": {
+      "en": "Type: Null",
+      "fr": "Type:0"
+    },
     "image": "cPK_10_007940_00_TYPENULL_U.webp",
     "packs": [
       "Deluxe"
@@ -3003,7 +3903,10 @@
     "set": "A4b",
     "number": 301,
     "rarity": "U",
-    "name": "Type: Null",
+    "name": {
+      "en": "Type: Null",
+      "fr": "Type:0"
+    },
     "image": "cPK_10_007940_01_TYPENULL_U.webp",
     "packs": [
       "Deluxe"
@@ -3013,7 +3916,10 @@
     "set": "A4b",
     "number": 302,
     "rarity": "R",
-    "name": "Silvally",
+    "name": {
+      "en": "Silvally",
+      "fr": "Silvallié"
+    },
     "image": "cPK_10_007950_00_SILVADY_R.webp",
     "packs": [
       "Deluxe"
@@ -3023,7 +3929,10 @@
     "set": "A4b",
     "number": 303,
     "rarity": "R",
-    "name": "Silvally",
+    "name": {
+      "en": "Silvally",
+      "fr": "Silvallié"
+    },
     "image": "cPK_10_007950_01_SILVADY_R.webp",
     "packs": [
       "Deluxe"
@@ -3033,7 +3942,10 @@
     "set": "A4b",
     "number": 304,
     "rarity": "R",
-    "name": "Celesteela",
+    "name": {
+      "en": "Celesteela",
+      "fr": "Bamboiselle"
+    },
     "image": "cPK_10_007960_00_TEKKAGUYA_R.webp",
     "packs": [
       "Deluxe"
@@ -3043,7 +3955,10 @@
     "set": "A4b",
     "number": 305,
     "rarity": "R",
-    "name": "Celesteela",
+    "name": {
+      "en": "Celesteela",
+      "fr": "Bamboiselle"
+    },
     "image": "cPK_10_007960_01_TEKKAGUYA_R.webp",
     "packs": [
       "Deluxe"
@@ -3053,7 +3968,10 @@
     "set": "A4b",
     "number": 306,
     "rarity": "U",
-    "name": "Cyclizar",
+    "name": {
+      "en": "Cyclizar",
+      "fr": "Motorizard"
+    },
     "image": "cPK_10_005090_00_MOTOTOKAGE_U.webp",
     "packs": [
       "Deluxe"
@@ -3063,7 +3981,10 @@
     "set": "A4b",
     "number": 307,
     "rarity": "U",
-    "name": "Cyclizar",
+    "name": {
+      "en": "Cyclizar",
+      "fr": "Motorizard"
+    },
     "image": "cPK_10_005090_01_MOTOTOKAGE_U.webp",
     "packs": [
       "Deluxe"
@@ -3073,7 +3994,10 @@
     "set": "A4b",
     "number": 308,
     "rarity": "U",
-    "name": "Eevee Bag",
+    "name": {
+      "en": "Eevee Bag",
+      "fr": "Sac Évoli"
+    },
     "image": "cTR_10_000670_00_IIBUINOBAKKU_U.webp",
     "packs": [
       "Deluxe"
@@ -3083,7 +4007,10 @@
     "set": "A4b",
     "number": 309,
     "rarity": "U",
-    "name": "Eevee Bag",
+    "name": {
+      "en": "Eevee Bag",
+      "fr": "Sac Évoli"
+    },
     "image": "cTR_10_000670_01_IIBUINOBAKKU_U.webp",
     "packs": [
       "Deluxe"
@@ -3093,7 +4020,10 @@
     "set": "A4b",
     "number": 310,
     "rarity": "U",
-    "name": "Elemental Switch",
+    "name": {
+      "en": "Elemental Switch",
+      "fr": "Échange Élémentaire"
+    },
     "image": "cTR_10_000710_00_EREMENTARUTSUKEKAE_U.webp",
     "packs": [
       "Deluxe"
@@ -3103,7 +4033,10 @@
     "set": "A4b",
     "number": 311,
     "rarity": "U",
-    "name": "Elemental Switch",
+    "name": {
+      "en": "Elemental Switch",
+      "fr": "Échange Élémentaire"
+    },
     "image": "cTR_10_000710_01_EREMENTARUTSUKEKAE_U.webp",
     "packs": [
       "Deluxe"
@@ -3113,7 +4046,10 @@
     "set": "A4b",
     "number": 312,
     "rarity": "C",
-    "name": "Old Amber",
+    "name": {
+      "en": "Old Amber",
+      "fr": "Vieil Ambre"
+    },
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
     "packs": [
       "Deluxe"
@@ -3123,7 +4059,10 @@
     "set": "A4b",
     "number": 313,
     "rarity": "C",
-    "name": "Old Amber",
+    "name": {
+      "en": "Old Amber",
+      "fr": "Vieil Ambre"
+    },
     "image": "cTR_10_000100_01_HIMITSUNOKOHAKU_C.webp",
     "packs": [
       "Deluxe"
@@ -3133,7 +4072,10 @@
     "set": "A4b",
     "number": 314,
     "rarity": "U",
-    "name": "Rare Candy",
+    "name": {
+      "en": "Rare Candy",
+      "fr": "Super Bonbon"
+    },
     "image": "cTR_10_000480_00_FUSHIGINAAME_U.webp",
     "packs": [
       "Deluxe"
@@ -3143,7 +4085,10 @@
     "set": "A4b",
     "number": 315,
     "rarity": "U",
-    "name": "Rare Candy",
+    "name": {
+      "en": "Rare Candy",
+      "fr": "Super Bonbon"
+    },
     "image": "cTR_10_000480_01_FUSHIGINAAME_U.webp",
     "packs": [
       "Deluxe"
@@ -3153,7 +4098,10 @@
     "set": "A4b",
     "number": 316,
     "rarity": "U",
-    "name": "Pokémon Communication",
+    "name": {
+      "en": "Pokémon Communication",
+      "fr": "Communication Pokémon"
+    },
     "image": "cTR_10_000280_00_POKEMONTSUUSHIN_U.webp",
     "packs": [
       "Deluxe"
@@ -3163,7 +4111,10 @@
     "set": "A4b",
     "number": 317,
     "rarity": "U",
-    "name": "Pokémon Communication",
+    "name": {
+      "en": "Pokémon Communication",
+      "fr": "Communication Pokémon"
+    },
     "image": "cTR_10_000280_01_POKEMONTSUUSHIN_U.webp",
     "packs": [
       "Deluxe"
@@ -3173,7 +4124,10 @@
     "set": "A4b",
     "number": 318,
     "rarity": "U",
-    "name": "Electrical Cord",
+    "name": {
+      "en": "Electrical Cord",
+      "fr": "Câble Électrique"
+    },
     "image": "cTR_10_000620_00_EREKIKORD_U.webp",
     "packs": [
       "Deluxe"
@@ -3183,7 +4137,10 @@
     "set": "A4b",
     "number": 319,
     "rarity": "U",
-    "name": "Electrical Cord",
+    "name": {
+      "en": "Electrical Cord",
+      "fr": "Câble Électrique"
+    },
     "image": "cTR_10_000620_01_EREKIKORD_U.webp",
     "packs": [
       "Deluxe"
@@ -3193,7 +4150,10 @@
     "set": "A4b",
     "number": 320,
     "rarity": "U",
-    "name": "Giant Cape",
+    "name": {
+      "en": "Giant Cape",
+      "fr": "Cape Géante"
+    },
     "image": "cTR_10_000290_00_OOKINAMANTO_U.webp",
     "packs": [
       "Deluxe"
@@ -3203,7 +4163,10 @@
     "set": "A4b",
     "number": 321,
     "rarity": "U",
-    "name": "Giant Cape",
+    "name": {
+      "en": "Giant Cape",
+      "fr": "Cape Géante"
+    },
     "image": "cTR_10_000290_01_OOKINAMANTO_U.webp",
     "packs": [
       "Deluxe"
@@ -3213,7 +4176,10 @@
     "set": "A4b",
     "number": 322,
     "rarity": "U",
-    "name": "Rocky Helmet",
+    "name": {
+      "en": "Rocky Helmet",
+      "fr": "Casque Brut"
+    },
     "image": "cTR_10_000300_00_GOTSUGOTSUMETTO_U.webp",
     "packs": [
       "Deluxe"
@@ -3223,7 +4189,10 @@
     "set": "A4b",
     "number": 323,
     "rarity": "U",
-    "name": "Rocky Helmet",
+    "name": {
+      "en": "Rocky Helmet",
+      "fr": "Casque Brut"
+    },
     "image": "cTR_10_000300_01_GOTSUGOTSUMETTO_U.webp",
     "packs": [
       "Deluxe"
@@ -3233,7 +4202,10 @@
     "set": "A4b",
     "number": 324,
     "rarity": "U",
-    "name": "Leaf Cape",
+    "name": {
+      "en": "Leaf Cape",
+      "fr": "Cape Sylvestre"
+    },
     "image": "cTR_10_000510_00_LEAFMANTO_U.webp",
     "packs": [
       "Deluxe"
@@ -3243,7 +4215,10 @@
     "set": "A4b",
     "number": 325,
     "rarity": "U",
-    "name": "Leaf Cape",
+    "name": {
+      "en": "Leaf Cape",
+      "fr": "Cape Sylvestre"
+    },
     "image": "cTR_10_000510_01_LEAFMANTO_U.webp",
     "packs": [
       "Deluxe"
@@ -3253,7 +4228,10 @@
     "set": "A4b",
     "number": 326,
     "rarity": "U",
-    "name": "Cyrus",
+    "name": {
+      "en": "Cyrus",
+      "fr": "Hélio"
+    },
     "image": "cTR_10_000320_00_AKAGI_U.webp",
     "packs": [
       "Deluxe"
@@ -3263,7 +4241,10 @@
     "set": "A4b",
     "number": 327,
     "rarity": "U",
-    "name": "Cyrus",
+    "name": {
+      "en": "Cyrus",
+      "fr": "Hélio"
+    },
     "image": "cTR_10_000320_01_AKAGI_U.webp",
     "packs": [
       "Deluxe"
@@ -3273,7 +4254,10 @@
     "set": "A4b",
     "number": 328,
     "rarity": "U",
-    "name": "Erika",
+    "name": {
+      "en": "Erika",
+      "fr": "Erika"
+    },
     "image": "cTR_10_000110_00_ERIKA_U.webp",
     "packs": [
       "Deluxe"
@@ -3283,7 +4267,10 @@
     "set": "A4b",
     "number": 329,
     "rarity": "U",
-    "name": "Erika",
+    "name": {
+      "en": "Erika",
+      "fr": "Erika"
+    },
     "image": "cTR_10_000110_01_ERIKA_U.webp",
     "packs": [
       "Deluxe"
@@ -3293,7 +4280,10 @@
     "set": "A4b",
     "number": 330,
     "rarity": "U",
-    "name": "Irida",
+    "name": {
+      "en": "Irida",
+      "fr": "Nacchara"
+    },
     "image": "cTR_10_000380_00_KAI_U.webp",
     "packs": [
       "Deluxe"
@@ -3303,7 +4293,10 @@
     "set": "A4b",
     "number": 331,
     "rarity": "U",
-    "name": "Irida",
+    "name": {
+      "en": "Irida",
+      "fr": "Nacchara"
+    },
     "image": "cTR_10_000380_01_KAI_U.webp",
     "packs": [
       "Deluxe"
@@ -3313,7 +4306,10 @@
     "set": "A4b",
     "number": 332,
     "rarity": "U",
-    "name": "Lyra",
+    "name": {
+      "en": "Lyra",
+      "fr": "Célesta"
+    },
     "image": "cTR_10_000770_00_KOTONE_U.webp",
     "packs": [
       "Deluxe"
@@ -3323,7 +4319,10 @@
     "set": "A4b",
     "number": 333,
     "rarity": "U",
-    "name": "Lyra",
+    "name": {
+      "en": "Lyra",
+      "fr": "Célesta"
+    },
     "image": "cTR_10_000770_01_KOTONE_U.webp",
     "packs": [
       "Deluxe"
@@ -3333,7 +4332,10 @@
     "set": "A4b",
     "number": 334,
     "rarity": "U",
-    "name": "Giovanni",
+    "name": {
+      "en": "Giovanni",
+      "fr": "Giovanni"
+    },
     "image": "cTR_10_000150_00_SAKAKI_U.webp",
     "packs": [
       "Deluxe"
@@ -3343,7 +4345,10 @@
     "set": "A4b",
     "number": 335,
     "rarity": "U",
-    "name": "Giovanni",
+    "name": {
+      "en": "Giovanni",
+      "fr": "Giovanni"
+    },
     "image": "cTR_10_000150_01_SAKAKI_U.webp",
     "packs": [
       "Deluxe"
@@ -3353,7 +4358,10 @@
     "set": "A4b",
     "number": 336,
     "rarity": "U",
-    "name": "Silver",
+    "name": {
+      "en": "Silver",
+      "fr": "Silver"
+    },
     "image": "cTR_10_000780_00_SILVER_U.webp",
     "packs": [
       "Deluxe"
@@ -3363,7 +4371,10 @@
     "set": "A4b",
     "number": 337,
     "rarity": "U",
-    "name": "Silver",
+    "name": {
+      "en": "Silver",
+      "fr": "Silver"
+    },
     "image": "cTR_10_000780_01_SILVER_U.webp",
     "packs": [
       "Deluxe"
@@ -3373,7 +4384,10 @@
     "set": "A4b",
     "number": 338,
     "rarity": "U",
-    "name": "Sabrina",
+    "name": {
+      "en": "Sabrina",
+      "fr": "Morgane"
+    },
     "image": "cTR_10_000170_00_NATSUME_U.webp",
     "packs": [
       "Deluxe"
@@ -3383,7 +4397,10 @@
     "set": "A4b",
     "number": 339,
     "rarity": "U",
-    "name": "Sabrina",
+    "name": {
+      "en": "Sabrina",
+      "fr": "Morgane"
+    },
     "image": "cTR_10_000170_01_NATSUME_U.webp",
     "packs": [
       "Deluxe"
@@ -3393,7 +4410,10 @@
     "set": "A4b",
     "number": 340,
     "rarity": "U",
-    "name": "Iono",
+    "name": {
+      "en": "Iono",
+      "fr": "Mashynn"
+    },
     "image": "cTR_10_000420_00_NANJYAMO_U.webp",
     "packs": [
       "Deluxe"
@@ -3403,7 +4423,10 @@
     "set": "A4b",
     "number": 341,
     "rarity": "U",
-    "name": "Iono",
+    "name": {
+      "en": "Iono",
+      "fr": "Mashynn"
+    },
     "image": "cTR_10_000420_01_NANJYAMO_U.webp",
     "packs": [
       "Deluxe"
@@ -3413,7 +4436,10 @@
     "set": "A4b",
     "number": 342,
     "rarity": "U",
-    "name": "Dawn",
+    "name": {
+      "en": "Dawn",
+      "fr": "Aurore"
+    },
     "image": "cTR_10_000360_00_HIKARI_U.webp",
     "packs": [
       "Deluxe"
@@ -3423,7 +4449,10 @@
     "set": "A4b",
     "number": 343,
     "rarity": "U",
-    "name": "Dawn",
+    "name": {
+      "en": "Dawn",
+      "fr": "Aurore"
+    },
     "image": "cTR_10_000360_01_HIKARI_U.webp",
     "packs": [
       "Deluxe"
@@ -3433,7 +4462,10 @@
     "set": "A4b",
     "number": 344,
     "rarity": "U",
-    "name": "Mars",
+    "name": {
+      "en": "Mars",
+      "fr": "Mars"
+    },
     "image": "cTR_10_000370_00_MARS_U.webp",
     "packs": [
       "Deluxe"
@@ -3443,7 +4475,10 @@
     "set": "A4b",
     "number": 345,
     "rarity": "U",
-    "name": "Mars",
+    "name": {
+      "en": "Mars",
+      "fr": "Mars"
+    },
     "image": "cTR_10_000370_01_MARS_U.webp",
     "packs": [
       "Deluxe"
@@ -3453,7 +4488,10 @@
     "set": "A4b",
     "number": 346,
     "rarity": "U",
-    "name": "Leaf",
+    "name": {
+      "en": "Leaf",
+      "fr": "Leaf"
+    },
     "image": "cTR_10_000230_00_LEAF_U.webp",
     "packs": [
       "Deluxe"
@@ -3463,7 +4501,10 @@
     "set": "A4b",
     "number": 347,
     "rarity": "U",
-    "name": "Leaf",
+    "name": {
+      "en": "Leaf",
+      "fr": "Leaf"
+    },
     "image": "cTR_10_000230_01_LEAF_U.webp",
     "packs": [
       "Deluxe"
@@ -3473,7 +4514,10 @@
     "set": "A4b",
     "number": 348,
     "rarity": "U",
-    "name": "Lillie",
+    "name": {
+      "en": "Lillie",
+      "fr": "Lilie"
+    },
     "image": "cTR_10_000590_00_LILIE_U.webp",
     "packs": [
       "Deluxe"
@@ -3483,7 +4527,10 @@
     "set": "A4b",
     "number": 349,
     "rarity": "U",
-    "name": "Lillie",
+    "name": {
+      "en": "Lillie",
+      "fr": "Lilie"
+    },
     "image": "cTR_10_000590_01_LILIE_U.webp",
     "packs": [
       "Deluxe"
@@ -3493,7 +4540,10 @@
     "set": "A4b",
     "number": 350,
     "rarity": "U",
-    "name": "Lusamine",
+    "name": {
+      "en": "Lusamine",
+      "fr": "Elsa-Mina"
+    },
     "image": "cTR_10_000660_00_LUSAMINE_U.webp",
     "packs": [
       "Deluxe"
@@ -3503,7 +4553,10 @@
     "set": "A4b",
     "number": 351,
     "rarity": "U",
-    "name": "Lusamine",
+    "name": {
+      "en": "Lusamine",
+      "fr": "Elsa-Mina"
+    },
     "image": "cTR_10_000660_01_LUSAMINE_U.webp",
     "packs": [
       "Deluxe"
@@ -3513,7 +4566,10 @@
     "set": "A4b",
     "number": 352,
     "rarity": "U",
-    "name": "Red",
+    "name": {
+      "en": "Red",
+      "fr": "Red"
+    },
     "image": "cTR_10_000440_00_RED_U.webp",
     "packs": [
       "Deluxe"
@@ -3523,7 +4579,10 @@
     "set": "A4b",
     "number": 353,
     "rarity": "U",
-    "name": "Red",
+    "name": {
+      "en": "Red",
+      "fr": "Red"
+    },
     "image": "cTR_10_000440_01_RED_U.webp",
     "packs": [
       "Deluxe"
@@ -3533,7 +4592,10 @@
     "set": "A4b",
     "number": 354,
     "rarity": "AR",
-    "name": "Floragato",
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    },
     "image": "cPK_20_005250_00_NYAROTE_AR.webp",
     "packs": [
       "Deluxe"
@@ -3543,7 +4605,10 @@
     "set": "A4b",
     "number": 355,
     "rarity": "AR",
-    "name": "Crawdaunt",
+    "name": {
+      "en": "Crawdaunt",
+      "fr": "Colhomard"
+    },
     "image": "cPK_20_009170_00_SHIZARIGER_AR.webp",
     "packs": [
       "Deluxe"
@@ -3553,7 +4618,10 @@
     "set": "A4b",
     "number": 356,
     "rarity": "AR",
-    "name": "Greninja",
+    "name": {
+      "en": "Greninja",
+      "fr": "Amphinobi"
+    },
     "image": "cPK_20_000890_01_GEKKOUGA_AR.webp",
     "packs": [
       "Deluxe"
@@ -3563,7 +4631,10 @@
     "set": "A4b",
     "number": 357,
     "rarity": "AR",
-    "name": "Gardevoir",
+    "name": {
+      "en": "Gardevoir",
+      "fr": "Gardevoir"
+    },
     "image": "cPK_20_001320_01_SIRNIGHT_AR.webp",
     "packs": [
       "Deluxe"
@@ -3573,7 +4644,10 @@
     "set": "A4b",
     "number": 358,
     "rarity": "AR",
-    "name": "Slurpuff",
+    "name": {
+      "en": "Slurpuff",
+      "fr": "Cupcanaille"
+    },
     "image": "cPK_20_008260_00_PEROREAM_AR.webp",
     "packs": [
       "Deluxe"
@@ -3583,7 +4657,10 @@
     "set": "A4b",
     "number": 359,
     "rarity": "AR",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_20_001980_01_KAMONEGI_AR.webp",
     "packs": [
       "Deluxe"
@@ -3593,7 +4670,10 @@
     "set": "A4b",
     "number": 360,
     "rarity": "SR",
-    "name": "Buzzwole ex",
+    "name": {
+      "en": "Buzzwole ex",
+      "fr": "Mouscoto-ex"
+    },
     "image": "cPK_20_007480_02_MASSIVOONex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3603,7 +4683,10 @@
     "set": "A4b",
     "number": 361,
     "rarity": "SR",
-    "name": "Charizard ex",
+    "name": {
+      "en": "Charizard ex",
+      "fr": "Dracaufeu-ex"
+    },
     "image": "cPK_20_000360_03_LIZARDONex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3613,7 +4696,10 @@
     "set": "A4b",
     "number": 362,
     "rarity": "SR",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "image": "cPK_20_008900_03_HOUOUex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3623,7 +4709,10 @@
     "set": "A4b",
     "number": 363,
     "rarity": "SR",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_20_003300_03_PALKIAex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3633,7 +4722,10 @@
     "set": "A4b",
     "number": 364,
     "rarity": "SR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_000960_03_PIKACHUex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3643,7 +4735,10 @@
     "set": "A4b",
     "number": 365,
     "rarity": "SR",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_20_001290_03_MEWTWOex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3653,7 +4748,10 @@
     "set": "A4b",
     "number": 366,
     "rarity": "SR",
-    "name": "Mew ex",
+    "name": {
+      "en": "Mew ex",
+      "fr": "Mew-ex"
+    },
     "image": "cPK_20_002450_04_MEWex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3663,7 +4761,10 @@
     "set": "A4b",
     "number": 367,
     "rarity": "SR",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "image": "cPK_20_006680_03_LUNALAex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3673,7 +4774,10 @@
     "set": "A4b",
     "number": 368,
     "rarity": "SR",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_20_004000_03_DIALGAex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3683,7 +4787,10 @@
     "set": "A4b",
     "number": 369,
     "rarity": "SR",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "image": "cPK_20_007030_03_SOLGALEOex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3693,7 +4800,10 @@
     "set": "A4b",
     "number": 370,
     "rarity": "SR",
-    "name": "Eevee ex",
+    "name": {
+      "en": "Eevee ex",
+      "fr": "Évoli-ex"
+    },
     "image": "cPK_20_008480_02_EIEVUIex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3703,7 +4813,10 @@
     "set": "A4b",
     "number": 371,
     "rarity": "SR",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "image": "cPK_20_010050_03_LUGIAex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3713,7 +4826,10 @@
     "set": "A4b",
     "number": 372,
     "rarity": "SR",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_20_004950_03_ARCEUSex_SR.webp",
     "packs": [
       "Deluxe"
@@ -3723,7 +4839,10 @@
     "set": "A4b",
     "number": 373,
     "rarity": "SR",
-    "name": "Professor’s Research",
+    "name": {
+      "en": "Professor’s Research",
+      "fr": "Recherches Professorales"
+    },
     "image": "cTR_20_000040_00_HAKASENOKENKYU_SR.webp",
     "packs": [
       "Deluxe"
@@ -3733,7 +4852,10 @@
     "set": "A4b",
     "number": 374,
     "rarity": "SR",
-    "name": "Lillie",
+    "name": {
+      "en": "Lillie",
+      "fr": "Lilie"
+    },
     "image": "cTR_20_000590_02_LILIE_SR.webp",
     "packs": [
       "Deluxe"
@@ -3743,7 +4865,10 @@
     "set": "A4b",
     "number": 375,
     "rarity": "SR",
-    "name": "Lusamine",
+    "name": {
+      "en": "Lusamine",
+      "fr": "Elsa-Mina"
+    },
     "image": "cTR_20_000660_01_LUSAMINE_SR.webp",
     "packs": [
       "Deluxe"
@@ -3753,7 +4878,10 @@
     "set": "A4b",
     "number": 376,
     "rarity": "IM",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_000960_04_PIKACHUex_IM.webp",
     "packs": [
       "Deluxe"
@@ -3763,7 +4891,10 @@
     "set": "A4b",
     "number": 377,
     "rarity": "SSR",
-    "name": "Giratina ex",
+    "name": {
+      "en": "Giratina ex",
+      "fr": "Giratina-ex"
+    },
     "image": "cPK_20_005520_02_GIRATINAex_SSR.webp",
     "packs": [
       "Deluxe"
@@ -3773,7 +4904,10 @@
     "set": "A4b",
     "number": 378,
     "rarity": "SSR",
-    "name": "Darkrai ex",
+    "name": {
+      "en": "Darkrai ex",
+      "fr": "Darkrai-ex"
+    },
     "image": "cPK_20_003910_02_DARKRAIex_SSR.webp",
     "packs": [
       "Deluxe"
@@ -3783,7 +4917,10 @@
     "set": "A4b",
     "number": 379,
     "rarity": "UR",
-    "name": "Rare Candy",
+    "name": {
+      "en": "Rare Candy",
+      "fr": "Super Bonbon"
+    },
     "image": "cTR_20_000480_00_FUSHIGINAAME_UR.webp",
     "packs": [
       "Deluxe"

--- a/dist/cards/B1.json
+++ b/dist/cards/B1.json
@@ -3,7 +3,10 @@
     "set": "B1",
     "number": 1,
     "rarity": "C",
-    "name": "Pinsir",
+    "name": {
+      "en": "Pinsir",
+      "fr": "Scarabrute"
+    },
     "image": "cPK_10_010830_00_KAILIOS_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -13,7 +16,10 @@
     "set": "B1",
     "number": 2,
     "rarity": "RR",
-    "name": "Mega Pinsir ex",
+    "name": {
+      "en": "Mega Pinsir ex",
+      "fr": "Méga-Scarabrute-ex"
+    },
     "image": "cPK_10_010840_00_MEGAKAILIOSex_RR.webp",
     "packs": [
       "Mega Blaziken"
@@ -23,7 +29,10 @@
     "set": "B1",
     "number": 3,
     "rarity": "C",
-    "name": "Wurmple",
+    "name": {
+      "en": "Wurmple",
+      "fr": "Chenipotte"
+    },
     "image": "cPK_10_010850_00_KEMUSSO_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -33,7 +42,10 @@
     "set": "B1",
     "number": 4,
     "rarity": "C",
-    "name": "Silcoon",
+    "name": {
+      "en": "Silcoon",
+      "fr": "Armulys"
+    },
     "image": "cPK_10_010860_00_KARASALIS_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -43,7 +55,10 @@
     "set": "B1",
     "number": 5,
     "rarity": "R",
-    "name": "Beautifly",
+    "name": {
+      "en": "Beautifly",
+      "fr": "Charmillon"
+    },
     "image": "cPK_10_010870_00_AGEHUNT_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -53,7 +68,10 @@
     "set": "B1",
     "number": 6,
     "rarity": "C",
-    "name": "Cascoon",
+    "name": {
+      "en": "Cascoon",
+      "fr": "Blindalys"
+    },
     "image": "cPK_10_010880_00_MAYULD_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -63,7 +81,10 @@
     "set": "B1",
     "number": 7,
     "rarity": "R",
-    "name": "Dustox",
+    "name": {
+      "en": "Dustox",
+      "fr": "Papinox"
+    },
     "image": "cPK_10_010890_00_DOKUCALE_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -73,7 +94,10 @@
     "set": "B1",
     "number": 8,
     "rarity": "C",
-    "name": "Seedot",
+    "name": {
+      "en": "Seedot",
+      "fr": "Grainipiot"
+    },
     "image": "cPK_10_010900_00_TANEBOH_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -83,7 +107,10 @@
     "set": "B1",
     "number": 9,
     "rarity": "U",
-    "name": "Nuzleaf",
+    "name": {
+      "en": "Nuzleaf",
+      "fr": "Pifeuil"
+    },
     "image": "cPK_10_010910_00_KONOHANA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -93,7 +120,10 @@
     "set": "B1",
     "number": 10,
     "rarity": "R",
-    "name": "Shiftry",
+    "name": {
+      "en": "Shiftry",
+      "fr": "Tengalice"
+    },
     "image": "cPK_10_010920_00_DIRTENG_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -103,7 +133,10 @@
     "set": "B1",
     "number": 11,
     "rarity": "C",
-    "name": "Shroomish",
+    "name": {
+      "en": "Shroomish",
+      "fr": "Balignon"
+    },
     "image": "cPK_10_010930_00_KINOCOCO_C.webp",
     "packs": [
       "Mega Altaria",
@@ -115,7 +148,10 @@
     "set": "B1",
     "number": 12,
     "rarity": "U",
-    "name": "Breloom",
+    "name": {
+      "en": "Breloom",
+      "fr": "Chapignon"
+    },
     "image": "cPK_10_010940_00_KINOGASSA_U.webp",
     "packs": [
       "Mega Altaria",
@@ -127,7 +163,10 @@
     "set": "B1",
     "number": 13,
     "rarity": "C",
-    "name": "Pansage",
+    "name": {
+      "en": "Pansage",
+      "fr": "Feuillajou"
+    },
     "image": "cPK_10_010950_00_YANAPPU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -137,7 +176,10 @@
     "set": "B1",
     "number": 14,
     "rarity": "C",
-    "name": "Simisage",
+    "name": {
+      "en": "Simisage",
+      "fr": "Feuiloutan"
+    },
     "image": "cPK_10_010960_00_YANAKKIE_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -147,7 +189,10 @@
     "set": "B1",
     "number": 15,
     "rarity": "C",
-    "name": "Cottonee",
+    "name": {
+      "en": "Cottonee",
+      "fr": "Doudouvet"
+    },
     "image": "cPK_10_010970_00_MONMEN_C.webp",
     "packs": [
       "Mega Altaria"
@@ -157,7 +202,10 @@
     "set": "B1",
     "number": 16,
     "rarity": "RR",
-    "name": "Whimsicott ex",
+    "name": {
+      "en": "Whimsicott ex",
+      "fr": "Farfaduvet-ex"
+    },
     "image": "cPK_10_010980_00_ELFUUNex_RR.webp",
     "packs": [
       "Mega Altaria"
@@ -167,7 +215,10 @@
     "set": "B1",
     "number": 17,
     "rarity": "C",
-    "name": "Petilil",
+    "name": {
+      "en": "Petilil",
+      "fr": "Chlorobule"
+    },
     "image": "cPK_10_010990_00_CHURINE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -177,7 +228,10 @@
     "set": "B1",
     "number": 18,
     "rarity": "R",
-    "name": "Lilligant",
+    "name": {
+      "en": "Lilligant",
+      "fr": "Fragilady"
+    },
     "image": "cPK_10_011000_00_DREDEAR_R.webp",
     "packs": [
       "Mega Altaria"
@@ -187,7 +241,10 @@
     "set": "B1",
     "number": 19,
     "rarity": "C",
-    "name": "Maractus",
+    "name": {
+      "en": "Maractus",
+      "fr": "Maracachi"
+    },
     "image": "cPK_10_011010_00_MARACACCHI_C.webp",
     "packs": [
       "Mega Altaria",
@@ -199,7 +256,10 @@
     "set": "B1",
     "number": 20,
     "rarity": "R",
-    "name": "Virizion",
+    "name": {
+      "en": "Virizion",
+      "fr": "Viridium"
+    },
     "image": "cPK_10_011020_00_VIRIZION_R.webp",
     "packs": [
       "Mega Altaria"
@@ -209,7 +269,10 @@
     "set": "B1",
     "number": 21,
     "rarity": "C",
-    "name": "Skiddo",
+    "name": {
+      "en": "Skiddo",
+      "fr": "Cabriolaine"
+    },
     "image": "cPK_10_011030_00_MEECLE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -219,7 +282,10 @@
     "set": "B1",
     "number": 22,
     "rarity": "C",
-    "name": "Gogoat",
+    "name": {
+      "en": "Gogoat",
+      "fr": "Chevroum"
+    },
     "image": "cPK_10_011040_00_GOGOAT_C.webp",
     "packs": [
       "Mega Altaria"
@@ -229,7 +295,10 @@
     "set": "B1",
     "number": 23,
     "rarity": "C",
-    "name": "Phantump",
+    "name": {
+      "en": "Phantump",
+      "fr": "Brocélôme"
+    },
     "image": "cPK_10_011050_00_BOKUREI_C.webp",
     "packs": [
       "Mega Altaria",
@@ -241,7 +310,10 @@
     "set": "B1",
     "number": 24,
     "rarity": "U",
-    "name": "Trevenant",
+    "name": {
+      "en": "Trevenant",
+      "fr": "Desséliande"
+    },
     "image": "cPK_10_011060_00_OHROT_U.webp",
     "packs": [
       "Mega Altaria",
@@ -253,7 +325,10 @@
     "set": "B1",
     "number": 25,
     "rarity": "C",
-    "name": "Grookey",
+    "name": {
+      "en": "Grookey",
+      "fr": "Ouistempo"
+    },
     "image": "cPK_10_011070_00_SARUNORI_C.webp",
     "packs": [
       "Mega Altaria"
@@ -263,7 +338,10 @@
     "set": "B1",
     "number": 26,
     "rarity": "U",
-    "name": "Thwackey",
+    "name": {
+      "en": "Thwackey",
+      "fr": "Badabouin"
+    },
     "image": "cPK_10_011080_00_BACHINKEY_U.webp",
     "packs": [
       "Mega Altaria"
@@ -273,7 +351,10 @@
     "set": "B1",
     "number": 27,
     "rarity": "R",
-    "name": "Rillaboom",
+    "name": {
+      "en": "Rillaboom",
+      "fr": "Gorythmic"
+    },
     "image": "cPK_10_011090_00_GORIRANDER_R.webp",
     "packs": [
       "Mega Altaria"
@@ -283,7 +364,10 @@
     "set": "B1",
     "number": 28,
     "rarity": "C",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_10_011100_00_GARDIE_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -293,7 +377,10 @@
     "set": "B1",
     "number": 29,
     "rarity": "U",
-    "name": "Arcanine",
+    "name": {
+      "en": "Arcanine",
+      "fr": "Arcanin"
+    },
     "image": "cPK_10_011110_00_WINDIE_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -303,7 +390,10 @@
     "set": "B1",
     "number": 30,
     "rarity": "C",
-    "name": "Ponyta",
+    "name": {
+      "en": "Ponyta",
+      "fr": "Ponyta"
+    },
     "image": "cPK_10_011120_00_PONYTA_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -313,7 +403,10 @@
     "set": "B1",
     "number": 31,
     "rarity": "RR",
-    "name": "Rapidash ex",
+    "name": {
+      "en": "Rapidash ex",
+      "fr": "Galopa-ex"
+    },
     "image": "cPK_10_011130_00_GALLOPex_RR.webp",
     "packs": [
       "Mega Blaziken"
@@ -323,7 +416,10 @@
     "set": "B1",
     "number": 32,
     "rarity": "R",
-    "name": "Ho-Oh",
+    "name": {
+      "en": "Ho-Oh",
+      "fr": "Ho-Oh"
+    },
     "image": "cPK_10_011140_00_HOUOU_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -333,7 +429,10 @@
     "set": "B1",
     "number": 33,
     "rarity": "C",
-    "name": "Torchic",
+    "name": {
+      "en": "Torchic",
+      "fr": "Poussifeu"
+    },
     "image": "cPK_10_011150_00_ACHAMO_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -343,7 +442,10 @@
     "set": "B1",
     "number": 34,
     "rarity": "U",
-    "name": "Combusken",
+    "name": {
+      "en": "Combusken",
+      "fr": "Galifeu"
+    },
     "image": "cPK_10_011160_00_WAKASYAMO_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -353,7 +455,10 @@
     "set": "B1",
     "number": 35,
     "rarity": "R",
-    "name": "Blaziken",
+    "name": {
+      "en": "Blaziken",
+      "fr": "Braségali"
+    },
     "image": "cPK_10_011170_00_BURSYAMO_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -363,7 +468,10 @@
     "set": "B1",
     "number": 36,
     "rarity": "RR",
-    "name": "Mega Blaziken ex",
+    "name": {
+      "en": "Mega Blaziken ex",
+      "fr": "Méga-Braségali-ex"
+    },
     "image": "cPK_10_011180_00_MEGABURSYAMOex_RR.webp",
     "packs": [
       "Mega Blaziken"
@@ -373,7 +481,10 @@
     "set": "B1",
     "number": 37,
     "rarity": "C",
-    "name": "Pansear",
+    "name": {
+      "en": "Pansear",
+      "fr": "Flamajou"
+    },
     "image": "cPK_10_011190_00_BAOPPU_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -383,7 +494,10 @@
     "set": "B1",
     "number": 38,
     "rarity": "C",
-    "name": "Simisear",
+    "name": {
+      "en": "Simisear",
+      "fr": "Flamoutan"
+    },
     "image": "cPK_10_011200_00_BAOKKIE_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -393,7 +507,10 @@
     "set": "B1",
     "number": 39,
     "rarity": "C",
-    "name": "Darumaka",
+    "name": {
+      "en": "Darumaka",
+      "fr": "Darumarond"
+    },
     "image": "cPK_10_011210_00_DARUMAKKA_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -403,7 +520,10 @@
     "set": "B1",
     "number": 40,
     "rarity": "U",
-    "name": "Darmanitan",
+    "name": {
+      "en": "Darmanitan",
+      "fr": "Darumacho"
+    },
     "image": "cPK_10_011220_00_HIHIDARUMA_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -413,7 +533,10 @@
     "set": "B1",
     "number": 41,
     "rarity": "C",
-    "name": "Litwick",
+    "name": {
+      "en": "Litwick",
+      "fr": "Funécire"
+    },
     "image": "cPK_10_011230_00_HITOMOSHI_C.webp",
     "packs": [
       "Mega Altaria"
@@ -423,7 +546,10 @@
     "set": "B1",
     "number": 42,
     "rarity": "U",
-    "name": "Lampent",
+    "name": {
+      "en": "Lampent",
+      "fr": "Mélancolux"
+    },
     "image": "cPK_10_011240_00_LAMPLER_U.webp",
     "packs": [
       "Mega Altaria"
@@ -433,7 +559,10 @@
     "set": "B1",
     "number": 43,
     "rarity": "R",
-    "name": "Chandelure",
+    "name": {
+      "en": "Chandelure",
+      "fr": "Lugulabre"
+    },
     "image": "cPK_10_011250_00_CHANDELA_R.webp",
     "packs": [
       "Mega Altaria"
@@ -443,7 +572,10 @@
     "set": "B1",
     "number": 44,
     "rarity": "C",
-    "name": "Heatmor",
+    "name": {
+      "en": "Heatmor",
+      "fr": "Aflamanoir"
+    },
     "image": "cPK_10_011260_00_KUITARAN_C.webp",
     "packs": [
       "Mega Altaria",
@@ -455,7 +587,10 @@
     "set": "B1",
     "number": 45,
     "rarity": "C",
-    "name": "Litleo",
+    "name": {
+      "en": "Litleo",
+      "fr": "Hélionceau"
+    },
     "image": "cPK_10_011270_00_SHISHIKO_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -465,7 +600,10 @@
     "set": "B1",
     "number": 46,
     "rarity": "R",
-    "name": "Pyroar",
+    "name": {
+      "en": "Pyroar",
+      "fr": "Némélios"
+    },
     "image": "cPK_10_011280_00_KAENJISHI_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -475,7 +613,10 @@
     "set": "B1",
     "number": 47,
     "rarity": "U",
-    "name": "Turtonator",
+    "name": {
+      "en": "Turtonator",
+      "fr": "Boumata"
+    },
     "image": "cPK_10_011290_00_BAKUGAMES_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -485,7 +626,10 @@
     "set": "B1",
     "number": 48,
     "rarity": "C",
-    "name": "Psyduck",
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    },
     "image": "cPK_10_011300_00_KODUCK_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -495,7 +639,10 @@
     "set": "B1",
     "number": 49,
     "rarity": "C",
-    "name": "Golduck",
+    "name": {
+      "en": "Golduck",
+      "fr": "Akwakwak"
+    },
     "image": "cPK_10_011310_00_GOLDUCK_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -505,7 +652,10 @@
     "set": "B1",
     "number": 50,
     "rarity": "C",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_10_011320_00_KOIKING_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -515,7 +665,10 @@
     "set": "B1",
     "number": 51,
     "rarity": "R",
-    "name": "Gyarados",
+    "name": {
+      "en": "Gyarados",
+      "fr": "Léviator"
+    },
     "image": "cPK_10_011330_00_GYARADOS_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -525,7 +678,10 @@
     "set": "B1",
     "number": 52,
     "rarity": "RR",
-    "name": "Mega Gyarados ex",
+    "name": {
+      "en": "Mega Gyarados ex",
+      "fr": "Méga-Léviator-ex"
+    },
     "image": "cPK_10_011340_00_MEGAGYARADOSex_RR.webp",
     "packs": [
       "Mega Gyarados"
@@ -535,7 +691,10 @@
     "set": "B1",
     "number": 53,
     "rarity": "C",
-    "name": "Lotad",
+    "name": {
+      "en": "Lotad",
+      "fr": "Nénupiot"
+    },
     "image": "cPK_10_011350_00_HASSBOH_C.webp",
     "packs": [
       "Mega Altaria"
@@ -545,7 +704,10 @@
     "set": "B1",
     "number": 54,
     "rarity": "U",
-    "name": "Lombre",
+    "name": {
+      "en": "Lombre",
+      "fr": "Lombre"
+    },
     "image": "cPK_10_011360_00_HASUBRERO_U.webp",
     "packs": [
       "Mega Altaria"
@@ -555,7 +717,10 @@
     "set": "B1",
     "number": 55,
     "rarity": "R",
-    "name": "Ludicolo",
+    "name": {
+      "en": "Ludicolo",
+      "fr": "Ludicolo"
+    },
     "image": "cPK_10_011370_00_RUNPAPPA_R.webp",
     "packs": [
       "Mega Altaria"
@@ -565,7 +730,10 @@
     "set": "B1",
     "number": 56,
     "rarity": "C",
-    "name": "Wailmer",
+    "name": {
+      "en": "Wailmer",
+      "fr": "Wailmer"
+    },
     "image": "cPK_10_011380_00_HOERUKO_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -575,7 +743,10 @@
     "set": "B1",
     "number": 57,
     "rarity": "R",
-    "name": "Wailord",
+    "name": {
+      "en": "Wailord",
+      "fr": "Wailord"
+    },
     "image": "cPK_10_011390_00_WHALOH_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -585,7 +756,10 @@
     "set": "B1",
     "number": 58,
     "rarity": "C",
-    "name": "Corphish",
+    "name": {
+      "en": "Corphish",
+      "fr": "Écrapince"
+    },
     "image": "cPK_10_011400_00_HEIGANI_C.webp",
     "packs": [
       "Mega Altaria",
@@ -597,7 +771,10 @@
     "set": "B1",
     "number": 59,
     "rarity": "U",
-    "name": "Crawdaunt",
+    "name": {
+      "en": "Crawdaunt",
+      "fr": "Colhomard"
+    },
     "image": "cPK_10_011410_00_SHIZARIGER_U.webp",
     "packs": [
       "Mega Altaria",
@@ -609,7 +786,10 @@
     "set": "B1",
     "number": 60,
     "rarity": "C",
-    "name": "Luvdisc",
+    "name": {
+      "en": "Luvdisc",
+      "fr": "Lovdisc"
+    },
     "image": "cPK_10_011420_00_LOVECUS_C.webp",
     "packs": [
       "Mega Altaria"
@@ -619,7 +799,10 @@
     "set": "B1",
     "number": 61,
     "rarity": "C",
-    "name": "Panpour",
+    "name": {
+      "en": "Panpour",
+      "fr": "Flotajou"
+    },
     "image": "cPK_10_011430_00_HIYAPPU_C.webp",
     "packs": [
       "Mega Altaria"
@@ -629,7 +812,10 @@
     "set": "B1",
     "number": 62,
     "rarity": "C",
-    "name": "Simipour",
+    "name": {
+      "en": "Simipour",
+      "fr": "Flotoutan"
+    },
     "image": "cPK_10_011440_00_HIYAKKIE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -639,7 +825,10 @@
     "set": "B1",
     "number": 63,
     "rarity": "C",
-    "name": "Tympole",
+    "name": {
+      "en": "Tympole",
+      "fr": "Tritonde"
+    },
     "image": "cPK_10_011450_00_OTAMARO_C.webp",
     "packs": [
       "Mega Altaria",
@@ -651,7 +840,10 @@
     "set": "B1",
     "number": 64,
     "rarity": "C",
-    "name": "Palpitoad",
+    "name": {
+      "en": "Palpitoad",
+      "fr": "Batracné"
+    },
     "image": "cPK_10_011460_00_GAMAGARU_C.webp",
     "packs": [
       "Mega Altaria",
@@ -663,7 +855,10 @@
     "set": "B1",
     "number": 65,
     "rarity": "U",
-    "name": "Seismitoad",
+    "name": {
+      "en": "Seismitoad",
+      "fr": "Crapustule"
+    },
     "image": "cPK_10_011470_00_GAMAGEROGE_U.webp",
     "packs": [
       "Mega Altaria",
@@ -675,7 +870,10 @@
     "set": "B1",
     "number": 66,
     "rarity": "U",
-    "name": "Tirtouga",
+    "name": {
+      "en": "Tirtouga",
+      "fr": "Carapagos"
+    },
     "image": "cPK_10_011480_00_PROTOGA_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -685,7 +883,10 @@
     "set": "B1",
     "number": 67,
     "rarity": "R",
-    "name": "Carracosta",
+    "name": {
+      "en": "Carracosta",
+      "fr": "Mégapagos"
+    },
     "image": "cPK_10_011490_00_ABAGOURA_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -695,7 +896,10 @@
     "set": "B1",
     "number": 68,
     "rarity": "C",
-    "name": "Frillish",
+    "name": {
+      "en": "Frillish",
+      "fr": "Viskuse"
+    },
     "image": "cPK_10_011500_00_PURURILL_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -705,7 +909,10 @@
     "set": "B1",
     "number": 69,
     "rarity": "R",
-    "name": "Jellicent",
+    "name": {
+      "en": "Jellicent",
+      "fr": "Moyade"
+    },
     "image": "cPK_10_011510_00_BURUNGEL_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -715,7 +922,10 @@
     "set": "B1",
     "number": 70,
     "rarity": "R",
-    "name": "Keldeo",
+    "name": {
+      "en": "Keldeo",
+      "fr": "Keldeo"
+    },
     "image": "cPK_10_011520_00_KELDEOITSUMONOSUGATA_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -725,7 +935,10 @@
     "set": "B1",
     "number": 71,
     "rarity": "C",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_10_011530_00_KEROMATSU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -735,7 +948,10 @@
     "set": "B1",
     "number": 72,
     "rarity": "U",
-    "name": "Frogadier",
+    "name": {
+      "en": "Frogadier",
+      "fr": "Croâporal"
+    },
     "image": "cPK_10_011540_00_GEKOGASHIRA_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -745,7 +961,10 @@
     "set": "B1",
     "number": 73,
     "rarity": "RR",
-    "name": "Greninja ex",
+    "name": {
+      "en": "Greninja ex",
+      "fr": "Amphinobi-ex"
+    },
     "image": "cPK_10_011550_00_GEKKOUGAex_RR.webp",
     "packs": [
       "Mega Gyarados"
@@ -755,7 +974,10 @@
     "set": "B1",
     "number": 74,
     "rarity": "C",
-    "name": "Bergmite",
+    "name": {
+      "en": "Bergmite",
+      "fr": "Grelaçon"
+    },
     "image": "cPK_10_011560_00_KACHIKOHRU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -765,7 +987,10 @@
     "set": "B1",
     "number": 75,
     "rarity": "U",
-    "name": "Avalugg",
+    "name": {
+      "en": "Avalugg",
+      "fr": "Séracrawl"
+    },
     "image": "cPK_10_011570_00_CREBASE_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -775,7 +1000,10 @@
     "set": "B1",
     "number": 76,
     "rarity": "C",
-    "name": "Chewtle",
+    "name": {
+      "en": "Chewtle",
+      "fr": "Khélocrok"
+    },
     "image": "cPK_10_011580_00_KAMUKAME_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -785,7 +1013,10 @@
     "set": "B1",
     "number": 77,
     "rarity": "U",
-    "name": "Drednaw",
+    "name": {
+      "en": "Drednaw",
+      "fr": "Torgamord"
+    },
     "image": "cPK_10_011590_00_KAJIRIGAME_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -795,7 +1026,10 @@
     "set": "B1",
     "number": 78,
     "rarity": "C",
-    "name": "Arrokuda",
+    "name": {
+      "en": "Arrokuda",
+      "fr": "Embrochet"
+    },
     "image": "cPK_10_011600_00_SASIKAMASU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -805,7 +1039,10 @@
     "set": "B1",
     "number": 79,
     "rarity": "U",
-    "name": "Barraskewda",
+    "name": {
+      "en": "Barraskewda",
+      "fr": "Hastacuda"
+    },
     "image": "cPK_10_011610_00_KAMASUJAW_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -815,7 +1052,10 @@
     "set": "B1",
     "number": 80,
     "rarity": "R",
-    "name": "Eiscue",
+    "name": {
+      "en": "Eiscue",
+      "fr": "Bekaglaçon"
+    },
     "image": "cPK_10_011620_00_KORIPPO_R.webp",
     "packs": [
       "Mega Altaria"
@@ -825,7 +1065,10 @@
     "set": "B1",
     "number": 81,
     "rarity": "RR",
-    "name": "Jolteon ex",
+    "name": {
+      "en": "Jolteon ex",
+      "fr": "Voltali-ex"
+    },
     "image": "cPK_10_011630_00_THUNDERSex_RR.webp",
     "packs": [
       "Mega Gyarados"
@@ -835,7 +1078,10 @@
     "set": "B1",
     "number": 82,
     "rarity": "C",
-    "name": "Mareep",
+    "name": {
+      "en": "Mareep",
+      "fr": "Wattouat"
+    },
     "image": "cPK_10_011640_00_MERRIEP_C.webp",
     "packs": [
       "Mega Altaria"
@@ -845,7 +1091,10 @@
     "set": "B1",
     "number": 83,
     "rarity": "U",
-    "name": "Flaaffy",
+    "name": {
+      "en": "Flaaffy",
+      "fr": "Lainergie"
+    },
     "image": "cPK_10_011650_00_MOKOKO_U.webp",
     "packs": [
       "Mega Altaria"
@@ -855,7 +1104,10 @@
     "set": "B1",
     "number": 84,
     "rarity": "R",
-    "name": "Ampharos",
+    "name": {
+      "en": "Ampharos",
+      "fr": "Pharamp"
+    },
     "image": "cPK_10_011660_00_DENRYU_R.webp",
     "packs": [
       "Mega Altaria"
@@ -865,7 +1117,10 @@
     "set": "B1",
     "number": 85,
     "rarity": "RR",
-    "name": "Mega Ampharos ex",
+    "name": {
+      "en": "Mega Ampharos ex",
+      "fr": "Méga-Pharamp-ex"
+    },
     "image": "cPK_10_011670_00_MEGADENRYUex_RR.webp",
     "packs": [
       "Mega Altaria"
@@ -875,7 +1130,10 @@
     "set": "B1",
     "number": 86,
     "rarity": "C",
-    "name": "Shinx",
+    "name": {
+      "en": "Shinx",
+      "fr": "Lixy"
+    },
     "image": "cPK_10_011680_00_KOLINK_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -885,7 +1143,10 @@
     "set": "B1",
     "number": 87,
     "rarity": "U",
-    "name": "Luxio",
+    "name": {
+      "en": "Luxio",
+      "fr": "Luxio"
+    },
     "image": "cPK_10_011690_00_LUXIO_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -895,7 +1156,10 @@
     "set": "B1",
     "number": 88,
     "rarity": "R",
-    "name": "Luxray",
+    "name": {
+      "en": "Luxray",
+      "fr": "Luxray"
+    },
     "image": "cPK_10_011700_00_RENTORAR_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -905,7 +1169,10 @@
     "set": "B1",
     "number": 89,
     "rarity": "C",
-    "name": "Pachirisu",
+    "name": {
+      "en": "Pachirisu",
+      "fr": "Pachirisu"
+    },
     "image": "cPK_10_011710_00_PACHIRISU_C.webp",
     "packs": [
       "Mega Altaria",
@@ -917,7 +1184,10 @@
     "set": "B1",
     "number": 90,
     "rarity": "C",
-    "name": "Blitzle",
+    "name": {
+      "en": "Blitzle",
+      "fr": "Zébibron"
+    },
     "image": "cPK_10_011720_00_SHIMAMA_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -927,7 +1197,10 @@
     "set": "B1",
     "number": 91,
     "rarity": "U",
-    "name": "Zebstrika",
+    "name": {
+      "en": "Zebstrika",
+      "fr": "Zéblitz"
+    },
     "image": "cPK_10_011730_00_ZEBRAIKA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -937,7 +1210,10 @@
     "set": "B1",
     "number": 92,
     "rarity": "C",
-    "name": "Joltik",
+    "name": {
+      "en": "Joltik",
+      "fr": "Statitik"
+    },
     "image": "cPK_10_011740_00_BACHURU_C.webp",
     "packs": [
       "Mega Altaria",
@@ -949,7 +1225,10 @@
     "set": "B1",
     "number": 93,
     "rarity": "U",
-    "name": "Galvantula",
+    "name": {
+      "en": "Galvantula",
+      "fr": "Mygavolt"
+    },
     "image": "cPK_10_011750_00_DENTULA_U.webp",
     "packs": [
       "Mega Altaria",
@@ -961,7 +1240,10 @@
     "set": "B1",
     "number": 94,
     "rarity": "C",
-    "name": "Dedenne",
+    "name": {
+      "en": "Dedenne",
+      "fr": "Dedenne"
+    },
     "image": "cPK_10_011760_00_DEDENNE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -971,7 +1253,10 @@
     "set": "B1",
     "number": 95,
     "rarity": "C",
-    "name": "Yamper",
+    "name": {
+      "en": "Yamper",
+      "fr": "Voltoutou"
+    },
     "image": "cPK_10_011770_00_WANPACHI_C.webp",
     "packs": [
       "Mega Altaria"
@@ -981,7 +1266,10 @@
     "set": "B1",
     "number": 96,
     "rarity": "U",
-    "name": "Boltund",
+    "name": {
+      "en": "Boltund",
+      "fr": "Fulgudog"
+    },
     "image": "cPK_10_011780_00_PULSEWAN_U.webp",
     "packs": [
       "Mega Altaria"
@@ -991,7 +1279,10 @@
     "set": "B1",
     "number": 97,
     "rarity": "C",
-    "name": "Natu",
+    "name": {
+      "en": "Natu",
+      "fr": "Natu"
+    },
     "image": "cPK_10_011790_00_NATY_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1003,7 +1294,10 @@
     "set": "B1",
     "number": 98,
     "rarity": "U",
-    "name": "Xatu",
+    "name": {
+      "en": "Xatu",
+      "fr": "Xatu"
+    },
     "image": "cPK_10_011800_00_NATIO_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1015,7 +1309,10 @@
     "set": "B1",
     "number": 99,
     "rarity": "C",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_10_011810_00_MUMA_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1027,7 +1324,10 @@
     "set": "B1",
     "number": 100,
     "rarity": "U",
-    "name": "Mismagius",
+    "name": {
+      "en": "Mismagius",
+      "fr": "Magirêve"
+    },
     "image": "cPK_10_011820_00_MUMARGI_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1039,7 +1339,10 @@
     "set": "B1",
     "number": 101,
     "rarity": "C",
-    "name": "Sableye",
+    "name": {
+      "en": "Sableye",
+      "fr": "Ténéfix"
+    },
     "image": "cPK_10_011830_00_YAMIRAMI_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1049,7 +1352,10 @@
     "set": "B1",
     "number": 102,
     "rarity": "RR",
-    "name": "Mega Altaria ex",
+    "name": {
+      "en": "Mega Altaria ex",
+      "fr": "Méga-Altaria-ex"
+    },
     "image": "cPK_10_011840_00_MEGATYLTALISex_RR.webp",
     "packs": [
       "Mega Altaria"
@@ -1059,7 +1365,10 @@
     "set": "B1",
     "number": 103,
     "rarity": "C",
-    "name": "Duskull",
+    "name": {
+      "en": "Duskull",
+      "fr": "Skelénox"
+    },
     "image": "cPK_10_011850_00_YOMAWARU_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1069,7 +1378,10 @@
     "set": "B1",
     "number": 104,
     "rarity": "U",
-    "name": "Dusclops",
+    "name": {
+      "en": "Dusclops",
+      "fr": "Téraclope"
+    },
     "image": "cPK_10_011860_00_SAMAYOURU_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -1079,7 +1391,10 @@
     "set": "B1",
     "number": 105,
     "rarity": "R",
-    "name": "Dusknoir",
+    "name": {
+      "en": "Dusknoir",
+      "fr": "Noctunoir"
+    },
     "image": "cPK_10_011870_00_YONOIR_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -1089,7 +1404,10 @@
     "set": "B1",
     "number": 106,
     "rarity": "R",
-    "name": "Jirachi",
+    "name": {
+      "en": "Jirachi",
+      "fr": "Jirachi"
+    },
     "image": "cPK_10_011880_00_JIRACHI_R.webp",
     "packs": [
       "Mega Altaria"
@@ -1099,7 +1417,10 @@
     "set": "B1",
     "number": 107,
     "rarity": "C",
-    "name": "Drifloon",
+    "name": {
+      "en": "Drifloon",
+      "fr": "Baudrive"
+    },
     "image": "cPK_10_011890_00_FUWANTE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1109,7 +1430,10 @@
     "set": "B1",
     "number": 108,
     "rarity": "U",
-    "name": "Drifblim",
+    "name": {
+      "en": "Drifblim",
+      "fr": "Grodrive"
+    },
     "image": "cPK_10_011900_00_FUWARIDE_U.webp",
     "packs": [
       "Mega Altaria"
@@ -1119,7 +1443,10 @@
     "set": "B1",
     "number": 109,
     "rarity": "R",
-    "name": "Chingling",
+    "name": {
+      "en": "Chingling",
+      "fr": "Korillon"
+    },
     "image": "cPK_10_011910_00_LISYAN_R.webp",
     "packs": [
       "Mega Altaria",
@@ -1131,7 +1458,10 @@
     "set": "B1",
     "number": 110,
     "rarity": "C",
-    "name": "Yamask",
+    "name": {
+      "en": "Yamask",
+      "fr": "Tutafeh"
+    },
     "image": "cPK_10_011920_00_DESUMASU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1141,7 +1471,10 @@
     "set": "B1",
     "number": 111,
     "rarity": "R",
-    "name": "Cofagrigus",
+    "name": {
+      "en": "Cofagrigus",
+      "fr": "Tutankafer"
+    },
     "image": "cPK_10_011930_00_DESUKARN_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1151,7 +1484,10 @@
     "set": "B1",
     "number": 112,
     "rarity": "C",
-    "name": "Gothita",
+    "name": {
+      "en": "Gothita",
+      "fr": "Scrutella"
+    },
     "image": "cPK_10_011940_00_GOTHIMU_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1161,7 +1497,10 @@
     "set": "B1",
     "number": 113,
     "rarity": "U",
-    "name": "Gothorita",
+    "name": {
+      "en": "Gothorita",
+      "fr": "Mesmérella"
+    },
     "image": "cPK_10_011950_00_GOTHIMIRU_U.webp",
     "packs": [
       "Mega Altaria"
@@ -1171,7 +1510,10 @@
     "set": "B1",
     "number": 114,
     "rarity": "R",
-    "name": "Gothitelle",
+    "name": {
+      "en": "Gothitelle",
+      "fr": "Sidérella"
+    },
     "image": "cPK_10_011960_00_GOTHIRUSELLE_R.webp",
     "packs": [
       "Mega Altaria"
@@ -1181,7 +1523,10 @@
     "set": "B1",
     "number": 115,
     "rarity": "C",
-    "name": "Spritzee",
+    "name": {
+      "en": "Spritzee",
+      "fr": "Fluvetin"
+    },
     "image": "cPK_10_011970_00_SHUSHUPU_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1193,7 +1538,10 @@
     "set": "B1",
     "number": 116,
     "rarity": "U",
-    "name": "Aromatisse",
+    "name": {
+      "en": "Aromatisse",
+      "fr": "Cocotine"
+    },
     "image": "cPK_10_011980_00_FREFUWAN_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1205,7 +1553,10 @@
     "set": "B1",
     "number": 117,
     "rarity": "C",
-    "name": "Swirlix",
+    "name": {
+      "en": "Swirlix",
+      "fr": "Sucroquin"
+    },
     "image": "cPK_10_011990_00_PEROPPAFU_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1215,7 +1566,10 @@
     "set": "B1",
     "number": 118,
     "rarity": "U",
-    "name": "Slurpuff",
+    "name": {
+      "en": "Slurpuff",
+      "fr": "Cupcanaille"
+    },
     "image": "cPK_10_012000_00_PEROREAM_U.webp",
     "packs": [
       "Mega Altaria"
@@ -1225,7 +1579,10 @@
     "set": "B1",
     "number": 119,
     "rarity": "C",
-    "name": "Carbink",
+    "name": {
+      "en": "Carbink",
+      "fr": "Strassie"
+    },
     "image": "cPK_10_012010_00_MELECIE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1235,7 +1592,10 @@
     "set": "B1",
     "number": 120,
     "rarity": "R",
-    "name": "Klefki",
+    "name": {
+      "en": "Klefki",
+      "fr": "Trousselin"
+    },
     "image": "cPK_10_012020_00_CLEFFY_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1245,7 +1605,10 @@
     "set": "B1",
     "number": 121,
     "rarity": "RR",
-    "name": "Indeedee ex",
+    "name": {
+      "en": "Indeedee ex",
+      "fr": "Wimessir-ex"
+    },
     "image": "cPK_10_012030_00_YESSANMESUNOSUGATA_RR.webp",
     "packs": [
       "Mega Altaria"
@@ -1255,7 +1618,10 @@
     "set": "B1",
     "number": 122,
     "rarity": "C",
-    "name": "Sandshrew",
+    "name": {
+      "en": "Sandshrew",
+      "fr": "Sabelette"
+    },
     "image": "cPK_10_012040_00_SAND_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1267,7 +1633,10 @@
     "set": "B1",
     "number": 123,
     "rarity": "U",
-    "name": "Sandslash",
+    "name": {
+      "en": "Sandslash",
+      "fr": "Sablaireau"
+    },
     "image": "cPK_10_012050_00_SANDPAN_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1279,7 +1648,10 @@
     "set": "B1",
     "number": 124,
     "rarity": "RR",
-    "name": "Hitmonchan ex",
+    "name": {
+      "en": "Hitmonchan ex",
+      "fr": "Tygnon-ex"
+    },
     "image": "cPK_10_012060_00_EBIWALARex_RR.webp",
     "packs": [
       "Mega Blaziken"
@@ -1289,7 +1661,10 @@
     "set": "B1",
     "number": 125,
     "rarity": "C",
-    "name": "Sudowoodo",
+    "name": {
+      "en": "Sudowoodo",
+      "fr": "Simularbre"
+    },
     "image": "cPK_10_012070_00_USOKKIE_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1301,7 +1676,10 @@
     "set": "B1",
     "number": 126,
     "rarity": "C",
-    "name": "Makuhita",
+    "name": {
+      "en": "Makuhita",
+      "fr": "Makuhita"
+    },
     "image": "cPK_10_012080_00_MAKUNOSHITA_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1311,7 +1689,10 @@
     "set": "B1",
     "number": 127,
     "rarity": "U",
-    "name": "Hariyama",
+    "name": {
+      "en": "Hariyama",
+      "fr": "Hariyama"
+    },
     "image": "cPK_10_012090_00_HARITEYAMA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -1321,7 +1702,10 @@
     "set": "B1",
     "number": 128,
     "rarity": "C",
-    "name": "Hippopotas",
+    "name": {
+      "en": "Hippopotas",
+      "fr": "Hippopotas"
+    },
     "image": "cPK_10_012100_00_HIPPOPOTAS_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1331,7 +1715,10 @@
     "set": "B1",
     "number": 129,
     "rarity": "U",
-    "name": "Hippowdon",
+    "name": {
+      "en": "Hippowdon",
+      "fr": "Hippodocus"
+    },
     "image": "cPK_10_012110_00_KABALDON_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -1341,7 +1728,10 @@
     "set": "B1",
     "number": 130,
     "rarity": "C",
-    "name": "Sandile",
+    "name": {
+      "en": "Sandile",
+      "fr": "Mascaïman"
+    },
     "image": "cPK_10_012120_00_MEGUROCO_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1351,7 +1741,10 @@
     "set": "B1",
     "number": 131,
     "rarity": "U",
-    "name": "Krokorok",
+    "name": {
+      "en": "Krokorok",
+      "fr": "Escroco"
+    },
     "image": "cPK_10_012130_00_WARUVILE_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -1361,7 +1754,10 @@
     "set": "B1",
     "number": 132,
     "rarity": "R",
-    "name": "Krookodile",
+    "name": {
+      "en": "Krookodile",
+      "fr": "Crocorible"
+    },
     "image": "cPK_10_012140_00_WARUVIAL_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1371,7 +1767,10 @@
     "set": "B1",
     "number": 133,
     "rarity": "U",
-    "name": "Archen",
+    "name": {
+      "en": "Archen",
+      "fr": "Arkéapti"
+    },
     "image": "cPK_10_012150_00_ARCHEN_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -1381,7 +1780,10 @@
     "set": "B1",
     "number": 134,
     "rarity": "R",
-    "name": "Archeops",
+    "name": {
+      "en": "Archeops",
+      "fr": "Aéroptéryx"
+    },
     "image": "cPK_10_012160_00_ARCHEOS_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -1391,7 +1793,10 @@
     "set": "B1",
     "number": 135,
     "rarity": "C",
-    "name": "Golett",
+    "name": {
+      "en": "Golett",
+      "fr": "Gringolem"
+    },
     "image": "cPK_10_012170_00_GOBIT_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1401,7 +1806,10 @@
     "set": "B1",
     "number": 136,
     "rarity": "R",
-    "name": "Golurk",
+    "name": {
+      "en": "Golurk",
+      "fr": "Golemastoc"
+    },
     "image": "cPK_10_012180_00_GOLOOG_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -1411,7 +1819,10 @@
     "set": "B1",
     "number": 137,
     "rarity": "R",
-    "name": "Terrakion",
+    "name": {
+      "en": "Terrakion",
+      "fr": "Terrakium"
+    },
     "image": "cPK_10_012190_00_TERRAKION_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1421,7 +1832,10 @@
     "set": "B1",
     "number": 138,
     "rarity": "C",
-    "name": "Pancham",
+    "name": {
+      "en": "Pancham",
+      "fr": "Pandespiègle"
+    },
     "image": "cPK_10_012200_00_YANCHAM_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1431,7 +1845,10 @@
     "set": "B1",
     "number": 139,
     "rarity": "C",
-    "name": "Crabrawler",
+    "name": {
+      "en": "Crabrawler",
+      "fr": "Crabagarre"
+    },
     "image": "cPK_10_012210_00_MAKENKANI_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1441,7 +1858,10 @@
     "set": "B1",
     "number": 140,
     "rarity": "U",
-    "name": "Crabominable",
+    "name": {
+      "en": "Crabominable",
+      "fr": "Crabominable"
+    },
     "image": "cPK_10_012220_00_KEKENKANI_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -1451,7 +1871,10 @@
     "set": "B1",
     "number": 141,
     "rarity": "C",
-    "name": "Stufful",
+    "name": {
+      "en": "Stufful",
+      "fr": "Nounourson"
+    },
     "image": "cPK_10_012230_00_NUIKOGUMA_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1461,7 +1884,10 @@
     "set": "B1",
     "number": 142,
     "rarity": "U",
-    "name": "Bewear",
+    "name": {
+      "en": "Bewear",
+      "fr": "Chelours"
+    },
     "image": "cPK_10_012240_00_KITERUGUMA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -1471,7 +1897,10 @@
     "set": "B1",
     "number": 143,
     "rarity": "C",
-    "name": "Sandygast",
+    "name": {
+      "en": "Sandygast",
+      "fr": "Bacabouh"
+    },
     "image": "cPK_10_012250_00_SUNABA_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1483,7 +1912,10 @@
     "set": "B1",
     "number": 144,
     "rarity": "U",
-    "name": "Palossand",
+    "name": {
+      "en": "Palossand",
+      "fr": "Trépassable"
+    },
     "image": "cPK_10_012260_00_SIRODETHNA_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1495,7 +1927,10 @@
     "set": "B1",
     "number": 145,
     "rarity": "C",
-    "name": "Rolycoly",
+    "name": {
+      "en": "Rolycoly",
+      "fr": "Charbi"
+    },
     "image": "cPK_10_012270_00_TANDON_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1505,7 +1940,10 @@
     "set": "B1",
     "number": 146,
     "rarity": "U",
-    "name": "Carkol",
+    "name": {
+      "en": "Carkol",
+      "fr": "Wagomine"
+    },
     "image": "cPK_10_012280_00_TOROGGON_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -1515,7 +1953,10 @@
     "set": "B1",
     "number": 147,
     "rarity": "R",
-    "name": "Coalossal",
+    "name": {
+      "en": "Coalossal",
+      "fr": "Monthracite"
+    },
     "image": "cPK_10_012290_00_SEKITANZAN_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1525,7 +1966,10 @@
     "set": "B1",
     "number": 148,
     "rarity": "C",
-    "name": "Murkrow",
+    "name": {
+      "en": "Murkrow",
+      "fr": "Cornèbre"
+    },
     "image": "cPK_10_012300_00_YAMIKARASU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1535,7 +1979,10 @@
     "set": "B1",
     "number": 149,
     "rarity": "R",
-    "name": "Honchkrow",
+    "name": {
+      "en": "Honchkrow",
+      "fr": "Corboss"
+    },
     "image": "cPK_10_012310_00_DONGKARASU_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1545,7 +1992,10 @@
     "set": "B1",
     "number": 150,
     "rarity": "U",
-    "name": "Absol",
+    "name": {
+      "en": "Absol",
+      "fr": "Absol"
+    },
     "image": "cPK_10_012320_00_ABSOL_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -1555,7 +2005,10 @@
     "set": "B1",
     "number": 151,
     "rarity": "RR",
-    "name": "Mega Absol ex",
+    "name": {
+      "en": "Mega Absol ex",
+      "fr": "Méga-Absol-ex"
+    },
     "image": "cPK_10_012330_00_MEGAABSOLex_RR.webp",
     "packs": [
       "Mega Gyarados"
@@ -1565,7 +2018,10 @@
     "set": "B1",
     "number": 152,
     "rarity": "C",
-    "name": "Skorupi",
+    "name": {
+      "en": "Skorupi",
+      "fr": "Rapion"
+    },
     "image": "cPK_10_012340_00_SCORUPI_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1575,7 +2031,10 @@
     "set": "B1",
     "number": 153,
     "rarity": "U",
-    "name": "Drapion",
+    "name": {
+      "en": "Drapion",
+      "fr": "Drascore"
+    },
     "image": "cPK_10_012350_00_DORAPION_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -1585,7 +2044,10 @@
     "set": "B1",
     "number": 154,
     "rarity": "R",
-    "name": "Darkrai",
+    "name": {
+      "en": "Darkrai",
+      "fr": "Darkrai"
+    },
     "image": "cPK_10_012360_00_DARKRAI_R.webp",
     "packs": [
       "Mega Altaria"
@@ -1595,7 +2057,10 @@
     "set": "B1",
     "number": 155,
     "rarity": "C",
-    "name": "Deino",
+    "name": {
+      "en": "Deino",
+      "fr": "Solochi"
+    },
     "image": "cPK_10_012370_00_MONOZU_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1605,7 +2070,10 @@
     "set": "B1",
     "number": 156,
     "rarity": "U",
-    "name": "Zweilous",
+    "name": {
+      "en": "Zweilous",
+      "fr": "Diamat"
+    },
     "image": "cPK_10_012380_00_DIHEAD_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -1615,7 +2083,10 @@
     "set": "B1",
     "number": 157,
     "rarity": "R",
-    "name": "Hydreigon",
+    "name": {
+      "en": "Hydreigon",
+      "fr": "Trioxhydre"
+    },
     "image": "cPK_10_012390_00_SAZANDORA_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1625,7 +2096,10 @@
     "set": "B1",
     "number": 158,
     "rarity": "R",
-    "name": "Pangoro",
+    "name": {
+      "en": "Pangoro",
+      "fr": "Pandarbare"
+    },
     "image": "cPK_10_012400_00_GORONDA_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1635,7 +2109,10 @@
     "set": "B1",
     "number": 159,
     "rarity": "C",
-    "name": "Skrelp",
+    "name": {
+      "en": "Skrelp",
+      "fr": "Venalgue"
+    },
     "image": "cPK_10_012410_00_KUZUMO_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1645,7 +2122,10 @@
     "set": "B1",
     "number": 160,
     "rarity": "RR",
-    "name": "Dragalge ex",
+    "name": {
+      "en": "Dragalge ex",
+      "fr": "Kravarech-ex"
+    },
     "image": "cPK_10_012420_00_DRAMIDOROex_RR.webp",
     "packs": [
       "Mega Blaziken"
@@ -1655,7 +2135,10 @@
     "set": "B1",
     "number": 161,
     "rarity": "C",
-    "name": "Mareanie",
+    "name": {
+      "en": "Mareanie",
+      "fr": "Vorastérie"
+    },
     "image": "cPK_10_012430_00_HIDOIDE_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1667,7 +2150,10 @@
     "set": "B1",
     "number": 162,
     "rarity": "U",
-    "name": "Toxapex",
+    "name": {
+      "en": "Toxapex",
+      "fr": "Prédastérie"
+    },
     "image": "cPK_10_012440_00_DOHIDOIDE_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1679,7 +2165,10 @@
     "set": "B1",
     "number": 163,
     "rarity": "C",
-    "name": "Impidimp",
+    "name": {
+      "en": "Impidimp",
+      "fr": "Grimalin"
+    },
     "image": "cPK_10_012450_00_BEROBA_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1689,7 +2178,10 @@
     "set": "B1",
     "number": 164,
     "rarity": "U",
-    "name": "Morgrem",
+    "name": {
+      "en": "Morgrem",
+      "fr": "Fourbelin"
+    },
     "image": "cPK_10_012460_00_GIMOH_U.webp",
     "packs": [
       "Mega Altaria"
@@ -1699,7 +2191,10 @@
     "set": "B1",
     "number": 165,
     "rarity": "R",
-    "name": "Grimmsnarl",
+    "name": {
+      "en": "Grimmsnarl",
+      "fr": "Angoliath"
+    },
     "image": "cPK_10_012470_00_OHLONGE_R.webp",
     "packs": [
       "Mega Altaria"
@@ -1709,7 +2204,10 @@
     "set": "B1",
     "number": 166,
     "rarity": "C",
-    "name": "Ferroseed",
+    "name": {
+      "en": "Ferroseed",
+      "fr": "Grindur"
+    },
     "image": "cPK_10_012480_00_TESSEED_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1721,7 +2219,10 @@
     "set": "B1",
     "number": 167,
     "rarity": "U",
-    "name": "Ferrothorn",
+    "name": {
+      "en": "Ferrothorn",
+      "fr": "Noacier"
+    },
     "image": "cPK_10_012490_00_NUTREY_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1733,7 +2234,10 @@
     "set": "B1",
     "number": 168,
     "rarity": "C",
-    "name": "Durant",
+    "name": {
+      "en": "Durant",
+      "fr": "Fermite"
+    },
     "image": "cPK_10_012500_00_AIANT_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1745,7 +2249,10 @@
     "set": "B1",
     "number": 169,
     "rarity": "R",
-    "name": "Cobalion",
+    "name": {
+      "en": "Cobalion",
+      "fr": "Cobaltium"
+    },
     "image": "cPK_10_012510_00_COBALON_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -1755,7 +2262,10 @@
     "set": "B1",
     "number": 170,
     "rarity": "C",
-    "name": "Honedge",
+    "name": {
+      "en": "Honedge",
+      "fr": "Monorpale"
+    },
     "image": "cPK_10_012520_00_HITOTSUKI_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -1765,7 +2275,10 @@
     "set": "B1",
     "number": 171,
     "rarity": "U",
-    "name": "Doublade",
+    "name": {
+      "en": "Doublade",
+      "fr": "Dimoclès"
+    },
     "image": "cPK_10_012530_00_NIDANGILL_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -1775,7 +2288,10 @@
     "set": "B1",
     "number": 172,
     "rarity": "R",
-    "name": "Aegislash",
+    "name": {
+      "en": "Aegislash",
+      "fr": "Exagide"
+    },
     "image": "cPK_10_012540_00_GILLGARDBLADEFORME_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -1785,7 +2301,10 @@
     "set": "B1",
     "number": 173,
     "rarity": "C",
-    "name": "Meltan",
+    "name": {
+      "en": "Meltan",
+      "fr": "Meltan"
+    },
     "image": "cPK_10_012550_00_MELTAN_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1795,7 +2314,10 @@
     "set": "B1",
     "number": 174,
     "rarity": "RR",
-    "name": "Melmetal ex",
+    "name": {
+      "en": "Melmetal ex",
+      "fr": "Melmetal-ex"
+    },
     "image": "cPK_10_012560_00_MELMETALex_RR.webp",
     "packs": [
       "Mega Gyarados"
@@ -1805,7 +2327,10 @@
     "set": "B1",
     "number": 175,
     "rarity": "R",
-    "name": "Corviknight",
+    "name": {
+      "en": "Corviknight",
+      "fr": "Corvaillus"
+    },
     "image": "cPK_10_012570_00_ARMORGA_R.webp",
     "packs": [
       "Mega Blaziken"
@@ -1815,7 +2340,10 @@
     "set": "B1",
     "number": 176,
     "rarity": "C",
-    "name": "Druddigon",
+    "name": {
+      "en": "Druddigon",
+      "fr": "Drakkarmin"
+    },
     "image": "cPK_10_012580_00_CRIMGAN_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1825,7 +2353,10 @@
     "set": "B1",
     "number": 177,
     "rarity": "C",
-    "name": "Goomy",
+    "name": {
+      "en": "Goomy",
+      "fr": "Mucuscule"
+    },
     "image": "cPK_10_012590_00_NUMERA_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1835,7 +2366,10 @@
     "set": "B1",
     "number": 178,
     "rarity": "U",
-    "name": "Sliggoo",
+    "name": {
+      "en": "Sliggoo",
+      "fr": "Colimucus"
+    },
     "image": "cPK_10_012600_00_NUMEIL_U.webp",
     "packs": [
       "Mega Altaria"
@@ -1845,7 +2379,10 @@
     "set": "B1",
     "number": 179,
     "rarity": "R",
-    "name": "Goodra",
+    "name": {
+      "en": "Goodra",
+      "fr": "Muplodocus"
+    },
     "image": "cPK_10_012610_00_NUMELGON_R.webp",
     "packs": [
       "Mega Altaria"
@@ -1855,7 +2392,10 @@
     "set": "B1",
     "number": 180,
     "rarity": "C",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_10_012620_00_POPPO_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1867,7 +2407,10 @@
     "set": "B1",
     "number": 181,
     "rarity": "C",
-    "name": "Pidgeotto",
+    "name": {
+      "en": "Pidgeotto",
+      "fr": "Roucoups"
+    },
     "image": "cPK_10_012630_00_PIGEON_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1879,7 +2422,10 @@
     "set": "B1",
     "number": 182,
     "rarity": "U",
-    "name": "Pidgeot",
+    "name": {
+      "en": "Pidgeot",
+      "fr": "Roucarnage"
+    },
     "image": "cPK_10_012640_00_PIGEOT_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1891,7 +2437,10 @@
     "set": "B1",
     "number": 183,
     "rarity": "RR",
-    "name": "Tauros ex",
+    "name": {
+      "en": "Tauros ex",
+      "fr": "Tauros-ex"
+    },
     "image": "cPK_10_012650_00_KENTAUROSex_RR.webp",
     "packs": [
       "Mega Altaria"
@@ -1901,7 +2450,10 @@
     "set": "B1",
     "number": 184,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_10_012660_00_EIEVUI_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1911,7 +2463,10 @@
     "set": "B1",
     "number": 185,
     "rarity": "C",
-    "name": "Aipom",
+    "name": {
+      "en": "Aipom",
+      "fr": "Capumain"
+    },
     "image": "cPK_10_012670_00_EIPAM_C.webp",
     "packs": [
       "Mega Altaria"
@@ -1921,7 +2476,10 @@
     "set": "B1",
     "number": 186,
     "rarity": "U",
-    "name": "Ambipom",
+    "name": {
+      "en": "Ambipom",
+      "fr": "Capidextre"
+    },
     "image": "cPK_10_012680_00_ETEBOTH_U.webp",
     "packs": [
       "Mega Altaria"
@@ -1931,7 +2489,10 @@
     "set": "B1",
     "number": 187,
     "rarity": "C",
-    "name": "Miltank",
+    "name": {
+      "en": "Miltank",
+      "fr": "Écrémeuh"
+    },
     "image": "cPK_10_012690_00_MILTANK_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1943,7 +2504,10 @@
     "set": "B1",
     "number": 188,
     "rarity": "C",
-    "name": "Zigzagoon",
+    "name": {
+      "en": "Zigzagoon",
+      "fr": "Zigzaton"
+    },
     "image": "cPK_10_012700_00_JIGUZAGUMA_C.webp",
     "packs": [
       "Mega Altaria",
@@ -1955,7 +2519,10 @@
     "set": "B1",
     "number": 189,
     "rarity": "U",
-    "name": "Linoone",
+    "name": {
+      "en": "Linoone",
+      "fr": "Linéon"
+    },
     "image": "cPK_10_012710_00_MASSUGUMA_U.webp",
     "packs": [
       "Mega Altaria",
@@ -1967,7 +2534,10 @@
     "set": "B1",
     "number": 190,
     "rarity": "C",
-    "name": "Whismur",
+    "name": {
+      "en": "Whismur",
+      "fr": "Chuchmur"
+    },
     "image": "cPK_10_012720_00_GONYONYO_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1977,7 +2547,10 @@
     "set": "B1",
     "number": 191,
     "rarity": "C",
-    "name": "Loudred",
+    "name": {
+      "en": "Loudred",
+      "fr": "Ramboum"
+    },
     "image": "cPK_10_012730_00_DOGOHMB_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -1987,7 +2560,10 @@
     "set": "B1",
     "number": 192,
     "rarity": "R",
-    "name": "Exploud",
+    "name": {
+      "en": "Exploud",
+      "fr": "Brouhabam"
+    },
     "image": "cPK_10_012740_00_BAKUONG_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -1997,7 +2573,10 @@
     "set": "B1",
     "number": 193,
     "rarity": "C",
-    "name": "Skitty",
+    "name": {
+      "en": "Skitty",
+      "fr": "Skitty"
+    },
     "image": "cPK_10_012750_00_ENECO_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -2007,7 +2586,10 @@
     "set": "B1",
     "number": 194,
     "rarity": "R",
-    "name": "Delcatty",
+    "name": {
+      "en": "Delcatty",
+      "fr": "Delcatty"
+    },
     "image": "cPK_10_012760_00_ENEKORORO_R.webp",
     "packs": [
       "Mega Gyarados"
@@ -2017,7 +2599,10 @@
     "set": "B1",
     "number": 195,
     "rarity": "C",
-    "name": "Spinda",
+    "name": {
+      "en": "Spinda",
+      "fr": "Spinda"
+    },
     "image": "cPK_10_012770_00_PATCHEEL_C.webp",
     "packs": [
       "Mega Altaria"
@@ -2027,7 +2612,10 @@
     "set": "B1",
     "number": 196,
     "rarity": "C",
-    "name": "Swablu",
+    "name": {
+      "en": "Swablu",
+      "fr": "Tylton"
+    },
     "image": "cPK_10_012780_00_TYLTTO_C.webp",
     "packs": [
       "Mega Altaria"
@@ -2037,7 +2625,10 @@
     "set": "B1",
     "number": 197,
     "rarity": "R",
-    "name": "Altaria",
+    "name": {
+      "en": "Altaria",
+      "fr": "Altaria"
+    },
     "image": "cPK_10_012790_00_TYLTALIS_R.webp",
     "packs": [
       "Mega Altaria"
@@ -2047,7 +2638,10 @@
     "set": "B1",
     "number": 198,
     "rarity": "C",
-    "name": "Chatot",
+    "name": {
+      "en": "Chatot",
+      "fr": "Pijako"
+    },
     "image": "cPK_10_012800_00_PERAP_C.webp",
     "packs": [
       "Mega Altaria",
@@ -2059,7 +2653,10 @@
     "set": "B1",
     "number": 199,
     "rarity": "C",
-    "name": "Patrat",
+    "name": {
+      "en": "Patrat",
+      "fr": "Ratentif"
+    },
     "image": "cPK_10_012810_00_MINEZUMI_C.webp",
     "packs": [
       "Mega Altaria",
@@ -2071,7 +2668,10 @@
     "set": "B1",
     "number": 200,
     "rarity": "U",
-    "name": "Watchog",
+    "name": {
+      "en": "Watchog",
+      "fr": "Miradar"
+    },
     "image": "cPK_10_012820_00_MIRUHOG_U.webp",
     "packs": [
       "Mega Altaria",
@@ -2083,7 +2683,10 @@
     "set": "B1",
     "number": 201,
     "rarity": "C",
-    "name": "Lillipup",
+    "name": {
+      "en": "Lillipup",
+      "fr": "Ponchiot"
+    },
     "image": "cPK_10_012830_00_YORTERRIE_C.webp",
     "packs": [
       "Mega Altaria"
@@ -2093,7 +2696,10 @@
     "set": "B1",
     "number": 202,
     "rarity": "U",
-    "name": "Herdier",
+    "name": {
+      "en": "Herdier",
+      "fr": "Ponchien"
+    },
     "image": "cPK_10_012840_00_HERDERRIE_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2103,7 +2709,10 @@
     "set": "B1",
     "number": 203,
     "rarity": "R",
-    "name": "Stoutland",
+    "name": {
+      "en": "Stoutland",
+      "fr": "Mastouffe"
+    },
     "image": "cPK_10_012850_00_MOOLAND_R.webp",
     "packs": [
       "Mega Altaria"
@@ -2113,7 +2722,10 @@
     "set": "B1",
     "number": 204,
     "rarity": "C",
-    "name": "Rufflet",
+    "name": {
+      "en": "Rufflet",
+      "fr": "Furaiglon"
+    },
     "image": "cPK_10_012860_00_WASHIBON_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -2123,7 +2735,10 @@
     "set": "B1",
     "number": 205,
     "rarity": "U",
-    "name": "Braviary",
+    "name": {
+      "en": "Braviary",
+      "fr": "Gueriaigle"
+    },
     "image": "cPK_10_012870_00_WARRGLE_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2133,7 +2748,10 @@
     "set": "B1",
     "number": 206,
     "rarity": "U",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "image": "cPK_10_012880_00_TRIMMIENYASEINOSUGATA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2143,7 +2761,10 @@
     "set": "B1",
     "number": 207,
     "rarity": "U",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "image": "cPK_10_012880_01_TRIMMIENHEARTCUT_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2153,7 +2774,10 @@
     "set": "B1",
     "number": 208,
     "rarity": "U",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "image": "cPK_10_012880_02_TRIMMIENKINGDOMCUT_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -2163,7 +2787,10 @@
     "set": "B1",
     "number": 209,
     "rarity": "C",
-    "name": "Rookidee",
+    "name": {
+      "en": "Rookidee",
+      "fr": "Minisange"
+    },
     "image": "cPK_10_012890_00_KOKOGARA_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -2173,7 +2800,10 @@
     "set": "B1",
     "number": 210,
     "rarity": "U",
-    "name": "Corvisquire",
+    "name": {
+      "en": "Corvisquire",
+      "fr": "Bleuseille"
+    },
     "image": "cPK_10_012900_00_AOGARASU_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2183,7 +2813,10 @@
     "set": "B1",
     "number": 211,
     "rarity": "C",
-    "name": "Wooloo",
+    "name": {
+      "en": "Wooloo",
+      "fr": "Moumouton"
+    },
     "image": "cPK_10_012910_00_WOOLUU_C.webp",
     "packs": [
       "Mega Altaria"
@@ -2193,7 +2826,10 @@
     "set": "B1",
     "number": 212,
     "rarity": "U",
-    "name": "Dubwool",
+    "name": {
+      "en": "Dubwool",
+      "fr": "Moumouflon"
+    },
     "image": "cPK_10_012920_00_BAIWOOLUU_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2203,7 +2839,10 @@
     "set": "B1",
     "number": 213,
     "rarity": "U",
-    "name": "Prank Spinner",
+    "name": {
+      "en": "Prank Spinner",
+      "fr": "Roue Farceuse"
+    },
     "image": "cTR_10_000870_00_ITAZURAROULETTE_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2213,7 +2852,10 @@
     "set": "B1",
     "number": 214,
     "rarity": "C",
-    "name": "Plume Fossil",
+    "name": {
+      "en": "Plume Fossil",
+      "fr": "Fossile Plume"
+    },
     "image": "cTR_10_000880_00_HANENOKASEKI_C.webp",
     "packs": [
       "Mega Blaziken"
@@ -2223,7 +2865,10 @@
     "set": "B1",
     "number": 215,
     "rarity": "U",
-    "name": "Hitting Hammer",
+    "name": {
+      "en": "Hitting Hammer",
+      "fr": "Maillet Cognant"
+    },
     "image": "cTR_10_000890_00_HITHAMMER_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -2233,7 +2878,10 @@
     "set": "B1",
     "number": 216,
     "rarity": "C",
-    "name": "Cover Fossil",
+    "name": {
+      "en": "Cover Fossil",
+      "fr": "Fossile Plaque"
+    },
     "image": "cTR_10_000900_00_FUTANOKASEKI_C.webp",
     "packs": [
       "Mega Gyarados"
@@ -2243,7 +2891,10 @@
     "set": "B1",
     "number": 217,
     "rarity": "U",
-    "name": "Flame Patch",
+    "name": {
+      "en": "Flame Patch",
+      "fr": "Fortifiant Flamboyant"
+    },
     "image": "cTR_10_000910_00_FUREIMUPACCHI_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2253,7 +2904,10 @@
     "set": "B1",
     "number": 218,
     "rarity": "U",
-    "name": "Sitrus Berry",
+    "name": {
+      "en": "Sitrus Berry",
+      "fr": "Baie Sitrus"
+    },
     "image": "cTR_10_000920_00_OBONNOMI_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2263,7 +2917,10 @@
     "set": "B1",
     "number": 219,
     "rarity": "U",
-    "name": "Heavy Helmet",
+    "name": {
+      "en": "Heavy Helmet",
+      "fr": "Casque Lourd"
+    },
     "image": "cTR_10_000930_00_BABYMET_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -2273,7 +2930,10 @@
     "set": "B1",
     "number": 220,
     "rarity": "U",
-    "name": "Lucky Mittens",
+    "name": {
+      "en": "Lucky Mittens",
+      "fr": "Moufles Chance"
+    },
     "image": "cTR_10_000940_00_LUCKYMITTENS_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2283,7 +2943,10 @@
     "set": "B1",
     "number": 221,
     "rarity": "U",
-    "name": "Marlon",
+    "name": {
+      "en": "Marlon",
+      "fr": "Amana"
+    },
     "image": "cTR_10_000950_00_SHIZUI_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -2293,7 +2956,10 @@
     "set": "B1",
     "number": 222,
     "rarity": "U",
-    "name": "Hala",
+    "name": {
+      "en": "Hala",
+      "fr": "Pectorius"
+    },
     "image": "cTR_10_000960_00_HALA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2303,7 +2969,10 @@
     "set": "B1",
     "number": 223,
     "rarity": "U",
-    "name": "May",
+    "name": {
+      "en": "May",
+      "fr": "Flora"
+    },
     "image": "cTR_10_000970_00_HARUKA_U.webp",
     "packs": [
       "Mega Blaziken"
@@ -2313,7 +2982,10 @@
     "set": "B1",
     "number": 224,
     "rarity": "U",
-    "name": "Fantina",
+    "name": {
+      "en": "Fantina",
+      "fr": "Kiméra"
+    },
     "image": "cTR_10_000980_00_MELISSA_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2323,7 +2995,10 @@
     "set": "B1",
     "number": 225,
     "rarity": "U",
-    "name": "Copycat",
+    "name": {
+      "en": "Copycat",
+      "fr": "Copieuse"
+    },
     "image": "cTR_10_000990_00_MONOMANEMUSUME_U.webp",
     "packs": [
       "Mega Gyarados"
@@ -2333,7 +3008,10 @@
     "set": "B1",
     "number": 226,
     "rarity": "U",
-    "name": "Lisia",
+    "name": {
+      "en": "Lisia",
+      "fr": "Atalante"
+    },
     "image": "cTR_10_001000_00_RUCHIA_U.webp",
     "packs": [
       "Mega Altaria"
@@ -2343,7 +3021,10 @@
     "set": "B1",
     "number": 227,
     "rarity": "AR",
-    "name": "Beautifly",
+    "name": {
+      "en": "Beautifly",
+      "fr": "Charmillon"
+    },
     "image": "cPK_20_010870_00_AGEHUNT_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2353,7 +3034,10 @@
     "set": "B1",
     "number": 228,
     "rarity": "AR",
-    "name": "Skiddo",
+    "name": {
+      "en": "Skiddo",
+      "fr": "Cabriolaine"
+    },
     "image": "cPK_20_011030_00_MEECLE_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2363,7 +3047,10 @@
     "set": "B1",
     "number": 229,
     "rarity": "AR",
-    "name": "Rillaboom",
+    "name": {
+      "en": "Rillaboom",
+      "fr": "Gorythmic"
+    },
     "image": "cPK_20_011090_00_GORIRANDER_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2373,7 +3060,10 @@
     "set": "B1",
     "number": 230,
     "rarity": "AR",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "image": "cPK_20_011100_00_GARDIE_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2383,7 +3073,10 @@
     "set": "B1",
     "number": 231,
     "rarity": "AR",
-    "name": "Chandelure",
+    "name": {
+      "en": "Chandelure",
+      "fr": "Lugulabre"
+    },
     "image": "cPK_20_011250_00_CHANDELA_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2393,7 +3086,10 @@
     "set": "B1",
     "number": 232,
     "rarity": "AR",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "image": "cPK_20_011320_00_KOIKING_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2403,7 +3099,10 @@
     "set": "B1",
     "number": 233,
     "rarity": "AR",
-    "name": "Ludicolo",
+    "name": {
+      "en": "Ludicolo",
+      "fr": "Ludicolo"
+    },
     "image": "cPK_20_011370_00_RUNPAPPA_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2413,7 +3112,10 @@
     "set": "B1",
     "number": 234,
     "rarity": "AR",
-    "name": "Jellicent",
+    "name": {
+      "en": "Jellicent",
+      "fr": "Moyade"
+    },
     "image": "cPK_20_011510_00_BURUNGEL_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2423,7 +3125,10 @@
     "set": "B1",
     "number": 235,
     "rarity": "AR",
-    "name": "Keldeo",
+    "name": {
+      "en": "Keldeo",
+      "fr": "Keldeo"
+    },
     "image": "cPK_20_011520_00_KELDEOITSUMONOSUGATA_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2433,7 +3138,10 @@
     "set": "B1",
     "number": 236,
     "rarity": "AR",
-    "name": "Eiscue",
+    "name": {
+      "en": "Eiscue",
+      "fr": "Bekaglaçon"
+    },
     "image": "cPK_20_011620_00_KORIPPO_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2443,7 +3151,10 @@
     "set": "B1",
     "number": 237,
     "rarity": "AR",
-    "name": "Luxray",
+    "name": {
+      "en": "Luxray",
+      "fr": "Luxray"
+    },
     "image": "cPK_20_011700_00_RENTORAR_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2453,7 +3164,10 @@
     "set": "B1",
     "number": 238,
     "rarity": "AR",
-    "name": "Cofagrigus",
+    "name": {
+      "en": "Cofagrigus",
+      "fr": "Tutankafer"
+    },
     "image": "cPK_20_011930_00_DESUKARN_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2463,7 +3177,10 @@
     "set": "B1",
     "number": 239,
     "rarity": "AR",
-    "name": "Gothita",
+    "name": {
+      "en": "Gothita",
+      "fr": "Scrutella"
+    },
     "image": "cPK_20_011940_00_GOTHIMU_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2473,7 +3190,10 @@
     "set": "B1",
     "number": 240,
     "rarity": "AR",
-    "name": "Makuhita",
+    "name": {
+      "en": "Makuhita",
+      "fr": "Makuhita"
+    },
     "image": "cPK_20_012080_00_MAKUNOSHITA_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2483,7 +3203,10 @@
     "set": "B1",
     "number": 241,
     "rarity": "AR",
-    "name": "Hippowdon",
+    "name": {
+      "en": "Hippowdon",
+      "fr": "Hippodocus"
+    },
     "image": "cPK_20_012110_00_KABALDON_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2493,7 +3216,10 @@
     "set": "B1",
     "number": 242,
     "rarity": "AR",
-    "name": "Archeops",
+    "name": {
+      "en": "Archeops",
+      "fr": "Aéroptéryx"
+    },
     "image": "cPK_20_012160_00_ARCHEOS_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2503,7 +3229,10 @@
     "set": "B1",
     "number": 243,
     "rarity": "AR",
-    "name": "Pancham",
+    "name": {
+      "en": "Pancham",
+      "fr": "Pandespiègle"
+    },
     "image": "cPK_20_012200_00_YANCHAM_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2513,7 +3242,10 @@
     "set": "B1",
     "number": 244,
     "rarity": "AR",
-    "name": "Honchkrow",
+    "name": {
+      "en": "Honchkrow",
+      "fr": "Corboss"
+    },
     "image": "cPK_20_012310_00_DONGKARASU_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2523,7 +3255,10 @@
     "set": "B1",
     "number": 245,
     "rarity": "AR",
-    "name": "Hydreigon",
+    "name": {
+      "en": "Hydreigon",
+      "fr": "Trioxhydre"
+    },
     "image": "cPK_20_012390_00_SAZANDORA_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2533,7 +3268,10 @@
     "set": "B1",
     "number": 246,
     "rarity": "AR",
-    "name": "Corviknight",
+    "name": {
+      "en": "Corviknight",
+      "fr": "Corvaillus"
+    },
     "image": "cPK_20_012570_00_ARMORGA_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2543,7 +3281,10 @@
     "set": "B1",
     "number": 247,
     "rarity": "AR",
-    "name": "Goomy",
+    "name": {
+      "en": "Goomy",
+      "fr": "Mucuscule"
+    },
     "image": "cPK_20_012590_00_NUMERA_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2553,7 +3294,10 @@
     "set": "B1",
     "number": 248,
     "rarity": "AR",
-    "name": "Delcatty",
+    "name": {
+      "en": "Delcatty",
+      "fr": "Delcatty"
+    },
     "image": "cPK_20_012760_00_ENEKORORO_AR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2563,7 +3307,10 @@
     "set": "B1",
     "number": 249,
     "rarity": "AR",
-    "name": "Stoutland",
+    "name": {
+      "en": "Stoutland",
+      "fr": "Mastouffe"
+    },
     "image": "cPK_20_012850_00_MOOLAND_AR.webp",
     "packs": [
       "Mega Altaria"
@@ -2573,7 +3320,10 @@
     "set": "B1",
     "number": 250,
     "rarity": "AR",
-    "name": "Rufflet",
+    "name": {
+      "en": "Rufflet",
+      "fr": "Furaiglon"
+    },
     "image": "cPK_20_012860_00_WASHIBON_AR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2583,7 +3333,10 @@
     "set": "B1",
     "number": 251,
     "rarity": "SR",
-    "name": "Mega Pinsir ex",
+    "name": {
+      "en": "Mega Pinsir ex",
+      "fr": "Méga-Scarabrute-ex"
+    },
     "image": "cPK_20_010840_00_MEGAKAILIOSex_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2593,7 +3346,10 @@
     "set": "B1",
     "number": 252,
     "rarity": "SR",
-    "name": "Whimsicott ex",
+    "name": {
+      "en": "Whimsicott ex",
+      "fr": "Farfaduvet-ex"
+    },
     "image": "cPK_20_010980_00_ELFUUNex_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2603,7 +3359,10 @@
     "set": "B1",
     "number": 253,
     "rarity": "SR",
-    "name": "Rapidash ex",
+    "name": {
+      "en": "Rapidash ex",
+      "fr": "Galopa-ex"
+    },
     "image": "cPK_20_011130_00_GALLOPex_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2613,7 +3372,10 @@
     "set": "B1",
     "number": 254,
     "rarity": "SR",
-    "name": "Mega Blaziken ex",
+    "name": {
+      "en": "Mega Blaziken ex",
+      "fr": "Méga-Braségali-ex"
+    },
     "image": "cPK_20_011180_00_MEGABURSYAMOex_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2623,7 +3385,10 @@
     "set": "B1",
     "number": 255,
     "rarity": "SR",
-    "name": "Mega Gyarados ex",
+    "name": {
+      "en": "Mega Gyarados ex",
+      "fr": "Méga-Léviator-ex"
+    },
     "image": "cPK_20_011340_00_MEGAGYARADOSex_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2633,7 +3398,10 @@
     "set": "B1",
     "number": 256,
     "rarity": "SR",
-    "name": "Greninja ex",
+    "name": {
+      "en": "Greninja ex",
+      "fr": "Amphinobi-ex"
+    },
     "image": "cPK_20_011550_00_GEKKOUGAex_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2643,7 +3411,10 @@
     "set": "B1",
     "number": 257,
     "rarity": "SR",
-    "name": "Jolteon ex",
+    "name": {
+      "en": "Jolteon ex",
+      "fr": "Voltali-ex"
+    },
     "image": "cPK_20_011630_00_THUNDERSex_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2653,7 +3424,10 @@
     "set": "B1",
     "number": 258,
     "rarity": "SR",
-    "name": "Mega Ampharos ex",
+    "name": {
+      "en": "Mega Ampharos ex",
+      "fr": "Méga-Pharamp-ex"
+    },
     "image": "cPK_20_011670_00_MEGADENRYUex_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2663,7 +3437,10 @@
     "set": "B1",
     "number": 259,
     "rarity": "SR",
-    "name": "Mega Altaria ex",
+    "name": {
+      "en": "Mega Altaria ex",
+      "fr": "Méga-Altaria-ex"
+    },
     "image": "cPK_20_011840_00_MEGATYLTALISex_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2673,7 +3450,10 @@
     "set": "B1",
     "number": 260,
     "rarity": "SR",
-    "name": "Indeedee ex",
+    "name": {
+      "en": "Indeedee ex",
+      "fr": "Wimessir-ex"
+    },
     "image": "cPK_20_012030_00_YESSANMESUNOSUGATA_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2683,7 +3463,10 @@
     "set": "B1",
     "number": 261,
     "rarity": "SR",
-    "name": "Hitmonchan ex",
+    "name": {
+      "en": "Hitmonchan ex",
+      "fr": "Tygnon-ex"
+    },
     "image": "cPK_20_012060_00_EBIWALARex_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2693,7 +3476,10 @@
     "set": "B1",
     "number": 262,
     "rarity": "SR",
-    "name": "Mega Absol ex",
+    "name": {
+      "en": "Mega Absol ex",
+      "fr": "Méga-Absol-ex"
+    },
     "image": "cPK_20_012330_00_MEGAABSOLex_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2703,7 +3489,10 @@
     "set": "B1",
     "number": 263,
     "rarity": "SR",
-    "name": "Dragalge ex",
+    "name": {
+      "en": "Dragalge ex",
+      "fr": "Kravarech-ex"
+    },
     "image": "cPK_20_012420_00_DRAMIDOROex_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2713,7 +3502,10 @@
     "set": "B1",
     "number": 264,
     "rarity": "SR",
-    "name": "Melmetal ex",
+    "name": {
+      "en": "Melmetal ex",
+      "fr": "Melmetal-ex"
+    },
     "image": "cPK_20_012560_00_MELMETALex_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2723,7 +3515,10 @@
     "set": "B1",
     "number": 265,
     "rarity": "SR",
-    "name": "Tauros ex",
+    "name": {
+      "en": "Tauros ex",
+      "fr": "Tauros-ex"
+    },
     "image": "cPK_20_012650_00_KENTAUROSex_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2733,7 +3528,10 @@
     "set": "B1",
     "number": 266,
     "rarity": "SR",
-    "name": "Marlon",
+    "name": {
+      "en": "Marlon",
+      "fr": "Amana"
+    },
     "image": "cTR_20_000950_00_SHIZUI_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2743,7 +3541,10 @@
     "set": "B1",
     "number": 267,
     "rarity": "SR",
-    "name": "Hala",
+    "name": {
+      "en": "Hala",
+      "fr": "Pectorius"
+    },
     "image": "cTR_20_000960_00_HALA_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2753,7 +3554,10 @@
     "set": "B1",
     "number": 268,
     "rarity": "SR",
-    "name": "May",
+    "name": {
+      "en": "May",
+      "fr": "Flora"
+    },
     "image": "cTR_20_000970_00_HARUKA_SR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2763,7 +3567,10 @@
     "set": "B1",
     "number": 269,
     "rarity": "SR",
-    "name": "Fantina",
+    "name": {
+      "en": "Fantina",
+      "fr": "Kiméra"
+    },
     "image": "cTR_20_000980_00_MELISSA_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2773,7 +3580,10 @@
     "set": "B1",
     "number": 270,
     "rarity": "SR",
-    "name": "Copycat",
+    "name": {
+      "en": "Copycat",
+      "fr": "Copieuse"
+    },
     "image": "cTR_20_000990_00_MONOMANEMUSUME_SR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2783,7 +3593,10 @@
     "set": "B1",
     "number": 271,
     "rarity": "SR",
-    "name": "Lisia",
+    "name": {
+      "en": "Lisia",
+      "fr": "Atalante"
+    },
     "image": "cTR_20_001000_00_RUCHIA_SR.webp",
     "packs": [
       "Mega Altaria"
@@ -2793,7 +3606,10 @@
     "set": "B1",
     "number": 272,
     "rarity": "SAR",
-    "name": "Mega Pinsir ex",
+    "name": {
+      "en": "Mega Pinsir ex",
+      "fr": "Méga-Scarabrute-ex"
+    },
     "image": "cPK_20_010840_01_MEGAKAILIOSex_SAR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2803,7 +3619,10 @@
     "set": "B1",
     "number": 273,
     "rarity": "SAR",
-    "name": "Whimsicott ex",
+    "name": {
+      "en": "Whimsicott ex",
+      "fr": "Farfaduvet-ex"
+    },
     "image": "cPK_20_010980_01_ELFUUNex_SAR.webp",
     "packs": [
       "Mega Altaria"
@@ -2813,7 +3632,10 @@
     "set": "B1",
     "number": 274,
     "rarity": "SAR",
-    "name": "Rapidash ex",
+    "name": {
+      "en": "Rapidash ex",
+      "fr": "Galopa-ex"
+    },
     "image": "cPK_20_011130_01_GALLOPex_SAR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2823,7 +3645,10 @@
     "set": "B1",
     "number": 275,
     "rarity": "SAR",
-    "name": "Greninja ex",
+    "name": {
+      "en": "Greninja ex",
+      "fr": "Amphinobi-ex"
+    },
     "image": "cPK_20_011550_01_GEKKOUGAex_SAR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2833,7 +3658,10 @@
     "set": "B1",
     "number": 276,
     "rarity": "SAR",
-    "name": "Jolteon ex",
+    "name": {
+      "en": "Jolteon ex",
+      "fr": "Voltali-ex"
+    },
     "image": "cPK_20_011630_01_THUNDERSex_SAR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2843,7 +3671,10 @@
     "set": "B1",
     "number": 277,
     "rarity": "SAR",
-    "name": "Mega Ampharos ex",
+    "name": {
+      "en": "Mega Ampharos ex",
+      "fr": "Méga-Pharamp-ex"
+    },
     "image": "cPK_20_011670_01_MEGADENRYUex_SAR.webp",
     "packs": [
       "Mega Altaria"
@@ -2853,7 +3684,10 @@
     "set": "B1",
     "number": 278,
     "rarity": "SAR",
-    "name": "Indeedee ex",
+    "name": {
+      "en": "Indeedee ex",
+      "fr": "Wimessir-ex"
+    },
     "image": "cPK_20_012030_01_YESSANMESUNOSUGATA_SAR.webp",
     "packs": [
       "Mega Altaria"
@@ -2863,7 +3697,10 @@
     "set": "B1",
     "number": 279,
     "rarity": "SAR",
-    "name": "Hitmonchan ex",
+    "name": {
+      "en": "Hitmonchan ex",
+      "fr": "Tygnon-ex"
+    },
     "image": "cPK_20_012060_01_EBIWALARex_SAR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2873,7 +3710,10 @@
     "set": "B1",
     "number": 280,
     "rarity": "SAR",
-    "name": "Mega Absol ex",
+    "name": {
+      "en": "Mega Absol ex",
+      "fr": "Méga-Absol-ex"
+    },
     "image": "cPK_20_012330_01_MEGAABSOLex_SAR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2883,7 +3723,10 @@
     "set": "B1",
     "number": 281,
     "rarity": "SAR",
-    "name": "Dragalge ex",
+    "name": {
+      "en": "Dragalge ex",
+      "fr": "Kravarech-ex"
+    },
     "image": "cPK_20_012420_01_DRAMIDOROex_SAR.webp",
     "packs": [
       "Mega Blaziken"
@@ -2893,7 +3736,10 @@
     "set": "B1",
     "number": 282,
     "rarity": "SAR",
-    "name": "Melmetal ex",
+    "name": {
+      "en": "Melmetal ex",
+      "fr": "Melmetal-ex"
+    },
     "image": "cPK_20_012560_01_MELMETALex_SAR.webp",
     "packs": [
       "Mega Gyarados"
@@ -2903,7 +3749,10 @@
     "set": "B1",
     "number": 283,
     "rarity": "SAR",
-    "name": "Tauros ex",
+    "name": {
+      "en": "Tauros ex",
+      "fr": "Tauros-ex"
+    },
     "image": "cPK_20_012650_01_KENTAUROSex_SAR.webp",
     "packs": [
       "Mega Altaria"
@@ -2913,7 +3762,10 @@
     "set": "B1",
     "number": 284,
     "rarity": "IM",
-    "name": "Mega Blaziken ex",
+    "name": {
+      "en": "Mega Blaziken ex",
+      "fr": "Méga-Braségali-ex"
+    },
     "image": "cPK_20_011180_01_MEGABURSYAMOex_IM.webp",
     "packs": [
       "Mega Blaziken"
@@ -2923,7 +3775,10 @@
     "set": "B1",
     "number": 285,
     "rarity": "IM",
-    "name": "Mega Gyarados ex",
+    "name": {
+      "en": "Mega Gyarados ex",
+      "fr": "Méga-Léviator-ex"
+    },
     "image": "cPK_20_011340_01_MEGAGYARADOSex_IM.webp",
     "packs": [
       "Mega Gyarados"
@@ -2933,7 +3788,10 @@
     "set": "B1",
     "number": 286,
     "rarity": "IM",
-    "name": "Mega Altaria ex",
+    "name": {
+      "en": "Mega Altaria ex",
+      "fr": "Méga-Altaria-ex"
+    },
     "image": "cPK_20_011840_01_MEGATYLTALISex_IM.webp",
     "packs": [
       "Mega Altaria"
@@ -2943,7 +3801,10 @@
     "set": "B1",
     "number": 287,
     "rarity": "S",
-    "name": "Bellsprout",
+    "name": {
+      "en": "Bellsprout",
+      "fr": "Chétiflor"
+    },
     "image": "cPK_20_000180_00_MADATSUBOMI_S.webp",
     "packs": [
       "Mega Altaria"
@@ -2953,7 +3814,10 @@
     "set": "B1",
     "number": 288,
     "rarity": "S",
-    "name": "Weepinbell",
+    "name": {
+      "en": "Weepinbell",
+      "fr": "Boustiflor"
+    },
     "image": "cPK_20_000190_00_UTSUDON_S.webp",
     "packs": [
       "Mega Altaria"
@@ -2963,7 +3827,10 @@
     "set": "B1",
     "number": 289,
     "rarity": "S",
-    "name": "Victreebel",
+    "name": {
+      "en": "Victreebel",
+      "fr": "Empiflor"
+    },
     "image": "cPK_20_000200_00_UTSUBOT_S.webp",
     "packs": [
       "Mega Altaria"
@@ -2973,7 +3840,10 @@
     "set": "B1",
     "number": 290,
     "rarity": "S",
-    "name": "Rowlet",
+    "name": {
+      "en": "Rowlet",
+      "fr": "Brindibou"
+    },
     "image": "cPK_20_005910_00_MOKUROH_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -2983,7 +3853,10 @@
     "set": "B1",
     "number": 291,
     "rarity": "S",
-    "name": "Dartrix",
+    "name": {
+      "en": "Dartrix",
+      "fr": "Efflèche"
+    },
     "image": "cPK_20_007460_00_FUKUTHROW_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -2993,7 +3866,10 @@
     "set": "B1",
     "number": 292,
     "rarity": "S",
-    "name": "Moltres",
+    "name": {
+      "en": "Moltres",
+      "fr": "Sulfura"
+    },
     "image": "cPK_20_000460_00_FIRE_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3003,7 +3879,10 @@
     "set": "B1",
     "number": 293,
     "rarity": "S",
-    "name": "Litten",
+    "name": {
+      "en": "Litten",
+      "fr": "Flamiaou"
+    },
     "image": "cPK_20_006110_00_NYABBY_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3013,7 +3892,10 @@
     "set": "B1",
     "number": 294,
     "rarity": "S",
-    "name": "Torracat",
+    "name": {
+      "en": "Torracat",
+      "fr": "Matoufeu"
+    },
     "image": "cPK_20_006130_00_NYAHEAT_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3023,7 +3905,10 @@
     "set": "B1",
     "number": 295,
     "rarity": "S",
-    "name": "Poliwag",
+    "name": {
+      "en": "Poliwag",
+      "fr": "Ptitard"
+    },
     "image": "cPK_20_010330_00_NYOROMO_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3033,7 +3918,10 @@
     "set": "B1",
     "number": 296,
     "rarity": "S",
-    "name": "Poliwhirl",
+    "name": {
+      "en": "Poliwhirl",
+      "fr": "Têtarte"
+    },
     "image": "cPK_20_000600_00_NYOROZO_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3043,7 +3931,10 @@
     "set": "B1",
     "number": 297,
     "rarity": "S",
-    "name": "Poliwrath",
+    "name": {
+      "en": "Poliwrath",
+      "fr": "Tartard"
+    },
     "image": "cPK_20_000610_00_NYOROBON_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3053,7 +3944,10 @@
     "set": "B1",
     "number": 298,
     "rarity": "S",
-    "name": "Articuno",
+    "name": {
+      "en": "Articuno",
+      "fr": "Artikodin"
+    },
     "image": "cPK_20_000830_00_FREEZER_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3063,7 +3957,10 @@
     "set": "B1",
     "number": 299,
     "rarity": "S",
-    "name": "Manaphy",
+    "name": {
+      "en": "Manaphy",
+      "fr": "Manaphy"
+    },
     "image": "cPK_20_003310_01_MANAPHY_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3073,7 +3970,10 @@
     "set": "B1",
     "number": 300,
     "rarity": "S",
-    "name": "Popplio",
+    "name": {
+      "en": "Popplio",
+      "fr": "Otaquin"
+    },
     "image": "cPK_20_006260_00_ASHIMARI_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3083,7 +3983,10 @@
     "set": "B1",
     "number": 301,
     "rarity": "S",
-    "name": "Brionne",
+    "name": {
+      "en": "Brionne",
+      "fr": "Otarlette"
+    },
     "image": "cPK_20_008180_00_OSYAMARI_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3093,7 +3996,10 @@
     "set": "B1",
     "number": 302,
     "rarity": "S",
-    "name": "Zapdos",
+    "name": {
+      "en": "Zapdos",
+      "fr": "Électhor"
+    },
     "image": "cPK_20_001030_00_THUNDER_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3103,7 +4009,10 @@
     "set": "B1",
     "number": 303,
     "rarity": "S",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "image": "cPK_20_006470_01_ODORIDORIPACHIPACHISTYLE_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3113,7 +4022,10 @@
     "set": "B1",
     "number": 304,
     "rarity": "S",
-    "name": "Zeraora",
+    "name": {
+      "en": "Zeraora",
+      "fr": "Zeraora"
+    },
     "image": "cPK_20_007410_00_ZERAORA_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3123,7 +4035,10 @@
     "set": "B1",
     "number": 305,
     "rarity": "S",
-    "name": "Drowzee",
+    "name": {
+      "en": "Drowzee",
+      "fr": "Soporifik"
+    },
     "image": "cPK_20_001240_00_SLEEPE_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3133,7 +4048,10 @@
     "set": "B1",
     "number": 306,
     "rarity": "S",
-    "name": "Hypno",
+    "name": {
+      "en": "Hypno",
+      "fr": "Hypnomade"
+    },
     "image": "cPK_20_001250_00_SLEEPER_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3143,7 +4061,10 @@
     "set": "B1",
     "number": 307,
     "rarity": "S",
-    "name": "Geodude",
+    "name": {
+      "en": "Geodude",
+      "fr": "Racaillou"
+    },
     "image": "cPK_20_001470_00_ISITSUBUTE_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3153,7 +4074,10 @@
     "set": "B1",
     "number": 308,
     "rarity": "S",
-    "name": "Graveler",
+    "name": {
+      "en": "Graveler",
+      "fr": "Gravalanch"
+    },
     "image": "cPK_20_002570_00_GOLONE_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3163,7 +4087,10 @@
     "set": "B1",
     "number": 309,
     "rarity": "S",
-    "name": "Golem",
+    "name": {
+      "en": "Golem",
+      "fr": "Grolem"
+    },
     "image": "cPK_20_002580_00_GOLONYA_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3173,7 +4100,10 @@
     "set": "B1",
     "number": 310,
     "rarity": "S",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "image": "cPK_20_006790_01_IWANKO_S.webp",
     "packs": [
       "Mega Gyarados"
@@ -3183,7 +4113,10 @@
     "set": "B1",
     "number": 311,
     "rarity": "S",
-    "name": "Alolan Diglett",
+    "name": {
+      "en": "Alolan Diglett",
+      "fr": "Taupiqueur d'Alola"
+    },
     "image": "cPK_20_006980_00_ALOLADIGDA_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3193,7 +4126,10 @@
     "set": "B1",
     "number": 312,
     "rarity": "S",
-    "name": "Meowth",
+    "name": {
+      "en": "Meowth",
+      "fr": "Miaouss"
+    },
     "image": "cPK_20_001960_01_NYARTH_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3203,7 +4139,10 @@
     "set": "B1",
     "number": 313,
     "rarity": "S",
-    "name": "Persian",
+    "name": {
+      "en": "Persian",
+      "fr": "Persian"
+    },
     "image": "cPK_20_001970_00_PERSIAN_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3213,7 +4152,10 @@
     "set": "B1",
     "number": 314,
     "rarity": "S",
-    "name": "Doduo",
+    "name": {
+      "en": "Doduo",
+      "fr": "Doduo"
+    },
     "image": "cPK_20_001990_00_DODO_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3223,7 +4165,10 @@
     "set": "B1",
     "number": 315,
     "rarity": "S",
-    "name": "Dodrio",
+    "name": {
+      "en": "Dodrio",
+      "fr": "Dodrio"
+    },
     "image": "cPK_20_002000_00_DODORIO_S.webp",
     "packs": [
       "Mega Blaziken"
@@ -3233,7 +4178,10 @@
     "set": "B1",
     "number": 316,
     "rarity": "S",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_20_004160_01_BIPPA_S.webp",
     "packs": [
       "Mega Altaria"
@@ -3243,7 +4191,10 @@
     "set": "B1",
     "number": 317,
     "rarity": "SSR",
-    "name": "Decidueye ex",
+    "name": {
+      "en": "Decidueye ex",
+      "fr": "Archéduc-ex"
+    },
     "image": "cPK_20_005930_02_JUNAIPERex_SSR.webp",
     "packs": [
       "Mega Blaziken"
@@ -3253,7 +4204,10 @@
     "set": "B1",
     "number": 318,
     "rarity": "SSR",
-    "name": "Incineroar ex",
+    "name": {
+      "en": "Incineroar ex",
+      "fr": "Félinferno-ex"
+    },
     "image": "cPK_20_006140_02_GAOGAENex_SSR.webp",
     "packs": [
       "Mega Gyarados"
@@ -3263,7 +4217,10 @@
     "set": "B1",
     "number": 319,
     "rarity": "SSR",
-    "name": "Palkia ex",
+    "name": {
+      "en": "Palkia ex",
+      "fr": "Palkia-ex"
+    },
     "image": "cPK_20_003300_04_PALKIAex_SSR.webp",
     "packs": [
       "Mega Blaziken"
@@ -3273,7 +4230,10 @@
     "set": "B1",
     "number": 320,
     "rarity": "SSR",
-    "name": "Primarina ex",
+    "name": {
+      "en": "Primarina ex",
+      "fr": "Oratoria-ex"
+    },
     "image": "cPK_20_008190_02_ASHIRENEex_SSR.webp",
     "packs": [
       "Mega Altaria"
@@ -3283,7 +4243,10 @@
     "set": "B1",
     "number": 321,
     "rarity": "SSR",
-    "name": "Pikachu ex",
+    "name": {
+      "en": "Pikachu ex",
+      "fr": "Pikachu-ex"
+    },
     "image": "cPK_20_005410_02_PIKACHUex_SSR.webp",
     "packs": [
       "Mega Gyarados"
@@ -3293,7 +4256,10 @@
     "set": "B1",
     "number": 322,
     "rarity": "SSR",
-    "name": "Tapu Koko ex",
+    "name": {
+      "en": "Tapu Koko ex",
+      "fr": "Tokorico-ex"
+    },
     "image": "cPK_20_007420_02_KAPU-KOKEKOex_SSR.webp",
     "packs": [
       "Mega Blaziken"
@@ -3303,7 +4269,10 @@
     "set": "B1",
     "number": 323,
     "rarity": "SSR",
-    "name": "Lycanroc ex",
+    "name": {
+      "en": "Lycanroc ex",
+      "fr": "Lougaroc-ex"
+    },
     "image": "cPK_20_007700_02_LUGARUGANex_SSR.webp",
     "packs": [
       "Mega Gyarados"
@@ -3313,7 +4282,10 @@
     "set": "B1",
     "number": 324,
     "rarity": "SSR",
-    "name": "Passimian ex",
+    "name": {
+      "en": "Passimian ex",
+      "fr": "Quartermac-ex"
+    },
     "image": "cPK_20_006850_02_NAGETUKESARUex_SSR.webp",
     "packs": [
       "Mega Altaria"
@@ -3323,7 +4295,10 @@
     "set": "B1",
     "number": 325,
     "rarity": "SSR",
-    "name": "Alolan Dugtrio ex",
+    "name": {
+      "en": "Alolan Dugtrio ex",
+      "fr": "Triopikeur d'Alola-ex"
+    },
     "image": "cPK_20_007830_02_ALOLADUGTRIOex_SSR.webp",
     "packs": [
       "Mega Blaziken"
@@ -3333,7 +4308,10 @@
     "set": "B1",
     "number": 326,
     "rarity": "SSR",
-    "name": "Dialga ex",
+    "name": {
+      "en": "Dialga ex",
+      "fr": "Dialga-ex"
+    },
     "image": "cPK_20_004000_04_DIALGAex_SSR.webp",
     "packs": [
       "Mega Altaria"
@@ -3343,7 +4321,10 @@
     "set": "B1",
     "number": 327,
     "rarity": "SSR",
-    "name": "Bibarel ex",
+    "name": {
+      "en": "Bibarel ex",
+      "fr": "Castorno-ex"
+    },
     "image": "cPK_20_005790_02_BEADARUex_SSR.webp",
     "packs": [
       "Mega Altaria"
@@ -3353,7 +4334,10 @@
     "set": "B1",
     "number": 328,
     "rarity": "SSR",
-    "name": "Arceus ex",
+    "name": {
+      "en": "Arceus ex",
+      "fr": "Arceus-ex"
+    },
     "image": "cPK_20_004950_04_ARCEUSex_SSR.webp",
     "packs": [
       "Mega Gyarados"
@@ -3363,7 +4347,10 @@
     "set": "B1",
     "number": 329,
     "rarity": "UR",
-    "name": "Lilligant",
+    "name": {
+      "en": "Lilligant",
+      "fr": "Fragilady"
+    },
     "image": "cPK_20_011000_00_DREDEAR_UR.webp",
     "packs": [
       "Mega Altaria",
@@ -3375,7 +4362,10 @@
     "set": "B1",
     "number": 330,
     "rarity": "UR",
-    "name": "Klefki",
+    "name": {
+      "en": "Klefki",
+      "fr": "Trousselin"
+    },
     "image": "cPK_20_012020_00_CLEFFY_UR.webp",
     "packs": [
       "Mega Altaria",
@@ -3387,7 +4377,10 @@
     "set": "B1",
     "number": 331,
     "rarity": "UR",
-    "name": "Flame Patch",
+    "name": {
+      "en": "Flame Patch",
+      "fr": "Fortifiant Flamboyant"
+    },
     "image": "cTR_20_000910_00_FUREIMUPACCHI_UR.webp",
     "packs": [
       "Mega Altaria",

--- a/dist/cards/B1a.json
+++ b/dist/cards/B1a.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_013070_00_FUSHIGIDANE_C.webp",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "U",
     "image": "cPK_10_013080_00_FUSHIGISOU_U.webp",
-    "name": "Ivysaur",
+    "name": {
+      "en": "Ivysaur",
+      "fr": "Herbizarre"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "R",
     "image": "cPK_10_013090_00_FUSHIGIBANA_R.webp",
-    "name": "Venusaur",
+    "name": {
+      "en": "Venusaur",
+      "fr": "Florizarre"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "RR",
     "image": "cPK_10_013100_00_MEGAFUSHIGIBANAex_RR.webp",
-    "name": "Mega Venusaur ex",
+    "name": {
+      "en": "Mega Venusaur ex",
+      "fr": "Méga-Florizarre-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "C",
     "image": "cPK_10_013110_00_ITOMARU_C.webp",
-    "name": "Spinarak",
+    "name": {
+      "en": "Spinarak",
+      "fr": "Mimigal"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "U",
     "image": "cPK_10_013120_00_ARIADOS_U.webp",
-    "name": "Ariados",
+    "name": {
+      "en": "Ariados",
+      "fr": "Migalos"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "C",
     "image": "cPK_10_013130_00_HIMANUTS_C.webp",
-    "name": "Sunkern",
+    "name": {
+      "en": "Sunkern",
+      "fr": "Tournegrin"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "U",
     "image": "cPK_10_013140_00_KIMAWARI_U.webp",
-    "name": "Sunflora",
+    "name": {
+      "en": "Sunflora",
+      "fr": "Héliatronc"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "C",
     "image": "cPK_10_013150_00_MINOMUCCHI_C.webp",
-    "name": "Burmy",
+    "name": {
+      "en": "Burmy",
+      "fr": "Cheniti"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "C",
     "image": "cPK_10_013160_00_GAMALE_C.webp",
-    "name": "Mothim",
+    "name": {
+      "en": "Mothim",
+      "fr": "Papilord"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "C",
     "image": "cPK_10_013170_00_HITOKAGE_C.webp",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "U",
     "image": "cPK_10_012980_00_LIZARDO_U.webp",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "R",
     "image": "cPK_10_013180_00_LIZARDON_R.webp",
-    "name": "Charizard",
+    "name": {
+      "en": "Charizard",
+      "fr": "Dracaufeu"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "RR",
     "image": "cPK_10_013190_00_MEGALIZARDONYex_RR.webp",
-    "name": "Mega Charizard Y ex",
+    "name": {
+      "en": "Mega Charizard Y ex",
+      "fr": "Méga-Dracaufeu Y-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "C",
     "image": "cPK_10_013200_00_DELVIL_C.webp",
-    "name": "Houndour",
+    "name": {
+      "en": "Houndour",
+      "fr": "Malosse"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "C",
     "image": "cPK_10_013210_00_HELLGAR_C.webp",
-    "name": "Houndoom",
+    "name": {
+      "en": "Houndoom",
+      "fr": "Démolosse"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "C",
     "image": "cPK_10_013220_00_ZENIGAME_C.webp",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "U",
     "image": "cPK_10_013230_00_KAMEIL_U.webp",
-    "name": "Wartortle",
+    "name": {
+      "en": "Wartortle",
+      "fr": "Carabaffe"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "R",
     "image": "cPK_10_013240_00_KAMEX_R.webp",
-    "name": "Blastoise",
+    "name": {
+      "en": "Blastoise",
+      "fr": "Tortank"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "RR",
     "image": "cPK_10_013250_00_MEGAKAMEXex_RR.webp",
-    "name": "Mega Blastoise ex",
+    "name": {
+      "en": "Mega Blastoise ex",
+      "fr": "Méga-Tortank-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "C",
     "image": "cPK_10_013260_00_BASSRAOAKASUJINOSUGATA_C.webp",
-    "name": "Basculin",
+    "name": {
+      "en": "Basculin",
+      "fr": "Bargantua"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "C",
     "image": "cPK_10_013270_00_UDEPPOU_C.webp",
-    "name": "Clauncher",
+    "name": {
+      "en": "Clauncher",
+      "fr": "Flingouste"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "U",
     "image": "cPK_10_013280_00_BLOSTER_U.webp",
-    "name": "Clawitzer",
+    "name": {
+      "en": "Clawitzer",
+      "fr": "Gamblast"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "C",
     "image": "cPK_10_013290_00_COIL_C.webp",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "U",
     "image": "cPK_10_013300_00_RARECOIL_U.webp",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "R",
     "image": "cPK_10_013310_00_JIBACOIL_R.webp",
-    "name": "Magnezone",
+    "name": {
+      "en": "Magnezone",
+      "fr": "Magnézone"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "C",
     "image": "cPK_10_013320_00_EMOLGA_C.webp",
-    "name": "Emolga",
+    "name": {
+      "en": "Emolga",
+      "fr": "Emolga"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "C",
     "image": "cPK_10_013330_00_ERIKITERU_C.webp",
-    "name": "Helioptile",
+    "name": {
+      "en": "Helioptile",
+      "fr": "Galvaran"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "U",
     "image": "cPK_10_013030_00_ELEZARD_U.webp",
-    "name": "Heliolisk",
+    "name": {
+      "en": "Heliolisk",
+      "fr": "Iguolta"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "C",
     "image": "cPK_10_013340_00_MUMA_C.webp",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "U",
     "image": "cPK_10_013350_00_MUMARGI_U.webp",
-    "name": "Mismagius",
+    "name": {
+      "en": "Mismagius",
+      "fr": "Magirêve"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "C",
     "image": "cPK_10_013360_00_UNIRAN_C.webp",
-    "name": "Solosis",
+    "name": {
+      "en": "Solosis",
+      "fr": "Nucléos"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "C",
     "image": "cPK_10_013370_00_DOUBLAN_C.webp",
-    "name": "Duosion",
+    "name": {
+      "en": "Duosion",
+      "fr": "Méios"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "R",
     "image": "cPK_10_013380_00_LANCULUS_R.webp",
-    "name": "Reuniclus",
+    "name": {
+      "en": "Reuniclus",
+      "fr": "Symbios"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "C",
     "image": "cPK_10_013390_00_SHUSHUPU_C.webp",
-    "name": "Spritzee",
+    "name": {
+      "en": "Spritzee",
+      "fr": "Fluvetin"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "C",
     "image": "cPK_10_013400_00_FREFUWAN_C.webp",
-    "name": "Aromatisse",
+    "name": {
+      "en": "Aromatisse",
+      "fr": "Cocotine"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "R",
     "image": "cPK_10_013410_00_XERNEAS_R.webp",
-    "name": "Xerneas",
+    "name": {
+      "en": "Xerneas",
+      "fr": "Xerneas"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "C",
     "image": "cPK_10_013420_00_IWARK_C.webp",
-    "name": "Onix",
+    "name": {
+      "en": "Onix",
+      "fr": "Onix"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "C",
     "image": "cPK_10_013430_00_MAKUNOSHITA_C.webp",
-    "name": "Makuhita",
+    "name": {
+      "en": "Makuhita",
+      "fr": "Makuhita"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "U",
     "image": "cPK_10_013440_00_HARITEYAMA_U.webp",
-    "name": "Hariyama",
+    "name": {
+      "en": "Hariyama",
+      "fr": "Hariyama"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "C",
     "image": "cPK_10_013450_00_NOSEPASS_C.webp",
-    "name": "Nosepass",
+    "name": {
+      "en": "Nosepass",
+      "fr": "Tarinor"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "RR",
     "image": "cPK_10_013460_00_MEGAMIMILOPex_RR.webp",
-    "name": "Mega Lopunny ex",
+    "name": {
+      "en": "Mega Lopunny ex",
+      "fr": "Méga-Lockpin-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "C",
     "image": "cPK_10_013470_00_KOJOFU_C.webp",
-    "name": "Mienfoo",
+    "name": {
+      "en": "Mienfoo",
+      "fr": "Kungfouine"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "C",
     "image": "cPK_10_013480_00_KOJONDO_C.webp",
-    "name": "Mienshao",
+    "name": {
+      "en": "Mienshao",
+      "fr": "Shaofouine"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "C",
     "image": "cPK_10_013490_00_BETBETER_C.webp",
-    "name": "Grimer",
+    "name": {
+      "en": "Grimer",
+      "fr": "Tadmorv"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "C",
     "image": "cPK_10_013500_00_BETBETON_C.webp",
-    "name": "Muk",
+    "name": {
+      "en": "Muk",
+      "fr": "Grotadmorv"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "C",
     "image": "cPK_10_013510_00_CHORONEKO_C.webp",
-    "name": "Purrloin",
+    "name": {
+      "en": "Purrloin",
+      "fr": "Chacripan"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "U",
     "image": "cPK_10_013520_00_LEPARDAS_U.webp",
-    "name": "Liepard",
+    "name": {
+      "en": "Liepard",
+      "fr": "Léopardus"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "C",
     "image": "cPK_10_013530_00_YABUKURON_C.webp",
-    "name": "Trubbish",
+    "name": {
+      "en": "Trubbish",
+      "fr": "Miamiasme"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "U",
     "image": "cPK_10_013540_00_DUSTDAS_U.webp",
-    "name": "Garbodor",
+    "name": {
+      "en": "Garbodor",
+      "fr": "Miasmax"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "U",
     "image": "cPK_10_013550_00_HAGANEIL_U.webp",
-    "name": "Steelix",
+    "name": {
+      "en": "Steelix",
+      "fr": "Steelix"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "RR",
     "image": "cPK_10_013560_00_MEGAHAGANEILex_RR.webp",
-    "name": "Mega Steelix ex",
+    "name": {
+      "en": "Mega Steelix ex",
+      "fr": "Méga-Steelix-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "U",
     "image": "cPK_10_013570_00_DAINOSE_U.webp",
-    "name": "Probopass",
+    "name": {
+      "en": "Probopass",
+      "fr": "Tarinorme"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "R",
     "image": "cPK_10_013010_00_GENESECT_R.webp",
-    "name": "Genesect",
+    "name": {
+      "en": "Genesect",
+      "fr": "Genesect"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "U",
     "image": "cPK_10_013060_00_METAMON_U.webp",
-    "name": "Ditto",
+    "name": {
+      "en": "Ditto",
+      "fr": "Métamorph"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "C",
     "image": "cPK_10_013580_00_PORYGON_C.webp",
-    "name": "Porygon",
+    "name": {
+      "en": "Porygon",
+      "fr": "Porygon"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "U",
     "image": "cPK_10_013590_00_PORYGON2_U.webp",
-    "name": "Porygon2",
+    "name": {
+      "en": "Porygon2",
+      "fr": "Porygon2"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "R",
     "image": "cPK_10_013600_00_PORYGON-Z_R.webp",
-    "name": "Porygon-Z",
+    "name": {
+      "en": "Porygon-Z",
+      "fr": "Porygon-Z"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "C",
     "image": "cPK_10_013610_00_MUKKURU_C.webp",
-    "name": "Starly",
+    "name": {
+      "en": "Starly",
+      "fr": "Étourmi"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "C",
     "image": "cPK_10_013620_00_MUKUBIRD_C.webp",
-    "name": "Staravia",
+    "name": {
+      "en": "Staravia",
+      "fr": "Étourvol"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "U",
     "image": "cPK_10_013630_00_MUKUHAWK_U.webp",
-    "name": "Staraptor",
+    "name": {
+      "en": "Staraptor",
+      "fr": "Étouraptor"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "C",
     "image": "cPK_10_013040_00_MIMIROL_C.webp",
-    "name": "Buneary",
+    "name": {
+      "en": "Buneary",
+      "fr": "Laporeille"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "U",
     "image": "cPK_10_013640_00_MIMILOP_U.webp",
-    "name": "Lopunny",
+    "name": {
+      "en": "Lopunny",
+      "fr": "Lockpin"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "U",
     "image": "cPK_10_013650_00_BUFFRON_U.webp",
-    "name": "Bouffalant",
+    "name": {
+      "en": "Bouffalant",
+      "fr": "Frison"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "U",
     "image": "cPK_10_013660_00_TRIMMIENKABUKICUT_U.webp",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "U",
     "image": "cTR_10_001010_00_CITRONNORYUKKU_U.webp",
-    "name": "Clemont’s Backpack",
+    "name": {
+      "en": "Clemont’s Backpack",
+      "fr": "Sac de Lem"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "U",
     "image": "cTR_10_001020_00_SOUJYUKUEKISU_U.webp",
-    "name": "Quick-Grow Extract",
+    "name": {
+      "en": "Quick-Grow Extract",
+      "fr": "Extrait de Croissance"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "U",
     "image": "cTR_10_001030_00_CITRON_U.webp",
-    "name": "Clemont",
+    "name": {
+      "en": "Clemont",
+      "fr": "Lem"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "U",
     "image": "cTR_10_001040_00_SERENA_U.webp",
-    "name": "Serena",
+    "name": {
+      "en": "Serena",
+      "fr": "Serena"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "AR",
     "image": "cPK_20_013120_00_ARIADOS_AR.webp",
-    "name": "Ariados",
+    "name": {
+      "en": "Ariados",
+      "fr": "Migalos"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "AR",
     "image": "cPK_20_013140_00_KIMAWARI_AR.webp",
-    "name": "Sunflora",
+    "name": {
+      "en": "Sunflora",
+      "fr": "Héliatronc"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "AR",
     "image": "cPK_20_013380_00_LANCULUS_AR.webp",
-    "name": "Reuniclus",
+    "name": {
+      "en": "Reuniclus",
+      "fr": "Symbios"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "AR",
     "image": "cPK_20_013410_00_XERNEAS_AR.webp",
-    "name": "Xerneas",
+    "name": {
+      "en": "Xerneas",
+      "fr": "Xerneas"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "AR",
     "image": "cPK_20_013530_00_YABUKURON_AR.webp",
-    "name": "Trubbish",
+    "name": {
+      "en": "Trubbish",
+      "fr": "Miamiasme"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "AR",
     "image": "cPK_20_013040_00_MIMIROL_AR.webp",
-    "name": "Buneary",
+    "name": {
+      "en": "Buneary",
+      "fr": "Laporeille"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "SR",
     "image": "cPK_20_013100_00_MEGAFUSHIGIBANAex_SR.webp",
-    "name": "Mega Venusaur ex",
+    "name": {
+      "en": "Mega Venusaur ex",
+      "fr": "Méga-Florizarre-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "SR",
     "image": "cPK_20_013190_00_MEGALIZARDONYex_SR.webp",
-    "name": "Mega Charizard Y ex",
+    "name": {
+      "en": "Mega Charizard Y ex",
+      "fr": "Méga-Dracaufeu Y-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "SR",
     "image": "cPK_20_013250_00_MEGAKAMEXex_SR.webp",
-    "name": "Mega Blastoise ex",
+    "name": {
+      "en": "Mega Blastoise ex",
+      "fr": "Méga-Tortank-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "SR",
     "image": "cPK_20_013460_00_MEGAMIMILOPex_SR.webp",
-    "name": "Mega Lopunny ex",
+    "name": {
+      "en": "Mega Lopunny ex",
+      "fr": "Méga-Lockpin-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "SR",
     "image": "cPK_20_013560_00_MEGAHAGANEILex_SR.webp",
-    "name": "Mega Steelix ex",
+    "name": {
+      "en": "Mega Steelix ex",
+      "fr": "Méga-Steelix-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "SR",
     "image": "cTR_20_001030_00_CITRON_SR.webp",
-    "name": "Clemont",
+    "name": {
+      "en": "Clemont",
+      "fr": "Lem"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "SR",
     "image": "cTR_20_001040_00_SERENA_SR.webp",
-    "name": "Serena",
+    "name": {
+      "en": "Serena",
+      "fr": "Serena"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "SAR",
     "image": "cPK_20_013100_01_MEGAFUSHIGIBANAex_SAR.webp",
-    "name": "Mega Venusaur ex",
+    "name": {
+      "en": "Mega Venusaur ex",
+      "fr": "Méga-Florizarre-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "SAR",
     "image": "cPK_20_013250_01_MEGAKAMEXex_SAR.webp",
-    "name": "Mega Blastoise ex",
+    "name": {
+      "en": "Mega Blastoise ex",
+      "fr": "Méga-Tortank-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "SAR",
     "image": "cPK_20_013460_01_MEGAMIMILOPex_SAR.webp",
-    "name": "Mega Lopunny ex",
+    "name": {
+      "en": "Mega Lopunny ex",
+      "fr": "Méga-Lockpin-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "SAR",
     "image": "cPK_20_013560_01_MEGAHAGANEILex_SAR.webp",
-    "name": "Mega Steelix ex",
+    "name": {
+      "en": "Mega Steelix ex",
+      "fr": "Méga-Steelix-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "IM",
     "image": "cPK_20_013190_01_MEGALIZARDONYex_IM.webp",
-    "name": "Mega Charizard Y ex",
+    "name": {
+      "en": "Mega Charizard Y ex",
+      "fr": "Méga-Dracaufeu Y-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "S",
     "image": "cPK_20_008570_00_NAZONOKUSA_S.webp",
-    "name": "Oddish",
+    "name": {
+      "en": "Oddish",
+      "fr": "Mystherbe"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "S",
     "image": "cPK_20_008580_00_KUSAIHANA_S.webp",
-    "name": "Gloom",
+    "name": {
+      "en": "Gloom",
+      "fr": "Ortide"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "S",
     "image": "cPK_20_000130_00_RUFFRESIA_S.webp",
-    "name": "Vileplume",
+    "name": {
+      "en": "Vileplume",
+      "fr": "Rafflesia"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "S",
     "image": "cPK_20_013180_00_LIZARDON_S.webp",
-    "name": "Charizard",
+    "name": {
+      "en": "Charizard",
+      "fr": "Dracaufeu"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "S",
     "image": "cPK_20_006230_00_SHELLDER_S.webp",
-    "name": "Shellder",
+    "name": {
+      "en": "Shellder",
+      "fr": "Kokiyas"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "S",
     "image": "cPK_20_006240_00_PARSHEN_S.webp",
-    "name": "Cloyster",
+    "name": {
+      "en": "Cloyster",
+      "fr": "Crustabri"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "S",
     "image": "cPK_20_012040_00_SAND_S.webp",
-    "name": "Sandshrew",
+    "name": {
+      "en": "Sandshrew",
+      "fr": "Sabelette"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "S",
     "image": "cPK_20_012050_00_SANDPAN_S.webp",
-    "name": "Sandslash",
+    "name": {
+      "en": "Sandslash",
+      "fr": "Sablaireau"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "S",
     "image": "cPK_20_007940_00_TYPENULL_S.webp",
-    "name": "Type: Null",
+    "name": {
+      "en": "Type: Null",
+      "fr": "Type:0"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "S",
     "image": "cPK_20_007950_01_SILVADY_S.webp",
-    "name": "Silvally",
+    "name": {
+      "en": "Silvally",
+      "fr": "Silvallié"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "SSR",
     "image": "cPK_20_007480_03_MASSIVOONex_SSR.webp",
-    "name": "Buzzwole ex",
+    "name": {
+      "en": "Buzzwole ex",
+      "fr": "Mouscoto-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "SSR",
     "image": "cPK_20_006680_04_LUNALAex_SSR.webp",
-    "name": "Lunala ex",
+    "name": {
+      "en": "Lunala ex",
+      "fr": "Lunala-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "SSR",
     "image": "cPK_20_007800_02_AKUZIKINGex_SSR.webp",
-    "name": "Guzzlord ex",
+    "name": {
+      "en": "Guzzlord ex",
+      "fr": "Engloutyran-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "SSR",
     "image": "cPK_20_007030_04_SOLGALEOex_SSR.webp",
-    "name": "Solgaleo ex",
+    "name": {
+      "en": "Solgaleo ex",
+      "fr": "Solgaleo-ex"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "UR",
     "image": "cPK_20_012540_00_GILLGARDBLADEFORME_UR.webp",
-    "name": "Aegislash",
+    "name": {
+      "en": "Aegislash",
+      "fr": "Exagide"
+    },
     "packs": [
       "Crimson Blaze"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "UR",
     "image": "cTR_20_001020_00_SOUJYUKUEKISU_UR.webp",
-    "name": "Quick-Grow Extract",
+    "name": {
+      "en": "Quick-Grow Extract",
+      "fr": "Extrait de Croissance"
+    },
     "packs": [
       "Crimson Blaze"
     ]

--- a/dist/cards/B2.json
+++ b/dist/cards/B2.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_013670_00_REDIBA_C.webp",
-    "name": "Ledyba",
+    "name": {
+      "en": "Ledyba",
+      "fr": "Coxy"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "C",
     "image": "cPK_10_013680_00_REDIAN_C.webp",
-    "name": "Ledian",
+    "name": {
+      "en": "Ledian",
+      "fr": "Coxyclaque"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "C",
     "image": "cPK_10_013690_00_TSUBOTSUBO_C.webp",
-    "name": "Shuckle",
+    "name": {
+      "en": "Shuckle",
+      "fr": "Caratroc"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "C",
     "image": "cPK_10_013700_00_ROSELIA_C.webp",
-    "name": "Roselia",
+    "name": {
+      "en": "Roselia",
+      "fr": "Rosélia"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "R",
     "image": "cPK_10_013710_00_ROSERADE_R.webp",
-    "name": "Roserade",
+    "name": {
+      "en": "Roserade",
+      "fr": "Roserade"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "C",
     "image": "cPK_10_013720_00_SABONEA_C.webp",
-    "name": "Cacnea",
+    "name": {
+      "en": "Cacnea",
+      "fr": "Cacnea"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "U",
     "image": "cPK_10_013730_00_NOCTUS_U.webp",
-    "name": "Cacturne",
+    "name": {
+      "en": "Cacturne",
+      "fr": "Cacturne"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "C",
     "image": "cPK_10_013740_00_HARIMARON_C.webp",
-    "name": "Chespin",
+    "name": {
+      "en": "Chespin",
+      "fr": "Marisson"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "U",
     "image": "cPK_10_013750_00_HARIBORG_U.webp",
-    "name": "Quilladin",
+    "name": {
+      "en": "Quilladin",
+      "fr": "Boguérisse"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "R",
     "image": "cPK_10_013760_00_BRIGARRON_R.webp",
-    "name": "Chesnaught",
+    "name": {
+      "en": "Chesnaught",
+      "fr": "Blindépique"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "C",
     "image": "cPK_10_013770_00_KOFUKIMUSHI_C.webp",
-    "name": "Scatterbug",
+    "name": {
+      "en": "Scatterbug",
+      "fr": "Lépidonille"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "C",
     "image": "cPK_10_013780_00_KOFUURAI_C.webp",
-    "name": "Spewpa",
+    "name": {
+      "en": "Spewpa",
+      "fr": "Pérégrain"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "U",
     "image": "cPK_10_013790_00_VIVIYON_U.webp",
-    "name": "Vivillon",
+    "name": {
+      "en": "Vivillon",
+      "fr": "Prismillon"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "R",
     "image": "cPK_10_013800_00_MASSIVOON_R.webp",
-    "name": "Buzzwole",
+    "name": {
+      "en": "Buzzwole",
+      "fr": "Mouscoto"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "C",
     "image": "cPK_10_013810_00_HIMENKA_C.webp",
-    "name": "Gossifleur",
+    "name": {
+      "en": "Gossifleur",
+      "fr": "Tournicoton"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "U",
     "image": "cPK_10_013820_00_WATASHIRAGA_U.webp",
-    "name": "Eldegoss",
+    "name": {
+      "en": "Eldegoss",
+      "fr": "Blancoton"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "RR",
     "image": "cPK_10_013830_00_OGERPONMIDORINOMENex_RR.webp",
-    "name": "Teal Mask Ogerpon ex",
+    "name": {
+      "en": "Teal Mask Ogerpon ex",
+      "fr": "Ogerpon Masque Turquoise-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "U",
     "image": "cPK_10_013840_00_ALOLAGARAGARA_U.webp",
-    "name": "Alolan Marowak",
+    "name": {
+      "en": "Alolan Marowak",
+      "fr": "Ossatueur d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "R",
     "image": "cPK_10_013850_00_RESHIRAM_R.webp",
-    "name": "Reshiram",
+    "name": {
+      "en": "Reshiram",
+      "fr": "Reshiram"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "C",
     "image": "cPK_10_013860_00_SHISHIKO_C.webp",
-    "name": "Litleo",
+    "name": {
+      "en": "Litleo",
+      "fr": "Hélionceau"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "U",
     "image": "cPK_10_013870_00_KAENJISHI_U.webp",
-    "name": "Pyroar",
+    "name": {
+      "en": "Pyroar",
+      "fr": "Némélios"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "U",
     "image": "cPK_10_013880_00_ODORIDORI_U.webp",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "RR",
     "image": "cPK_10_013890_00_ZUGADOONex_RR.webp",
-    "name": "Blacephalon ex",
+    "name": {
+      "en": "Blacephalon ex",
+      "fr": "Pierroteknik-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "C",
     "image": "cPK_10_013900_00_HIBANNY_C.webp",
-    "name": "Scorbunny",
+    "name": {
+      "en": "Scorbunny",
+      "fr": "Flambino"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "U",
     "image": "cPK_10_013910_00_RABBIFUTO_U.webp",
-    "name": "Raboot",
+    "name": {
+      "en": "Raboot",
+      "fr": "Lapyro"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "R",
     "image": "cPK_10_013920_00_ACEBURN_R.webp",
-    "name": "Cinderace",
+    "name": {
+      "en": "Cinderace",
+      "fr": "Pyrobut"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "R",
     "image": "cPK_10_013930_00_OGERPONKAMADONOMEN_R.webp",
-    "name": "Hearthflame Mask Ogerpon",
+    "name": {
+      "en": "Hearthflame Mask Ogerpon",
+      "fr": "Ogerpon Masque du Fourneau"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "C",
     "image": "cPK_10_013940_00_ALOLAROKON_C.webp",
-    "name": "Alolan Vulpix",
+    "name": {
+      "en": "Alolan Vulpix",
+      "fr": "Goupix d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "RR",
     "image": "cPK_10_013950_00_ALOLAKYUKONex_RR.webp",
-    "name": "Alolan Ninetales ex",
+    "name": {
+      "en": "Alolan Ninetales ex",
+      "fr": "Feunard d'Alola-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "C",
     "image": "cPK_10_013960_00_GALARBARRIERD_C.webp",
-    "name": "Galarian Mr. Mime",
+    "name": {
+      "en": "Galarian Mr. Mime",
+      "fr": "M. Mime de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "U",
     "image": "cPK_10_013970_00_GALARBARRIKOHRU_U.webp",
-    "name": "Galarian Mr. Rime",
+    "name": {
+      "en": "Galarian Mr. Rime",
+      "fr": "M. Glaquette de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "U",
     "image": "cPK_10_013980_00_DELIBIRD_U.webp",
-    "name": "Delibird",
+    "name": {
+      "en": "Delibird",
+      "fr": "Cadoizo"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "C",
     "image": "cPK_10_013990_00_MIZUGOROU_C.webp",
-    "name": "Mudkip",
+    "name": {
+      "en": "Mudkip",
+      "fr": "Gobou"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "U",
     "image": "cPK_10_014000_00_NUMACRAW_U.webp",
-    "name": "Marshtomp",
+    "name": {
+      "en": "Marshtomp",
+      "fr": "Flobio"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "R",
     "image": "cPK_10_014010_00_LAGLARGE_R.webp",
-    "name": "Swampert",
+    "name": {
+      "en": "Swampert",
+      "fr": "Laggron"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "RR",
     "image": "cPK_10_014020_00_MEGALAGLARGEex_RR.webp",
-    "name": "Mega Swampert ex",
+    "name": {
+      "en": "Mega Swampert ex",
+      "fr": "Méga-Laggron-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "C",
     "image": "cPK_10_014030_00_VANIPETI_C.webp",
-    "name": "Vanillite",
+    "name": {
+      "en": "Vanillite",
+      "fr": "Sorbébé"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "C",
     "image": "cPK_10_014040_00_VANIRICH_C.webp",
-    "name": "Vanillish",
+    "name": {
+      "en": "Vanillish",
+      "fr": "Sorboul"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "U",
     "image": "cPK_10_014050_00_BAIVANILLA_U.webp",
-    "name": "Vanilluxe",
+    "name": {
+      "en": "Vanilluxe",
+      "fr": "Sorbouboul"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "C",
     "image": "cPK_10_014060_00_FREEGEO_C.webp",
-    "name": "Cryogonal",
+    "name": {
+      "en": "Cryogonal",
+      "fr": "Hexagel"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "U",
     "image": "cPK_10_014070_00_AMARUS_U.webp",
-    "name": "Amaura",
+    "name": {
+      "en": "Amaura",
+      "fr": "Amagara"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "R",
     "image": "cPK_10_014080_00_AMARURUGA_R.webp",
-    "name": "Aurorus",
+    "name": {
+      "en": "Aurorus",
+      "fr": "Dragmara"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "C",
     "image": "cPK_10_014090_00_KAMUKAME_C.webp",
-    "name": "Chewtle",
+    "name": {
+      "en": "Chewtle",
+      "fr": "Khélocrok"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "U",
     "image": "cPK_10_014100_00_KAJIRIGAME_U.webp",
-    "name": "Drednaw",
+    "name": {
+      "en": "Drednaw",
+      "fr": "Torgamord"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "C",
     "image": "cPK_10_014110_00_UU_C.webp",
-    "name": "Cramorant",
+    "name": {
+      "en": "Cramorant",
+      "fr": "Nigosier"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "C",
     "image": "cPK_10_014120_00_SASIKAMASU_C.webp",
-    "name": "Arrokuda",
+    "name": {
+      "en": "Arrokuda",
+      "fr": "Embrochet"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "C",
     "image": "cPK_10_014130_00_KAMASUJAW_C.webp",
-    "name": "Barraskewda",
+    "name": {
+      "en": "Barraskewda",
+      "fr": "Hastacuda"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "R",
     "image": "cPK_10_014140_00_OGERPONIDONOMEN_R.webp",
-    "name": "Wellspring Mask Ogerpon",
+    "name": {
+      "en": "Wellspring Mask Ogerpon",
+      "fr": "Ogerpon Masque du Puits"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "C",
     "image": "cPK_10_014150_00_PIKACHU_C.webp",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "R",
     "image": "cPK_10_014160_00_ALOLARAICHU_R.webp",
-    "name": "Alolan Raichu",
+    "name": {
+      "en": "Alolan Raichu",
+      "fr": "Raichu d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "R",
     "image": "cPK_10_014170_00_THUNDER_R.webp",
-    "name": "Zapdos",
+    "name": {
+      "en": "Zapdos",
+      "fr": "Électhor"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "C",
     "image": "cPK_10_014180_00_PRASLE_C.webp",
-    "name": "Plusle",
+    "name": {
+      "en": "Plusle",
+      "fr": "Posipi"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "C",
     "image": "cPK_10_014190_00_MINUN_C.webp",
-    "name": "Minun",
+    "name": {
+      "en": "Minun",
+      "fr": "Négapi"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "C",
     "image": "cPK_10_014200_00_ELESON_C.webp",
-    "name": "Toxel",
+    "name": {
+      "en": "Toxel",
+      "fr": "Toxizap"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "RR",
     "image": "cPK_10_014210_00_STRINDERex_RR.webp",
-    "name": "Toxtricity ex",
+    "name": {
+      "en": "Toxtricity ex",
+      "fr": "Salarsen-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "C",
     "image": "cPK_10_014220_00_ZUPIKA_C.webp",
-    "name": "Tadbulb",
+    "name": {
+      "en": "Tadbulb",
+      "fr": "Têtampoule"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "U",
     "image": "cPK_10_014230_00_HARABARIE_U.webp",
-    "name": "Bellibolt",
+    "name": {
+      "en": "Bellibolt",
+      "fr": "Ampibidou"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "C",
     "image": "cPK_10_014240_00_GALARPONYTA_C.webp",
-    "name": "Galarian Ponyta",
+    "name": {
+      "en": "Galarian Ponyta",
+      "fr": "Ponyta de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "U",
     "image": "cPK_10_014250_00_GALARGALLOP_U.webp",
-    "name": "Galarian Rapidash",
+    "name": {
+      "en": "Galarian Rapidash",
+      "fr": "Galopa de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "C",
     "image": "cPK_10_014260_00_SONANS_C.webp",
-    "name": "Wobbuffet",
+    "name": {
+      "en": "Wobbuffet",
+      "fr": "Qulbutoké"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "C",
     "image": "cPK_10_014270_00_BULU_C.webp",
-    "name": "Snubbull",
+    "name": {
+      "en": "Snubbull",
+      "fr": "Snubbull"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "U",
     "image": "cPK_10_014280_00_GRANBULU_U.webp",
-    "name": "Granbull",
+    "name": {
+      "en": "Granbull",
+      "fr": "Granbull"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "C",
     "image": "cPK_10_014290_00_RALTS_C.webp",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "U",
     "image": "cPK_10_014300_00_KIRLIA_U.webp",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "R",
     "image": "cPK_10_014310_00_SIRNIGHT_R.webp",
-    "name": "Gardevoir",
+    "name": {
+      "en": "Gardevoir",
+      "fr": "Gardevoir"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "RR",
     "image": "cPK_10_014320_00_MEGASIRNIGHTex_RR.webp",
-    "name": "Mega Gardevoir ex",
+    "name": {
+      "en": "Mega Gardevoir ex",
+      "fr": "Méga-Gardevoir-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "C",
     "image": "cPK_10_014330_00_HITOMOSHI_C.webp",
-    "name": "Litwick",
+    "name": {
+      "en": "Litwick",
+      "fr": "Funécire"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "U",
     "image": "cPK_10_014340_00_LAMPLER_U.webp",
-    "name": "Lampent",
+    "name": {
+      "en": "Lampent",
+      "fr": "Mélancolux"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "R",
     "image": "cPK_10_014350_00_CHANDELA_R.webp",
-    "name": "Chandelure",
+    "name": {
+      "en": "Chandelure",
+      "fr": "Lugulabre"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "U",
     "image": "cPK_10_014360_00_MELOETTA_U.webp",
-    "name": "Meloetta",
+    "name": {
+      "en": "Meloetta",
+      "fr": "Meloetta"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "C",
     "image": "cPK_10_014370_00_BAKECCHA_C.webp",
-    "name": "Pumpkaboo",
+    "name": {
+      "en": "Pumpkaboo",
+      "fr": "Pitrouille"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "R",
     "image": "cPK_10_014380_00_PUMPJIN_R.webp",
-    "name": "Gourgeist",
+    "name": {
+      "en": "Gourgeist",
+      "fr": "Banshitrouye"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "RR",
     "image": "cPK_10_014390_00_MIMIKKYUex_RR.webp",
-    "name": "Mimikyu ex",
+    "name": {
+      "en": "Mimikyu ex",
+      "fr": "Mimiqui-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "C",
     "image": "cPK_10_014400_00_YABACHA_C.webp",
-    "name": "Sinistea",
+    "name": {
+      "en": "Sinistea",
+      "fr": "Théffroi"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "U",
     "image": "cPK_10_014410_00_POTDEATH_U.webp",
-    "name": "Polteageist",
+    "name": {
+      "en": "Polteageist",
+      "fr": "Polthégeist"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "C",
     "image": "cPK_10_014420_00_YESSAN_C.webp",
-    "name": "Indeedee",
+    "name": {
+      "en": "Indeedee",
+      "fr": "Wimessir"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "C",
     "image": "cPK_10_014430_00_SAND_C.webp",
-    "name": "Sandshrew",
+    "name": {
+      "en": "Sandshrew",
+      "fr": "Sabelette"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "C",
     "image": "cPK_10_014440_00_SANDPAN_C.webp",
-    "name": "Sandslash",
+    "name": {
+      "en": "Sandslash",
+      "fr": "Sablaireau"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "C",
     "image": "cPK_10_014450_00_WANRIKY_C.webp",
-    "name": "Machop",
+    "name": {
+      "en": "Machop",
+      "fr": "Machoc"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "C",
     "image": "cPK_10_014460_00_GORIKY_C.webp",
-    "name": "Machoke",
+    "name": {
+      "en": "Machoke",
+      "fr": "Machopeur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "U",
     "image": "cPK_10_014470_00_KAIRIKY_U.webp",
-    "name": "Machamp",
+    "name": {
+      "en": "Machamp",
+      "fr": "Mackogneur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "C",
     "image": "cPK_10_014480_00_KARAKARA_C.webp",
-    "name": "Cubone",
+    "name": {
+      "en": "Cubone",
+      "fr": "Osselait"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "C",
     "image": "cPK_10_014490_00_ASANAN_C.webp",
-    "name": "Meditite",
+    "name": {
+      "en": "Meditite",
+      "fr": "Méditikka"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "U",
     "image": "cPK_10_014500_00_CHAREM_U.webp",
-    "name": "Medicham",
+    "name": {
+      "en": "Medicham",
+      "fr": "Charmina"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "C",
     "image": "cPK_10_014510_00_DANGORO_C.webp",
-    "name": "Roggenrola",
+    "name": {
+      "en": "Roggenrola",
+      "fr": "Nodulithe"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "U",
     "image": "cPK_10_014520_00_GANTLE_U.webp",
-    "name": "Boldore",
+    "name": {
+      "en": "Boldore",
+      "fr": "Géolithe"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "RR",
     "image": "cPK_10_014530_00_GIGAIATHex_RR.webp",
-    "name": "Gigalith ex",
+    "name": {
+      "en": "Gigalith ex",
+      "fr": "Gigalithe-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "C",
     "image": "cPK_10_014540_00_MOGUREW_C.webp",
-    "name": "Drilbur",
+    "name": {
+      "en": "Drilbur",
+      "fr": "Rototaupe"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "U",
     "image": "cPK_10_014550_00_CHIGORAS_U.webp",
-    "name": "Tyrunt",
+    "name": {
+      "en": "Tyrunt",
+      "fr": "Ptyranidur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "R",
     "image": "cPK_10_014560_00_GACHIGORAS_R.webp",
-    "name": "Tyrantrum",
+    "name": {
+      "en": "Tyrantrum",
+      "fr": "Rexillius"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "C",
     "image": "cPK_10_014570_00_NAGETUKESARU_C.webp",
-    "name": "Passimian",
+    "name": {
+      "en": "Passimian",
+      "fr": "Quartermac"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "U",
     "image": "cPK_10_014580_00_TAIRETSU_U.webp",
-    "name": "Falinks",
+    "name": {
+      "en": "Falinks",
+      "fr": "Hexadron"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "R",
     "image": "cPK_10_014590_00_OGERPONISHIZUENOMEN_R.webp",
-    "name": "Cornerstone Mask Ogerpon",
+    "name": {
+      "en": "Cornerstone Mask Ogerpon",
+      "fr": "Ogerpon Masque de la Pierre"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "C",
     "image": "cPK_10_014600_00_ALOLANYARTH_C.webp",
-    "name": "Alolan Meowth",
+    "name": {
+      "en": "Alolan Meowth",
+      "fr": "Miaouss d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "U",
     "image": "cPK_10_014610_00_ALOLAPERSIAN_U.webp",
-    "name": "Alolan Persian",
+    "name": {
+      "en": "Alolan Persian",
+      "fr": "Persian d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "C",
     "image": "cPK_10_014620_00_ALOLABETBETER_C.webp",
-    "name": "Alolan Grimer",
+    "name": {
+      "en": "Alolan Grimer",
+      "fr": "Tadmorv d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "R",
     "image": "cPK_10_014630_00_ALOLABETBETON_R.webp",
-    "name": "Alolan Muk",
+    "name": {
+      "en": "Alolan Muk",
+      "fr": "Grotadmorv d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "C",
     "image": "cPK_10_014640_00_GALARJIGUZAGUMA_C.webp",
-    "name": "Galarian Zigzagoon",
+    "name": {
+      "en": "Galarian Zigzagoon",
+      "fr": "Zigzaton de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "U",
     "image": "cPK_10_014650_00_GALARMASSUGUMA_U.webp",
-    "name": "Galarian Linoone",
+    "name": {
+      "en": "Galarian Linoone",
+      "fr": "Linéon de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "R",
     "image": "cPK_10_014660_00_GALARTACHIFUSAGUMA_R.webp",
-    "name": "Galarian Obstagoon",
+    "name": {
+      "en": "Galarian Obstagoon",
+      "fr": "Ixon de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "C",
     "image": "cPK_10_014670_00_SKUNPUU_C.webp",
-    "name": "Stunky",
+    "name": {
+      "en": "Stunky",
+      "fr": "Moufouette"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "U",
     "image": "cPK_10_014680_00_SKUTANK_U.webp",
-    "name": "Skuntank",
+    "name": {
+      "en": "Skuntank",
+      "fr": "Moufflair"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "R",
     "image": "cPK_10_014690_00_MIKARUGE_R.webp",
-    "name": "Spiritomb",
+    "name": {
+      "en": "Spiritomb",
+      "fr": "Spiritomb"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1034,7 +1343,10 @@
     "number": 104,
     "rarity": "C",
     "image": "cPK_10_014700_00_CHORONEKO_C.webp",
-    "name": "Purrloin",
+    "name": {
+      "en": "Purrloin",
+      "fr": "Chacripan"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1044,7 +1356,10 @@
     "number": 105,
     "rarity": "U",
     "image": "cPK_10_014710_00_LEPARDAS_U.webp",
-    "name": "Liepard",
+    "name": {
+      "en": "Liepard",
+      "fr": "Léopardus"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1054,7 +1369,10 @@
     "number": 106,
     "rarity": "C",
     "image": "cPK_10_014720_00_ZURUGGU_C.webp",
-    "name": "Scraggy",
+    "name": {
+      "en": "Scraggy",
+      "fr": "Baggiguane"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1064,7 +1382,10 @@
     "number": 107,
     "rarity": "U",
     "image": "cPK_10_014730_00_ZURUZUKIN_U.webp",
-    "name": "Scrafty",
+    "name": {
+      "en": "Scrafty",
+      "fr": "Baggaïd"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1074,7 +1395,10 @@
     "number": 108,
     "rarity": "R",
     "image": "cPK_10_014740_00_YVELTAL_R.webp",
-    "name": "Yveltal",
+    "name": {
+      "en": "Yveltal",
+      "fr": "Yveltal"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1084,7 +1408,10 @@
     "number": 109,
     "rarity": "R",
     "image": "cPK_10_014750_00_AKUZIKING_R.webp",
-    "name": "Guzzlord",
+    "name": {
+      "en": "Guzzlord",
+      "fr": "Engloutyran"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1094,7 +1421,10 @@
     "number": 110,
     "rarity": "C",
     "image": "cPK_10_014760_00_GALARNYARTH_C.webp",
-    "name": "Galarian Meowth",
+    "name": {
+      "en": "Galarian Meowth",
+      "fr": "Miaouss de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1104,7 +1434,10 @@
     "number": 111,
     "rarity": "R",
     "image": "cPK_10_014770_00_GALARNYAIKING_R.webp",
-    "name": "Galarian Perrserker",
+    "name": {
+      "en": "Galarian Perrserker",
+      "fr": "Berserkatt de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1114,7 +1447,10 @@
     "number": 112,
     "rarity": "C",
     "image": "cPK_10_014780_00_KUCHEAT_C.webp",
-    "name": "Mawile",
+    "name": {
+      "en": "Mawile",
+      "fr": "Mysdibule"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1124,7 +1460,10 @@
     "number": 113,
     "rarity": "RR",
     "image": "cPK_10_014790_00_MEGAKUCHEATex_RR.webp",
-    "name": "Mega Mawile ex",
+    "name": {
+      "en": "Mega Mawile ex",
+      "fr": "Méga-Mysdibule-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1134,7 +1473,10 @@
     "number": 114,
     "rarity": "U",
     "image": "cPK_10_014800_00_DORYUZU_U.webp",
-    "name": "Excadrill",
+    "name": {
+      "en": "Excadrill",
+      "fr": "Minotaupe"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1144,7 +1486,10 @@
     "number": 115,
     "rarity": "C",
     "image": "cPK_10_014810_00_TESSEED_C.webp",
-    "name": "Ferroseed",
+    "name": {
+      "en": "Ferroseed",
+      "fr": "Grindur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1154,7 +1499,10 @@
     "number": 116,
     "rarity": "C",
     "image": "cPK_10_014820_00_NUTREY_C.webp",
-    "name": "Ferrothorn",
+    "name": {
+      "en": "Ferrothorn",
+      "fr": "Noacier"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1164,7 +1512,10 @@
     "number": 117,
     "rarity": "U",
     "image": "cPK_10_014830_00_GALARMAGGYO_U.webp",
-    "name": "Galarian Stunfisk",
+    "name": {
+      "en": "Galarian Stunfisk",
+      "fr": "Limonde de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1174,7 +1525,10 @@
     "number": 118,
     "rarity": "C",
     "image": "cPK_10_014840_00_HITOTSUKI_C.webp",
-    "name": "Honedge",
+    "name": {
+      "en": "Honedge",
+      "fr": "Monorpale"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1184,7 +1538,10 @@
     "number": 119,
     "rarity": "U",
     "image": "cPK_10_014850_00_NIDANGILL_U.webp",
-    "name": "Doublade",
+    "name": {
+      "en": "Doublade",
+      "fr": "Dimoclès"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1194,7 +1551,10 @@
     "number": 120,
     "rarity": "R",
     "image": "cPK_10_014860_00_GILLGARD_R.webp",
-    "name": "Aegislash",
+    "name": {
+      "en": "Aegislash",
+      "fr": "Exagide"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1204,7 +1564,10 @@
     "number": 121,
     "rarity": "C",
     "image": "cPK_10_014870_00_TATSUBAY_C.webp",
-    "name": "Bagon",
+    "name": {
+      "en": "Bagon",
+      "fr": "Draby"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1214,7 +1577,10 @@
     "number": 122,
     "rarity": "U",
     "image": "cPK_10_014880_00_KOMORUU_U.webp",
-    "name": "Shelgon",
+    "name": {
+      "en": "Shelgon",
+      "fr": "Drackhaus"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1224,7 +1590,10 @@
     "number": 123,
     "rarity": "R",
     "image": "cPK_10_014890_00_BOHMANDER_R.webp",
-    "name": "Salamence",
+    "name": {
+      "en": "Salamence",
+      "fr": "Drattak"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1234,7 +1603,10 @@
     "number": 124,
     "rarity": "C",
     "image": "cPK_10_014900_00_NYARTH_C.webp",
-    "name": "Meowth",
+    "name": {
+      "en": "Meowth",
+      "fr": "Miaouss"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1244,7 +1616,10 @@
     "number": 125,
     "rarity": "C",
     "image": "cPK_10_014910_00_PERSIAN_C.webp",
-    "name": "Persian",
+    "name": {
+      "en": "Persian",
+      "fr": "Persian"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1254,7 +1629,10 @@
     "number": 126,
     "rarity": "U",
     "image": "cPK_10_014920_00_GARURA_U.webp",
-    "name": "Kangaskhan",
+    "name": {
+      "en": "Kangaskhan",
+      "fr": "Kangourex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1264,7 +1642,10 @@
     "number": 127,
     "rarity": "RR",
     "image": "cPK_10_014930_00_MEGAGARURAex_RR.webp",
-    "name": "Mega Kangaskhan ex",
+    "name": {
+      "en": "Mega Kangaskhan ex",
+      "fr": "Méga-Kangourex-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1274,7 +1655,10 @@
     "number": 128,
     "rarity": "C",
     "image": "cPK_10_014940_00_OTACHI_C.webp",
-    "name": "Sentret",
+    "name": {
+      "en": "Sentret",
+      "fr": "Fouinette"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1284,7 +1668,10 @@
     "number": 129,
     "rarity": "C",
     "image": "cPK_10_014950_00_OOTACHI_C.webp",
-    "name": "Furret",
+    "name": {
+      "en": "Furret",
+      "fr": "Fouinar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1294,7 +1681,10 @@
     "number": 130,
     "rarity": "U",
     "image": "cPK_10_014960_00_DOBLE_U.webp",
-    "name": "Smeargle",
+    "name": {
+      "en": "Smeargle",
+      "fr": "Queulorior"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1304,7 +1694,10 @@
     "number": 131,
     "rarity": "R",
     "image": "cPK_10_014970_00_LUGIA_R.webp",
-    "name": "Lugia",
+    "name": {
+      "en": "Lugia",
+      "fr": "Lugia"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1314,7 +1707,10 @@
     "number": 132,
     "rarity": "C",
     "image": "cPK_10_014980_00_SUBAME_C.webp",
-    "name": "Taillow",
+    "name": {
+      "en": "Taillow",
+      "fr": "Nirondelle"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1324,7 +1720,10 @@
     "number": 133,
     "rarity": "R",
     "image": "cPK_10_014990_00_OHSUBAME_R.webp",
-    "name": "Swellow",
+    "name": {
+      "en": "Swellow",
+      "fr": "Hélédelle"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1334,7 +1733,10 @@
     "number": 134,
     "rarity": "C",
     "image": "cPK_10_015000_00_NAMAKERO_C.webp",
-    "name": "Slakoth",
+    "name": {
+      "en": "Slakoth",
+      "fr": "Parecool"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1344,7 +1746,10 @@
     "number": 135,
     "rarity": "U",
     "image": "cPK_10_015010_00_YARUKIMONO_U.webp",
-    "name": "Vigoroth",
+    "name": {
+      "en": "Vigoroth",
+      "fr": "Vigoroth"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1354,7 +1759,10 @@
     "number": 136,
     "rarity": "R",
     "image": "cPK_10_015020_00_KEKKING_R.webp",
-    "name": "Slaking",
+    "name": {
+      "en": "Slaking",
+      "fr": "Monaflèmit"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1364,7 +1772,10 @@
     "number": 137,
     "rarity": "C",
     "image": "cPK_10_015030_00_PATCHEEL_C.webp",
-    "name": "Spinda",
+    "name": {
+      "en": "Spinda",
+      "fr": "Spinda"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1374,7 +1785,10 @@
     "number": 138,
     "rarity": "R",
     "image": "cPK_10_015040_00_TORNELOS_R.webp",
-    "name": "Tornadus",
+    "name": {
+      "en": "Tornadus",
+      "fr": "Boréas"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1384,7 +1798,10 @@
     "number": 139,
     "rarity": "C",
     "image": "cPK_10_015050_00_HORUBEE_C.webp",
-    "name": "Bunnelby",
+    "name": {
+      "en": "Bunnelby",
+      "fr": "Sapereau"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1394,7 +1811,10 @@
     "number": 140,
     "rarity": "U",
     "image": "cPK_10_015060_00_HORUDO_U.webp",
-    "name": "Diggersby",
+    "name": {
+      "en": "Diggersby",
+      "fr": "Excavarenne"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1404,7 +1824,10 @@
     "number": 141,
     "rarity": "U",
     "image": "cPK_10_015070_00_TRIMMIEN_U.webp",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1414,7 +1837,10 @@
     "number": 142,
     "rarity": "C",
     "image": "cPK_10_015080_00_WAKKANEZUMI_C.webp",
-    "name": "Tandemaus",
+    "name": {
+      "en": "Tandemaus",
+      "fr": "Compagnol"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1424,7 +1850,10 @@
     "number": 143,
     "rarity": "U",
     "image": "cPK_10_015090_00_IKKANEZUMI_U.webp",
-    "name": "Maushold",
+    "name": {
+      "en": "Maushold",
+      "fr": "Famignol"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1434,7 +1863,10 @@
     "number": 144,
     "rarity": "C",
     "image": "cTR_10_001050_00_AGONOKASEKI_C.webp",
-    "name": "Jaw Fossil",
+    "name": {
+      "en": "Jaw Fossil",
+      "fr": "Fossile Mâchoire"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1444,7 +1876,10 @@
     "number": 145,
     "rarity": "U",
     "image": "cTR_10_001060_00_ATARITSUKIAISU_U.webp",
-    "name": "Lucky Ice Pop",
+    "name": {
+      "en": "Lucky Ice Pop",
+      "fr": "Glace Chanceuse"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1454,7 +1889,10 @@
     "number": 146,
     "rarity": "C",
     "image": "cTR_10_001070_00_HIRENOKASEKI_C.webp",
-    "name": "Sail Fossil",
+    "name": {
+      "en": "Sail Fossil",
+      "fr": "Fossile Nageoire"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1464,7 +1902,10 @@
     "number": 147,
     "rarity": "U",
     "image": "cTR_10_001080_00_MAMORINOPONCHO_U.webp",
-    "name": "Protective Poncho",
+    "name": {
+      "en": "Protective Poncho",
+      "fr": "Poncho Protecteur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1474,7 +1915,10 @@
     "number": 148,
     "rarity": "U",
     "image": "cTR_10_001090_00_METARUKOABARIA_U.webp",
-    "name": "Metal Core Barrier",
+    "name": {
+      "en": "Metal Core Barrier",
+      "fr": "Barrière de Métal Renforcé"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1484,7 +1928,10 @@
     "number": 149,
     "rarity": "U",
     "image": "cTR_10_001100_00_CARNE_U.webp",
-    "name": "Diantha",
+    "name": {
+      "en": "Diantha",
+      "fr": "Dianthéa"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1494,7 +1941,10 @@
     "number": 150,
     "rarity": "U",
     "image": "cTR_10_001110_00_KANKOUKYAKU_U.webp",
-    "name": "Sightseer",
+    "name": {
+      "en": "Sightseer",
+      "fr": "Vacancière"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1504,7 +1954,10 @@
     "number": 151,
     "rarity": "U",
     "image": "cTR_10_001120_00_JAGURA_U.webp",
-    "name": "Juggler",
+    "name": {
+      "en": "Juggler",
+      "fr": "Jongleur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1514,7 +1967,10 @@
     "number": 152,
     "rarity": "U",
     "image": "cTR_10_001130_00_NEZU_U.webp",
-    "name": "Piers",
+    "name": {
+      "en": "Piers",
+      "fr": "Peterson"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1524,7 +1980,10 @@
     "number": 153,
     "rarity": "U",
     "image": "cTR_10_001140_00_TORENINGUERIA_U.webp",
-    "name": "Training Area",
+    "name": {
+      "en": "Training Area",
+      "fr": "Zone d'Entraînement"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1534,7 +1993,10 @@
     "number": 154,
     "rarity": "U",
     "image": "cTR_10_001150_00_HAJIMARINOHEIGEN_U.webp",
-    "name": "Starting Plains",
+    "name": {
+      "en": "Starting Plains",
+      "fr": "Plaine du Départ"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1544,7 +2006,10 @@
     "number": 155,
     "rarity": "U",
     "image": "cTR_10_001160_00_FUSHIGINAHIROBA_U.webp",
-    "name": "Peculiar Plaza",
+    "name": {
+      "en": "Peculiar Plaza",
+      "fr": "Place Étrange"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1554,7 +2019,10 @@
     "number": 156,
     "rarity": "AR",
     "image": "cPK_20_013720_00_SABONEA_AR.webp",
-    "name": "Cacnea",
+    "name": {
+      "en": "Cacnea",
+      "fr": "Cacnea"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1564,7 +2032,10 @@
     "number": 157,
     "rarity": "AR",
     "image": "cPK_20_013710_00_ROSERADE_AR.webp",
-    "name": "Roserade",
+    "name": {
+      "en": "Roserade",
+      "fr": "Roserade"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1574,7 +2045,10 @@
     "number": 158,
     "rarity": "AR",
     "image": "cPK_20_013790_00_VIVIYON_AR.webp",
-    "name": "Vivillon",
+    "name": {
+      "en": "Vivillon",
+      "fr": "Prismillon"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1584,7 +2058,10 @@
     "number": 159,
     "rarity": "AR",
     "image": "cPK_20_013800_00_MASSIVOON_AR.webp",
-    "name": "Buzzwole",
+    "name": {
+      "en": "Buzzwole",
+      "fr": "Mouscoto"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1594,7 +2071,10 @@
     "number": 160,
     "rarity": "AR",
     "image": "cPK_20_013850_00_RESHIRAM_AR.webp",
-    "name": "Reshiram",
+    "name": {
+      "en": "Reshiram",
+      "fr": "Reshiram"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1604,7 +2084,10 @@
     "number": 161,
     "rarity": "AR",
     "image": "cPK_20_013880_00_ODORIDORI_AR.webp",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1614,7 +2097,10 @@
     "number": 162,
     "rarity": "AR",
     "image": "cPK_20_013900_00_HIBANNY_AR.webp",
-    "name": "Scorbunny",
+    "name": {
+      "en": "Scorbunny",
+      "fr": "Flambino"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1624,7 +2110,10 @@
     "number": 163,
     "rarity": "AR",
     "image": "cPK_20_014080_00_AMARURUGA_AR.webp",
-    "name": "Aurorus",
+    "name": {
+      "en": "Aurorus",
+      "fr": "Dragmara"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1634,7 +2123,10 @@
     "number": 164,
     "rarity": "AR",
     "image": "cPK_20_014110_00_UU_AR.webp",
-    "name": "Cramorant",
+    "name": {
+      "en": "Cramorant",
+      "fr": "Nigosier"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1644,7 +2136,10 @@
     "number": 165,
     "rarity": "AR",
     "image": "cPK_20_014190_00_MINUN_AR.webp",
-    "name": "Minun",
+    "name": {
+      "en": "Minun",
+      "fr": "Négapi"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1654,7 +2149,10 @@
     "number": 166,
     "rarity": "AR",
     "image": "cPK_20_014200_00_ELESON_AR.webp",
-    "name": "Toxel",
+    "name": {
+      "en": "Toxel",
+      "fr": "Toxizap"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1664,7 +2162,10 @@
     "number": 167,
     "rarity": "AR",
     "image": "cPK_20_014240_00_GALARPONYTA_AR.webp",
-    "name": "Galarian Ponyta",
+    "name": {
+      "en": "Galarian Ponyta",
+      "fr": "Ponyta de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1674,7 +2175,10 @@
     "number": 168,
     "rarity": "AR",
     "image": "cPK_20_014270_00_BULU_AR.webp",
-    "name": "Snubbull",
+    "name": {
+      "en": "Snubbull",
+      "fr": "Snubbull"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1684,7 +2188,10 @@
     "number": 169,
     "rarity": "AR",
     "image": "cPK_20_014420_00_YESSAN_AR.webp",
-    "name": "Indeedee",
+    "name": {
+      "en": "Indeedee",
+      "fr": "Wimessir"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1694,7 +2201,10 @@
     "number": 170,
     "rarity": "AR",
     "image": "cPK_20_014430_00_SAND_AR.webp",
-    "name": "Sandshrew",
+    "name": {
+      "en": "Sandshrew",
+      "fr": "Sabelette"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1704,7 +2214,10 @@
     "number": 171,
     "rarity": "AR",
     "image": "cPK_20_014560_00_GACHIGORAS_AR.webp",
-    "name": "Tyrantrum",
+    "name": {
+      "en": "Tyrantrum",
+      "fr": "Rexillius"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1714,7 +2227,10 @@
     "number": 172,
     "rarity": "AR",
     "image": "cPK_20_014580_00_TAIRETSU_AR.webp",
-    "name": "Falinks",
+    "name": {
+      "en": "Falinks",
+      "fr": "Hexadron"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1724,7 +2240,10 @@
     "number": 173,
     "rarity": "AR",
     "image": "cPK_20_014630_00_ALOLABETBETON_AR.webp",
-    "name": "Alolan Muk",
+    "name": {
+      "en": "Alolan Muk",
+      "fr": "Grotadmorv d'Alola"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1734,7 +2253,10 @@
     "number": 174,
     "rarity": "AR",
     "image": "cPK_20_014700_00_CHORONEKO_AR.webp",
-    "name": "Purrloin",
+    "name": {
+      "en": "Purrloin",
+      "fr": "Chacripan"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1744,7 +2266,10 @@
     "number": 175,
     "rarity": "AR",
     "image": "cPK_20_014740_00_YVELTAL_AR.webp",
-    "name": "Yveltal",
+    "name": {
+      "en": "Yveltal",
+      "fr": "Yveltal"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1754,7 +2279,10 @@
     "number": 176,
     "rarity": "AR",
     "image": "cPK_20_014660_00_GALARTACHIFUSAGUMA_AR.webp",
-    "name": "Galarian Obstagoon",
+    "name": {
+      "en": "Galarian Obstagoon",
+      "fr": "Ixon de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1764,7 +2292,10 @@
     "number": 177,
     "rarity": "AR",
     "image": "cPK_20_014770_00_GALARNYAIKING_AR.webp",
-    "name": "Galarian Perrserker",
+    "name": {
+      "en": "Galarian Perrserker",
+      "fr": "Berserkatt de Galar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1774,7 +2305,10 @@
     "number": 178,
     "rarity": "AR",
     "image": "cPK_20_014890_00_BOHMANDER_AR.webp",
-    "name": "Salamence",
+    "name": {
+      "en": "Salamence",
+      "fr": "Drattak"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1784,7 +2318,10 @@
     "number": 179,
     "rarity": "AR",
     "image": "cPK_20_015000_00_NAMAKERO_AR.webp",
-    "name": "Slakoth",
+    "name": {
+      "en": "Slakoth",
+      "fr": "Parecool"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1794,7 +2331,10 @@
     "number": 180,
     "rarity": "SR",
     "image": "cPK_20_013830_00_OGERPONMIDORINOMENex_SR.webp",
-    "name": "Teal Mask Ogerpon ex",
+    "name": {
+      "en": "Teal Mask Ogerpon ex",
+      "fr": "Ogerpon Masque Turquoise-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1804,7 +2344,10 @@
     "number": 181,
     "rarity": "SR",
     "image": "cPK_20_013890_00_ZUGADOONex_SR.webp",
-    "name": "Blacephalon ex",
+    "name": {
+      "en": "Blacephalon ex",
+      "fr": "Pierroteknik-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1814,7 +2357,10 @@
     "number": 182,
     "rarity": "SR",
     "image": "cPK_20_013950_00_ALOLAKYUKONex_SR.webp",
-    "name": "Alolan Ninetales ex",
+    "name": {
+      "en": "Alolan Ninetales ex",
+      "fr": "Feunard d'Alola-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1824,7 +2370,10 @@
     "number": 183,
     "rarity": "SR",
     "image": "cPK_20_014020_00_MEGALAGLARGEex_SR.webp",
-    "name": "Mega Swampert ex",
+    "name": {
+      "en": "Mega Swampert ex",
+      "fr": "Méga-Laggron-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1834,7 +2383,10 @@
     "number": 184,
     "rarity": "SR",
     "image": "cPK_20_014210_00_STRINDERex_SR.webp",
-    "name": "Toxtricity ex",
+    "name": {
+      "en": "Toxtricity ex",
+      "fr": "Salarsen-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1844,7 +2396,10 @@
     "number": 185,
     "rarity": "SR",
     "image": "cPK_20_014320_00_MEGASIRNIGHTex_SR.webp",
-    "name": "Mega Gardevoir ex",
+    "name": {
+      "en": "Mega Gardevoir ex",
+      "fr": "Méga-Gardevoir-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1854,7 +2409,10 @@
     "number": 186,
     "rarity": "SR",
     "image": "cPK_20_014390_00_MIMIKKYUex_SR.webp",
-    "name": "Mimikyu ex",
+    "name": {
+      "en": "Mimikyu ex",
+      "fr": "Mimiqui-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1864,7 +2422,10 @@
     "number": 187,
     "rarity": "SR",
     "image": "cPK_20_014530_00_GIGAIATHex_SR.webp",
-    "name": "Gigalith ex",
+    "name": {
+      "en": "Gigalith ex",
+      "fr": "Gigalithe-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1874,7 +2435,10 @@
     "number": 188,
     "rarity": "SR",
     "image": "cPK_20_014790_00_MEGAKUCHEATex_SR.webp",
-    "name": "Mega Mawile ex",
+    "name": {
+      "en": "Mega Mawile ex",
+      "fr": "Méga-Mysdibule-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1884,7 +2448,10 @@
     "number": 189,
     "rarity": "SR",
     "image": "cPK_20_014930_00_MEGAGARURAex_SR.webp",
-    "name": "Mega Kangaskhan ex",
+    "name": {
+      "en": "Mega Kangaskhan ex",
+      "fr": "Méga-Kangourex-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1894,7 +2461,10 @@
     "number": 190,
     "rarity": "SR",
     "image": "cTR_20_001100_00_CARNE_SR.webp",
-    "name": "Diantha",
+    "name": {
+      "en": "Diantha",
+      "fr": "Dianthéa"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1904,7 +2474,10 @@
     "number": 191,
     "rarity": "SR",
     "image": "cTR_20_001110_00_KANKOUKYAKU_SR.webp",
-    "name": "Sightseer",
+    "name": {
+      "en": "Sightseer",
+      "fr": "Vacancière"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1914,7 +2487,10 @@
     "number": 192,
     "rarity": "SR",
     "image": "cTR_20_001120_00_JAGURA_SR.webp",
-    "name": "Juggler",
+    "name": {
+      "en": "Juggler",
+      "fr": "Jongleur"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1924,7 +2500,10 @@
     "number": 193,
     "rarity": "SR",
     "image": "cTR_20_001130_00_NEZU_SR.webp",
-    "name": "Piers",
+    "name": {
+      "en": "Piers",
+      "fr": "Peterson"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1934,7 +2513,10 @@
     "number": 194,
     "rarity": "SAR",
     "image": "cPK_20_013830_01_OGERPONMIDORINOMENex_SAR.webp",
-    "name": "Teal Mask Ogerpon ex",
+    "name": {
+      "en": "Teal Mask Ogerpon ex",
+      "fr": "Ogerpon Masque Turquoise-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1944,7 +2526,10 @@
     "number": 195,
     "rarity": "SAR",
     "image": "cPK_20_013890_01_ZUGADOONex_SAR.webp",
-    "name": "Blacephalon ex",
+    "name": {
+      "en": "Blacephalon ex",
+      "fr": "Pierroteknik-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1954,7 +2539,10 @@
     "number": 196,
     "rarity": "SAR",
     "image": "cPK_20_013950_01_ALOLAKYUKONex_SAR.webp",
-    "name": "Alolan Ninetales ex",
+    "name": {
+      "en": "Alolan Ninetales ex",
+      "fr": "Feunard d'Alola-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1964,7 +2552,10 @@
     "number": 197,
     "rarity": "SAR",
     "image": "cPK_20_014020_01_MEGALAGLARGEex_SAR.webp",
-    "name": "Mega Swampert ex",
+    "name": {
+      "en": "Mega Swampert ex",
+      "fr": "Méga-Laggron-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1974,7 +2565,10 @@
     "number": 198,
     "rarity": "SAR",
     "image": "cPK_20_014210_01_STRINDERex_SAR.webp",
-    "name": "Toxtricity ex",
+    "name": {
+      "en": "Toxtricity ex",
+      "fr": "Salarsen-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1984,7 +2578,10 @@
     "number": 199,
     "rarity": "SAR",
     "image": "cPK_20_014390_01_MIMIKKYUex_SAR.webp",
-    "name": "Mimikyu ex",
+    "name": {
+      "en": "Mimikyu ex",
+      "fr": "Mimiqui-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -1994,7 +2591,10 @@
     "number": 200,
     "rarity": "SAR",
     "image": "cPK_20_014530_01_GIGAIATHex_SAR.webp",
-    "name": "Gigalith ex",
+    "name": {
+      "en": "Gigalith ex",
+      "fr": "Gigalithe-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2004,7 +2604,10 @@
     "number": 201,
     "rarity": "SAR",
     "image": "cPK_20_014790_01_MEGAKUCHEATex_SAR.webp",
-    "name": "Mega Mawile ex",
+    "name": {
+      "en": "Mega Mawile ex",
+      "fr": "Méga-Mysdibule-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2014,7 +2617,10 @@
     "number": 202,
     "rarity": "SAR",
     "image": "cPK_20_014930_01_MEGAGARURAex_SAR.webp",
-    "name": "Mega Kangaskhan ex",
+    "name": {
+      "en": "Mega Kangaskhan ex",
+      "fr": "Méga-Kangourex-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2024,7 +2630,10 @@
     "number": 203,
     "rarity": "IM",
     "image": "cPK_20_014320_01_MEGASIRNIGHTex_IM.webp",
-    "name": "Mega Gardevoir ex",
+    "name": {
+      "en": "Mega Gardevoir ex",
+      "fr": "Méga-Gardevoir-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2034,7 +2643,10 @@
     "number": 204,
     "rarity": "IM",
     "image": "cPK_20_014900_00_NYARTH_IM.webp",
-    "name": "Meowth",
+    "name": {
+      "en": "Meowth",
+      "fr": "Miaouss"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2044,7 +2656,10 @@
     "number": 205,
     "rarity": "S",
     "image": "cPK_20_008600_00_MONJARA_S.webp",
-    "name": "Tangela",
+    "name": {
+      "en": "Tangela",
+      "fr": "Saquedeneu"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2054,7 +2669,10 @@
     "number": 206,
     "rarity": "S",
     "image": "cPK_20_008880_01_BUBY_S.webp",
-    "name": "Magby",
+    "name": {
+      "en": "Magby",
+      "fr": "Magby"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2064,7 +2682,10 @@
     "number": 207,
     "rarity": "S",
     "image": "cPK_20_003040_00_BOOBER_S.webp",
-    "name": "Magmar",
+    "name": {
+      "en": "Magmar",
+      "fr": "Magmar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2074,7 +2695,10 @@
     "number": 208,
     "rarity": "S",
     "image": "cPK_20_008970_00_TATTU_S.webp",
-    "name": "Horsea",
+    "name": {
+      "en": "Horsea",
+      "fr": "Hypotrempe"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2084,7 +2708,10 @@
     "number": 209,
     "rarity": "S",
     "image": "cPK_20_008980_00_SEADRA_S.webp",
-    "name": "Seadra",
+    "name": {
+      "en": "Seadra",
+      "fr": "Hypocéan"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2094,7 +2721,10 @@
     "number": 210,
     "rarity": "S",
     "image": "cPK_20_010420_01_TAMANTA_S.webp",
-    "name": "Mantyke",
+    "name": {
+      "en": "Mantyke",
+      "fr": "Amonita"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2104,7 +2734,10 @@
     "number": 211,
     "rarity": "S",
     "image": "cPK_20_000810_00_OMNITE_S.webp",
-    "name": "Omanyte",
+    "name": {
+      "en": "Omanyte",
+      "fr": "Amonistar"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2114,7 +2747,10 @@
     "number": 212,
     "rarity": "S",
     "image": "cPK_20_000820_00_OMSTAR_S.webp",
-    "name": "Omastar",
+    "name": {
+      "en": "Omastar",
+      "fr": "Babimanta"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2124,7 +2760,10 @@
     "number": 213,
     "rarity": "S",
     "image": "cPK_20_009220_01_PICHU_S.webp",
-    "name": "Pichu",
+    "name": {
+      "en": "Pichu",
+      "fr": "Pichu"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2134,7 +2773,10 @@
     "number": 214,
     "rarity": "S",
     "image": "cPK_20_001130_00_PIPPI_S.webp",
-    "name": "Clefairy",
+    "name": {
+      "en": "Clefairy",
+      "fr": "Mélofée"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2144,7 +2786,10 @@
     "number": 215,
     "rarity": "S",
     "image": "cPK_20_001140_00_PIXY_S.webp",
-    "name": "Clefable",
+    "name": {
+      "en": "Clefable",
+      "fr": "Mélodelfe"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2154,7 +2799,10 @@
     "number": 216,
     "rarity": "S",
     "image": "cPK_20_010200_00_LATIAS_S.webp",
-    "name": "Latias",
+    "name": {
+      "en": "Latias",
+      "fr": "Latias"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2164,7 +2812,10 @@
     "number": 217,
     "rarity": "S",
     "image": "cPK_20_010550_01_LATIOS_S.webp",
-    "name": "Latios",
+    "name": {
+      "en": "Latios",
+      "fr": "Latios"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2174,7 +2825,10 @@
     "number": 218,
     "rarity": "S",
     "image": "cPK_20_001540_00_SAWAMULAR_S.webp",
-    "name": "Hitmonlee",
+    "name": {
+      "en": "Hitmonlee",
+      "fr": "Kicklee"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2184,7 +2838,10 @@
     "number": 219,
     "rarity": "S",
     "image": "cPK_20_001550_00_EBIWALAR_S.webp",
-    "name": "Hitmonchan",
+    "name": {
+      "en": "Hitmonchan",
+      "fr": "Tygnon"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2194,7 +2851,10 @@
     "number": 220,
     "rarity": "S",
     "image": "cPK_20_001580_00_KABUTO_S.webp",
-    "name": "Kabuto",
+    "name": {
+      "en": "Kabuto",
+      "fr": "Kabuto"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2204,7 +2864,10 @@
     "number": 221,
     "rarity": "S",
     "image": "cPK_20_001590_00_KABUTOPS_S.webp",
-    "name": "Kabutops",
+    "name": {
+      "en": "Kabutops",
+      "fr": "Kabutops"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2214,7 +2877,10 @@
     "number": 222,
     "rarity": "S",
     "image": "cPK_20_009550_00_GOMAZOU_S.webp",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2224,7 +2890,10 @@
     "number": 223,
     "rarity": "S",
     "image": "cPK_20_009570_00_BALKIE_S.webp",
-    "name": "Tyrogue",
+    "name": {
+      "en": "Tyrogue",
+      "fr": "Debugant"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2234,7 +2903,10 @@
     "number": 224,
     "rarity": "S",
     "image": "cPK_20_002730_00_KENTAUROS_S.webp",
-    "name": "Tauros",
+    "name": {
+      "en": "Tauros",
+      "fr": "Tauros"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2244,7 +2916,10 @@
     "number": 225,
     "rarity": "SSR",
     "image": "cPK_20_008050_02_BOOSTERex_SSR.webp",
-    "name": "Flareon ex",
+    "name": {
+      "en": "Flareon ex",
+      "fr": "Pyroli-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2254,7 +2929,10 @@
     "number": 226,
     "rarity": "SSR",
     "image": "cPK_20_008900_04_HOUOUex_SSR.webp",
-    "name": "Ho-Oh ex",
+    "name": {
+      "en": "Ho-Oh ex",
+      "fr": "Ho-Oh-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2264,7 +2942,10 @@
     "number": 227,
     "rarity": "SSR",
     "image": "cPK_20_008990_02_KINGDRAex_SSR.webp",
-    "name": "Kingdra ex",
+    "name": {
+      "en": "Kingdra ex",
+      "fr": "Hyporoi-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2274,7 +2955,10 @@
     "number": 228,
     "rarity": "SSR",
     "image": "cPK_20_009390_02_EIFIEex_SSR.webp",
-    "name": "Espeon ex",
+    "name": {
+      "en": "Espeon ex",
+      "fr": "Mentali-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2284,7 +2968,10 @@
     "number": 229,
     "rarity": "SSR",
     "image": "cPK_20_008280_02_NYMPHIAex_SSR.webp",
-    "name": "Sylveon ex",
+    "name": {
+      "en": "Sylveon ex",
+      "fr": "Nymphali-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2294,7 +2981,10 @@
     "number": 230,
     "rarity": "SSR",
     "image": "cPK_20_009560_02_DONFANex_SSR.webp",
-    "name": "Donphan ex",
+    "name": {
+      "en": "Donphan ex",
+      "fr": "Donphan-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2304,7 +2994,10 @@
     "number": 231,
     "rarity": "SSR",
     "image": "cPK_20_009680_02_BRACKYex_SSR.webp",
-    "name": "Umbreon ex",
+    "name": {
+      "en": "Umbreon ex",
+      "fr": "Noctali-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2314,7 +3007,10 @@
     "number": 232,
     "rarity": "SSR",
     "image": "cPK_20_010050_04_LUGIAex_SSR.webp",
-    "name": "Lugia ex",
+    "name": {
+      "en": "Lugia ex",
+      "fr": "Lugia-ex"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2324,7 +3020,10 @@
     "number": 233,
     "rarity": "UR",
     "image": "cPK_20_014360_00_MELOETTA_UR.webp",
-    "name": "Meloetta",
+    "name": {
+      "en": "Meloetta",
+      "fr": "Meloetta"
+    },
     "packs": [
       "Gardevoir"
     ]
@@ -2334,7 +3033,10 @@
     "number": 234,
     "rarity": "UR",
     "image": "cTR_20_001080_00_MAMORINOPONCHO_UR.webp",
-    "name": "Protective Poncho",
+    "name": {
+      "en": "Protective Poncho",
+      "fr": "Poncho Protecteur"
+    },
     "packs": [
       "Gardevoir"
     ]

--- a/dist/cards/B2a.json
+++ b/dist/cards/B2a.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_015100_00_NYAHOJA_C.webp",
-    "name": "Sprigatito",
+    "name": {
+      "en": "Sprigatito",
+      "fr": "Poussacha"
+    },
     "packs": [
       "Paldean"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "C",
     "image": "cPK_10_015110_00_NYAROTE_C.webp",
-    "name": "Floragato",
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "RR",
     "image": "cPK_10_015120_00_MASQUERNYAex_RR.webp",
-    "name": "Meowscarada ex",
+    "name": {
+      "en": "Meowscarada ex",
+      "fr": "Miascarade-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "C",
     "image": "cPK_10_015130_00_TAMANTULA_C.webp",
-    "name": "Tarountula",
+    "name": {
+      "en": "Tarountula",
+      "fr": "Tissenboule"
+    },
     "packs": [
       "Paldean"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "U",
     "image": "cPK_10_015140_00_WANAIDER_U.webp",
-    "name": "Spidops",
+    "name": {
+      "en": "Spidops",
+      "fr": "Filentrappe"
+    },
     "packs": [
       "Paldean"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "C",
     "image": "cPK_10_015150_00_MAMEBATTA_C.webp",
-    "name": "Nymble",
+    "name": {
+      "en": "Nymble",
+      "fr": "Lilliterelle"
+    },
     "packs": [
       "Paldean"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "C",
     "image": "cPK_10_015160_00_MINIVE_C.webp",
-    "name": "Smoliv",
+    "name": {
+      "en": "Smoliv",
+      "fr": "Olivini"
+    },
     "packs": [
       "Paldean"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "C",
     "image": "cPK_10_015170_00_OLINYO_C.webp",
-    "name": "Dolliv",
+    "name": {
+      "en": "Dolliv",
+      "fr": "Olivado"
+    },
     "packs": [
       "Paldean"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "R",
     "image": "cPK_10_015180_00_OLIVA_R.webp",
-    "name": "Arboliva",
+    "name": {
+      "en": "Arboliva",
+      "fr": "Arboliva"
+    },
     "packs": [
       "Paldean"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "C",
     "image": "cPK_10_015190_00_ANOKUSA_C.webp",
-    "name": "Bramblin",
+    "name": {
+      "en": "Bramblin",
+      "fr": "Virovent"
+    },
     "packs": [
       "Paldean"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "U",
     "image": "cPK_10_015200_00_ANOHORAGUSA_U.webp",
-    "name": "Brambleghast",
+    "name": {
+      "en": "Brambleghast",
+      "fr": "Virevorreur"
+    },
     "packs": [
       "Paldean"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "C",
     "image": "cPK_10_015210_00_CAPSAIJI_C.webp",
-    "name": "Capsakid",
+    "name": {
+      "en": "Capsakid",
+      "fr": "Pimito"
+    },
     "packs": [
       "Paldean"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "U",
     "image": "cPK_10_015220_00_SCOVILLAIN_U.webp",
-    "name": "Scovillain",
+    "name": {
+      "en": "Scovillain",
+      "fr": "Scovilain"
+    },
     "packs": [
       "Paldean"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "C",
     "image": "cPK_10_015230_00_SHIGAROKO_C.webp",
-    "name": "Rellor",
+    "name": {
+      "en": "Rellor",
+      "fr": "Léboulérou"
+    },
     "packs": [
       "Paldean"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "R",
     "image": "cPK_10_015240_00_CHIONJEN_R.webp",
-    "name": "Wo-Chien",
+    "name": {
+      "en": "Wo-Chien",
+      "fr": "Chongjian"
+    },
     "packs": [
       "Paldean"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "C",
     "image": "cPK_10_015250_00_HOGATOR_C.webp",
-    "name": "Fuecoco",
+    "name": {
+      "en": "Fuecoco",
+      "fr": "Chochodile"
+    },
     "packs": [
       "Paldean"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "C",
     "image": "cPK_10_015260_00_ACHIGATOR_C.webp",
-    "name": "Crocalor",
+    "name": {
+      "en": "Crocalor",
+      "fr": "Crocogril"
+    },
     "packs": [
       "Paldean"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "R",
     "image": "cPK_10_015270_00_LAUDBON_R.webp",
-    "name": "Skeledirge",
+    "name": {
+      "en": "Skeledirge",
+      "fr": "Flâmigator"
+    },
     "packs": [
       "Paldean"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "C",
     "image": "cPK_10_015280_00_CARBOU_C.webp",
-    "name": "Charcadet",
+    "name": {
+      "en": "Charcadet",
+      "fr": "Charbambin"
+    },
     "packs": [
       "Paldean"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "RR",
     "image": "cPK_10_015290_00_GURENARMAex_RR.webp",
-    "name": "Armarouge ex",
+    "name": {
+      "en": "Armarouge ex",
+      "fr": "Carmadura-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "R",
     "image": "cPK_10_015300_00_YIYUI_R.webp",
-    "name": "Chi-Yu",
+    "name": {
+      "en": "Chi-Yu",
+      "fr": "Yuyu"
+    },
     "packs": [
       "Paldean"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "C",
     "image": "cPK_10_015310_00_KUWASSU_C.webp",
-    "name": "Quaxly",
+    "name": {
+      "en": "Quaxly",
+      "fr": "Coiffeton"
+    },
     "packs": [
       "Paldean"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "C",
     "image": "cPK_10_015320_00_WELKAMO_C.webp",
-    "name": "Quaxwell",
+    "name": {
+      "en": "Quaxwell",
+      "fr": "Canarbello"
+    },
     "packs": [
       "Paldean"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "R",
     "image": "cPK_10_015330_00_WANIVAL_R.webp",
-    "name": "Quaquaval",
+    "name": {
+      "en": "Quaquaval",
+      "fr": "Palmaval"
+    },
     "packs": [
       "Paldean"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "C",
     "image": "cPK_10_015340_00_UMIDIGDA_C.webp",
-    "name": "Wiglett",
+    "name": {
+      "en": "Wiglett",
+      "fr": "Taupikeau"
+    },
     "packs": [
       "Paldean"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "U",
     "image": "cPK_10_015350_00_UMITRIO_U.webp",
-    "name": "Wugtrio",
+    "name": {
+      "en": "Wugtrio",
+      "fr": "Triopikeau"
+    },
     "packs": [
       "Paldean"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "C",
     "image": "cPK_10_015360_00_NAMIIRUKA_C.webp",
-    "name": "Finizen",
+    "name": {
+      "en": "Finizen",
+      "fr": "Dofin"
+    },
     "packs": [
       "Paldean"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "R",
     "image": "cPK_10_015370_00_IRUKAMANMIGHTYFORME_R.webp",
-    "name": "Palafin",
+    "name": {
+      "en": "Palafin",
+      "fr": "Superdofin"
+    },
     "packs": [
       "Paldean"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "C",
     "image": "cPK_10_015380_00_ARUKUJIRA_C.webp",
-    "name": "Cetoddle",
+    "name": {
+      "en": "Cetoddle",
+      "fr": "Piétacé"
+    },
     "packs": [
       "Paldean"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "U",
     "image": "cPK_10_015390_00_HULKUJIRA_U.webp",
-    "name": "Cetitan",
+    "name": {
+      "en": "Cetitan",
+      "fr": "Balbalèze"
+    },
     "packs": [
       "Paldean"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "U",
     "image": "cPK_10_015400_00_MIGALUSA_U.webp",
-    "name": "Veluza",
+    "name": {
+      "en": "Veluza",
+      "fr": "Délestin"
+    },
     "packs": [
       "Paldean"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "U",
     "image": "cPK_10_015410_00_HEYRUSHER_U.webp",
-    "name": "Dondozo",
+    "name": {
+      "en": "Dondozo",
+      "fr": "Oyacata"
+    },
     "packs": [
       "Paldean"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "U",
     "image": "cPK_10_015420_00_SYARITATSU_U.webp",
-    "name": "Tatsugiri",
+    "name": {
+      "en": "Tatsugiri",
+      "fr": "Nigirigon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "C",
     "image": "cPK_10_015430_00_SEBIE_C.webp",
-    "name": "Frigibax",
+    "name": {
+      "en": "Frigibax",
+      "fr": "Frigodo"
+    },
     "packs": [
       "Paldean"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "C",
     "image": "cPK_10_015440_00_SEGOHRU_C.webp",
-    "name": "Arctibax",
+    "name": {
+      "en": "Arctibax",
+      "fr": "Cryodo"
+    },
     "packs": [
       "Paldean"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "R",
     "image": "cPK_10_015450_00_SEGLAIVE_R.webp",
-    "name": "Baxcalibur",
+    "name": {
+      "en": "Baxcalibur",
+      "fr": "Glaivodo"
+    },
     "packs": [
       "Paldean"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "RR",
     "image": "cPK_10_015460_00_PAOJIANex_RR.webp",
-    "name": "Chien-Pao ex",
+    "name": {
+      "en": "Chien-Pao ex",
+      "fr": "Baojian-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "C",
     "image": "cPK_10_015470_00_PAMO_C.webp",
-    "name": "Pawmi",
+    "name": {
+      "en": "Pawmi",
+      "fr": "Pohm"
+    },
     "packs": [
       "Paldean"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "C",
     "image": "cPK_10_015480_00_PAMOT_C.webp",
-    "name": "Pawmo",
+    "name": {
+      "en": "Pawmo",
+      "fr": "Pohmotte"
+    },
     "packs": [
       "Paldean"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "U",
     "image": "cPK_10_015490_00_PARMOT_U.webp",
-    "name": "Pawmot",
+    "name": {
+      "en": "Pawmot",
+      "fr": "Pohmarmotte"
+    },
     "packs": [
       "Paldean"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "C",
     "image": "cPK_10_015500_00_ZUPIKA_C.webp",
-    "name": "Tadbulb",
+    "name": {
+      "en": "Tadbulb",
+      "fr": "Têtampoule"
+    },
     "packs": [
       "Paldean"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "RR",
     "image": "cPK_10_015510_00_HARABARIEex_RR.webp",
-    "name": "Bellibolt ex",
+    "name": {
+      "en": "Bellibolt ex",
+      "fr": "Ampibidou-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "C",
     "image": "cPK_10_015520_00_KAIDEN_C.webp",
-    "name": "Wattrel",
+    "name": {
+      "en": "Wattrel",
+      "fr": "Zapétrel"
+    },
     "packs": [
       "Paldean"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "U",
     "image": "cPK_10_015530_00_TAIKAIDEN_U.webp",
-    "name": "Kilowattrel",
+    "name": {
+      "en": "Kilowattrel",
+      "fr": "Fulgulairo"
+    },
     "packs": [
       "Paldean"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "R",
     "image": "cPK_10_015540_00_MIRAIDONCOMPLETEMODE_R.webp",
-    "name": "Miraidon",
+    "name": {
+      "en": "Miraidon",
+      "fr": "Miraidon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "C",
     "image": "cPK_10_015550_00_PUPIMOCCHI_C.webp",
-    "name": "Fidough",
+    "name": {
+      "en": "Fidough",
+      "fr": "Pâtachiot"
+    },
     "packs": [
       "Paldean"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "U",
     "image": "cPK_10_015560_00_BOWTZEL_U.webp",
-    "name": "Dachsbun",
+    "name": {
+      "en": "Dachsbun",
+      "fr": "Briochien"
+    },
     "packs": [
       "Paldean"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "R",
     "image": "cPK_10_015570_00_SOUBLADES_R.webp",
-    "name": "Ceruledge",
+    "name": {
+      "en": "Ceruledge",
+      "fr": "Malvalame"
+    },
     "packs": [
       "Paldean"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "U",
     "image": "cPK_10_015580_00_BERACAS_U.webp",
-    "name": "Rabsca",
+    "name": {
+      "en": "Rabsca",
+      "fr": "Bérasca"
+    },
     "packs": [
       "Paldean"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "C",
     "image": "cPK_10_015590_00_HIRAHINA_C.webp",
-    "name": "Flittle",
+    "name": {
+      "en": "Flittle",
+      "fr": "Flotillon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "U",
     "image": "cPK_10_015600_00_CUESPATRA_U.webp",
-    "name": "Espathra",
+    "name": {
+      "en": "Espathra",
+      "fr": "Cléopsytra"
+    },
     "packs": [
       "Paldean"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "C",
     "image": "cPK_10_015610_00_BOCHI_C.webp",
-    "name": "Greavard",
+    "name": {
+      "en": "Greavard",
+      "fr": "Toutombe"
+    },
     "packs": [
       "Paldean"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "U",
     "image": "cPK_10_015620_00_HAKADOG_U.webp",
-    "name": "Houndstone",
+    "name": {
+      "en": "Houndstone",
+      "fr": "Tomberro"
+    },
     "packs": [
       "Paldean"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "C",
     "image": "cPK_10_015630_00_COLLECUREI_C.webp",
-    "name": "Gimmighoul",
+    "name": {
+      "en": "Gimmighoul",
+      "fr": "Mordudor"
+    },
     "packs": [
       "Paldean"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "C",
     "image": "cPK_10_015640_00_MANKEY_C.webp",
-    "name": "Mankey",
+    "name": {
+      "en": "Mankey",
+      "fr": "Férosinge"
+    },
     "packs": [
       "Paldean"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "C",
     "image": "cPK_10_015650_00_OKORIZARU_C.webp",
-    "name": "Primeape",
+    "name": {
+      "en": "Primeape",
+      "fr": "Colossinge"
+    },
     "packs": [
       "Paldean"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "U",
     "image": "cPK_10_015660_00_KONOYOZARU_U.webp",
-    "name": "Annihilape",
+    "name": {
+      "en": "Annihilape",
+      "fr": "Courrousinge"
+    },
     "packs": [
       "Paldean"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "U",
     "image": "cPK_10_015670_00_PALDEAKENTAUROS_U.webp",
-    "name": "Paldean Tauros",
+    "name": {
+      "en": "Paldean Tauros",
+      "fr": "Tauros de Paldea"
+    },
     "packs": [
       "Paldean"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "C",
     "image": "cPK_10_015680_00_NONOKURAGE_C.webp",
-    "name": "Toedscool",
+    "name": {
+      "en": "Toedscool",
+      "fr": "Terracool"
+    },
     "packs": [
       "Paldean"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "U",
     "image": "cPK_10_015690_00_RIKUKURAGE_U.webp",
-    "name": "Toedscruel",
+    "name": {
+      "en": "Toedscruel",
+      "fr": "Terracruel"
+    },
     "packs": [
       "Paldean"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "C",
     "image": "cPK_10_015700_00_GAKEGANI_C.webp",
-    "name": "Klawf",
+    "name": {
+      "en": "Klawf",
+      "fr": "Craparoi"
+    },
     "packs": [
       "Paldean"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "R",
     "image": "cPK_10_015710_00_DINLU_R.webp",
-    "name": "Ting-Lu",
+    "name": {
+      "en": "Ting-Lu",
+      "fr": "Dinglu"
+    },
     "packs": [
       "Paldean"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "R",
     "image": "cPK_10_015720_00_KORAIDON_R.webp",
-    "name": "Koraidon",
+    "name": {
+      "en": "Koraidon",
+      "fr": "Koraidon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "C",
     "image": "cPK_10_015730_00_PALDEAUPAH_C.webp",
-    "name": "Paldean Wooper",
+    "name": {
+      "en": "Paldean Wooper",
+      "fr": "Axoloto de Paldea"
+    },
     "packs": [
       "Paldean"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "U",
     "image": "cPK_10_015740_00_PALDEADOOH_U.webp",
-    "name": "Paldean Clodsire",
+    "name": {
+      "en": "Paldean Clodsire",
+      "fr": "Terraiste de Paldea"
+    },
     "packs": [
       "Paldean"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "U",
     "image": "cPK_10_015750_00_EXLEG_U.webp",
-    "name": "Lokix",
+    "name": {
+      "en": "Lokix",
+      "fr": "Gambex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "C",
     "image": "cPK_10_015760_00_ORACHIFU_C.webp",
-    "name": "Maschiff",
+    "name": {
+      "en": "Maschiff",
+      "fr": "Grondogue"
+    },
     "packs": [
       "Paldean"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "U",
     "image": "cPK_10_015770_00_MAFITIFF_U.webp",
-    "name": "Mabosstiff",
+    "name": {
+      "en": "Mabosstiff",
+      "fr": "Dogrino"
+    },
     "packs": [
       "Paldean"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "C",
     "image": "cPK_10_015780_00_SHIRUSHREW_C.webp",
-    "name": "Shroodle",
+    "name": {
+      "en": "Shroodle",
+      "fr": "Gribouraigne"
+    },
     "packs": [
       "Paldean"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "U",
     "image": "cPK_10_015790_00_TAGGINGRU_U.webp",
-    "name": "Grafaiai",
+    "name": {
+      "en": "Grafaiai",
+      "fr": "Tag-Tag"
+    },
     "packs": [
       "Paldean"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "C",
     "image": "cPK_10_015800_00_OTOSHIDORI_C.webp",
-    "name": "Bombirdier",
+    "name": {
+      "en": "Bombirdier",
+      "fr": "Lestombaile"
+    },
     "packs": [
       "Paldean"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "C",
     "image": "cPK_10_015810_00_KANUCHAN_C.webp",
-    "name": "Tinkatink",
+    "name": {
+      "en": "Tinkatink",
+      "fr": "Forgerette"
+    },
     "packs": [
       "Paldean"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "C",
     "image": "cPK_10_015820_00_NAKANUCHAN_C.webp",
-    "name": "Tinkatuff",
+    "name": {
+      "en": "Tinkatuff",
+      "fr": "Forgella"
+    },
     "packs": [
       "Paldean"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "R",
     "image": "cPK_10_015830_00_DEKANUCHAN_R.webp",
-    "name": "Tinkaton",
+    "name": {
+      "en": "Tinkaton",
+      "fr": "Forgelina"
+    },
     "packs": [
       "Paldean"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "C",
     "image": "cPK_10_015840_00_BURORON_C.webp",
-    "name": "Varoom",
+    "name": {
+      "en": "Varoom",
+      "fr": "Vrombi"
+    },
     "packs": [
       "Paldean"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "U",
     "image": "cPK_10_015850_00_BUROROROOM_U.webp",
-    "name": "Revavroom",
+    "name": {
+      "en": "Revavroom",
+      "fr": "Vrombotor"
+    },
     "packs": [
       "Paldean"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "U",
     "image": "cPK_10_015860_00_MIMIZUZU_U.webp",
-    "name": "Orthworm",
+    "name": {
+      "en": "Orthworm",
+      "fr": "Ferdeter"
+    },
     "packs": [
       "Paldean"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "RR",
     "image": "cPK_10_015870_00_SURFUGOex_RR.webp",
-    "name": "Gholdengo ex",
+    "name": {
+      "en": "Gholdengo ex",
+      "fr": "Gromago-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "C",
     "image": "cPK_10_015880_00_GOURTON_C.webp",
-    "name": "Lechonk",
+    "name": {
+      "en": "Lechonk",
+      "fr": "Gourmelet"
+    },
     "packs": [
       "Paldean"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "C",
     "image": "cPK_10_015890_00_PERFUTONOSUNOSUGATA_C.webp",
-    "name": "Oinkologne",
+    "name": {
+      "en": "Oinkologne",
+      "fr": "Fragroin"
+    },
     "packs": [
       "Paldean"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "C",
     "image": "cPK_10_015900_00_WAKKANEZUMI_C.webp",
-    "name": "Tandemaus",
+    "name": {
+      "en": "Tandemaus",
+      "fr": "Compagnol"
+    },
     "packs": [
       "Paldean"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "U",
     "image": "cPK_10_015910_00_IKKANEZUMISANBIKIKAZOKU_U.webp",
-    "name": "Maushold",
+    "name": {
+      "en": "Maushold",
+      "fr": "Famignol"
+    },
     "packs": [
       "Paldean"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "C",
     "image": "cPK_10_015920_00_IKIRINKOGREENFEATHER_C.webp",
-    "name": "Squawkabilly",
+    "name": {
+      "en": "Squawkabilly",
+      "fr": "Tapatoès"
+    },
     "packs": [
       "Paldean"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "U",
     "image": "cPK_10_015930_00_MOTOTOKAGE_U.webp",
-    "name": "Cyclizar",
+    "name": {
+      "en": "Cyclizar",
+      "fr": "Motorizard"
+    },
     "packs": [
       "Paldean"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "C",
     "image": "cPK_10_015940_00_KARAMINGO_C.webp",
-    "name": "Flamigo",
+    "name": {
+      "en": "Flamigo",
+      "fr": "Flamenroule"
+    },
     "packs": [
       "Paldean"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "U",
     "image": "cTR_10_001170_00_ELECTRICGENERATOR_U.webp",
-    "name": "Electric Generator",
+    "name": {
+      "en": "Electric Generator",
+      "fr": "Générateur Électrique"
+    },
     "packs": [
       "Paldean"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "U",
     "image": "cTR_10_001180_00_BIGAIRBALLOON_U.webp",
-    "name": "Big Air Balloon",
+    "name": {
+      "en": "Big Air Balloon",
+      "fr": "Gros Ballon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "U",
     "image": "cTR_10_001190_00_TEAMSTARGRUNT_U.webp",
-    "name": "Team Star Grunt",
+    "name": {
+      "en": "Team Star Grunt",
+      "fr": "Sbire de la Team Star"
+    },
     "packs": [
       "Paldean"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "U",
     "image": "cTR_10_000420_02_NANJYAMO_U.webp",
-    "name": "Iono",
+    "name": {
+      "en": "Iono",
+      "fr": "Mashynn"
+    },
     "packs": [
       "Paldean"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "U",
     "image": "cTR_10_001200_00_NEMO_U.webp",
-    "name": "Nemona",
+    "name": {
+      "en": "Nemona",
+      "fr": "Menzi"
+    },
     "packs": [
       "Paldean"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "U",
     "image": "cTR_10_001210_00_PEPER_U.webp",
-    "name": "Arven",
+    "name": {
+      "en": "Arven",
+      "fr": "Pepper"
+    },
     "packs": [
       "Paldean"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "U",
     "image": "cTR_10_000700_01_BOTAN_U.webp",
-    "name": "Penny",
+    "name": {
+      "en": "Penny",
+      "fr": "Pania"
+    },
     "packs": [
       "Paldean"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "U",
     "image": "cTR_10_001220_00_TABLECITY_U.webp",
-    "name": "Mesagoza",
+    "name": {
+      "en": "Mesagoza",
+      "fr": "Mesaledo"
+    },
     "packs": [
       "Paldean"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "AR",
     "image": "cPK_20_015250_00_HOGATOR_AR.webp",
-    "name": "Fuecoco",
+    "name": {
+      "en": "Fuecoco",
+      "fr": "Chochodile"
+    },
     "packs": [
       "Paldean"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "AR",
     "image": "cPK_20_015610_00_BOCHI_AR.webp",
-    "name": "Greavard",
+    "name": {
+      "en": "Greavard",
+      "fr": "Toutombe"
+    },
     "packs": [
       "Paldean"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "AR",
     "image": "cPK_20_015630_00_COLLECUREI_AR.webp",
-    "name": "Gimmighoul",
+    "name": {
+      "en": "Gimmighoul",
+      "fr": "Mordudor"
+    },
     "packs": [
       "Paldean"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "AR",
     "image": "cPK_20_015730_00_PALDEAUPAH_AR.webp",
-    "name": "Paldean Wooper",
+    "name": {
+      "en": "Paldean Wooper",
+      "fr": "Axoloto de Paldea"
+    },
     "packs": [
       "Paldean"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "AR",
     "image": "cPK_20_015860_00_MIMIZUZU_AR.webp",
-    "name": "Orthworm",
+    "name": {
+      "en": "Orthworm",
+      "fr": "Ferdeter"
+    },
     "packs": [
       "Paldean"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "AR",
     "image": "cPK_20_015910_00_IKKANEZUMISANBIKIKAZOKU_AR.webp",
-    "name": "Maushold",
+    "name": {
+      "en": "Maushold",
+      "fr": "Famignol"
+    },
     "packs": [
       "Paldean"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "SR",
     "image": "cPK_20_015120_00_MASQUERNYAex_SR.webp",
-    "name": "Meowscarada ex",
+    "name": {
+      "en": "Meowscarada ex",
+      "fr": "Miascarade-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "SR",
     "image": "cPK_20_015290_00_GURENARMAex_SR.webp",
-    "name": "Armarouge ex",
+    "name": {
+      "en": "Armarouge ex",
+      "fr": "Carmadura-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "SR",
     "image": "cPK_20_015460_00_PAOJIANex_SR.webp",
-    "name": "Chien-Pao ex",
+    "name": {
+      "en": "Chien-Pao ex",
+      "fr": "Baojian-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "SR",
     "image": "cPK_20_015510_00_HARABARIEex_SR.webp",
-    "name": "Bellibolt ex",
+    "name": {
+      "en": "Bellibolt ex",
+      "fr": "Ampibidou-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1034,7 +1343,10 @@
     "number": 104,
     "rarity": "SR",
     "image": "cPK_20_015870_00_SURFUGOex_SR.webp",
-    "name": "Gholdengo ex",
+    "name": {
+      "en": "Gholdengo ex",
+      "fr": "Gromago-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1044,7 +1356,10 @@
     "number": 105,
     "rarity": "SR",
     "image": "cTR_20_001190_00_TEAMSTARGRUNT_SR.webp",
-    "name": "Team Star Grunt",
+    "name": {
+      "en": "Team Star Grunt",
+      "fr": "Sbire de la Team Star"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1054,7 +1369,10 @@
     "number": 106,
     "rarity": "SR",
     "image": "cTR_20_000420_01_NANJYAMO_SR.webp",
-    "name": "Iono",
+    "name": {
+      "en": "Iono",
+      "fr": "Mashynn"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1064,7 +1382,10 @@
     "number": 107,
     "rarity": "SR",
     "image": "cTR_20_001200_00_NEMO_SR.webp",
-    "name": "Nemona",
+    "name": {
+      "en": "Nemona",
+      "fr": "Menzi"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1074,7 +1395,10 @@
     "number": 108,
     "rarity": "SR",
     "image": "cTR_20_001210_00_PEPER_SR.webp",
-    "name": "Arven",
+    "name": {
+      "en": "Arven",
+      "fr": "Pepper"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1084,7 +1408,10 @@
     "number": 109,
     "rarity": "SR",
     "image": "cTR_20_000700_01_BOTAN_SR.webp",
-    "name": "Penny",
+    "name": {
+      "en": "Penny",
+      "fr": "Pania"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1094,7 +1421,10 @@
     "number": 110,
     "rarity": "SAR",
     "image": "cPK_20_015120_01_MASQUERNYAex_SAR.webp",
-    "name": "Meowscarada ex",
+    "name": {
+      "en": "Meowscarada ex",
+      "fr": "Miascarade-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1104,7 +1434,10 @@
     "number": 111,
     "rarity": "SAR",
     "image": "cPK_20_015290_01_GURENARMAex_SAR.webp",
-    "name": "Armarouge ex",
+    "name": {
+      "en": "Armarouge ex",
+      "fr": "Carmadura-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1114,7 +1447,10 @@
     "number": 112,
     "rarity": "SAR",
     "image": "cPK_20_015460_01_PAOJIANex_SAR.webp",
-    "name": "Chien-Pao ex",
+    "name": {
+      "en": "Chien-Pao ex",
+      "fr": "Baojian-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1124,7 +1460,10 @@
     "number": 113,
     "rarity": "SAR",
     "image": "cPK_20_015510_01_HARABARIEex_SAR.webp",
-    "name": "Bellibolt ex",
+    "name": {
+      "en": "Bellibolt ex",
+      "fr": "Ampibidou-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1134,7 +1473,10 @@
     "number": 114,
     "rarity": "SAR",
     "image": "cPK_20_015870_01_SURFUGOex_SAR.webp",
-    "name": "Gholdengo ex",
+    "name": {
+      "en": "Gholdengo ex",
+      "fr": "Gromago-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1144,7 +1486,10 @@
     "number": 115,
     "rarity": "IM",
     "image": "cTR_20_001210_01_PEPER_IM.webp",
-    "name": "Arven",
+    "name": {
+      "en": "Arven",
+      "fr": "Pepper"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1154,7 +1499,10 @@
     "number": 116,
     "rarity": "S",
     "image": "cPK_20_015100_00_NYAHOJA_S.webp",
-    "name": "Sprigatito",
+    "name": {
+      "en": "Sprigatito",
+      "fr": "Poussacha"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1164,7 +1512,10 @@
     "number": 117,
     "rarity": "S",
     "image": "cPK_20_015110_00_NYAROTE_S.webp",
-    "name": "Floragato",
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1174,7 +1525,10 @@
     "number": 118,
     "rarity": "S",
     "image": "cPK_20_005260_01_MASQUERNYA_S.webp",
-    "name": "Meowscarada",
+    "name": {
+      "en": "Meowscarada",
+      "fr": "Miascarade"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1184,7 +1538,10 @@
     "number": 119,
     "rarity": "S",
     "image": "cPK_20_015470_00_PAMO_S.webp",
-    "name": "Pawmi",
+    "name": {
+      "en": "Pawmi",
+      "fr": "Pohm"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1194,7 +1551,10 @@
     "number": 120,
     "rarity": "S",
     "image": "cPK_20_015480_00_PAMOT_S.webp",
-    "name": "Pawmo",
+    "name": {
+      "en": "Pawmo",
+      "fr": "Pohmotte"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1204,7 +1564,10 @@
     "number": 121,
     "rarity": "S",
     "image": "cPK_20_015490_00_PARMOT_S.webp",
-    "name": "Pawmot",
+    "name": {
+      "en": "Pawmot",
+      "fr": "Pohmarmotte"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1214,7 +1577,10 @@
     "number": 122,
     "rarity": "S",
     "image": "cPK_20_015630_01_COLLECUREI_S.webp",
-    "name": "Gimmighoul",
+    "name": {
+      "en": "Gimmighoul",
+      "fr": "Mordudor"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1224,7 +1590,10 @@
     "number": 123,
     "rarity": "S",
     "image": "cPK_20_015810_00_KANUCHAN_S.webp",
-    "name": "Tinkatink",
+    "name": {
+      "en": "Tinkatink",
+      "fr": "Forgerette"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1234,7 +1603,10 @@
     "number": 124,
     "rarity": "S",
     "image": "cPK_20_015820_00_NAKANUCHAN_S.webp",
-    "name": "Tinkatuff",
+    "name": {
+      "en": "Tinkatuff",
+      "fr": "Forgella"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1244,7 +1616,10 @@
     "number": 125,
     "rarity": "S",
     "image": "cPK_20_005720_01_SURFUGO_S.webp",
-    "name": "Gholdengo",
+    "name": {
+      "en": "Gholdengo",
+      "fr": "Gromago"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1254,7 +1629,10 @@
     "number": 126,
     "rarity": "SSR",
     "image": "cPK_20_010210_02_ENTEIex_SSR.webp",
-    "name": "Entei ex",
+    "name": {
+      "en": "Entei ex",
+      "fr": "Entei-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1264,7 +1642,10 @@
     "number": 127,
     "rarity": "SSR",
     "image": "cPK_20_010400_02_SUICUNEex_SSR.webp",
-    "name": "Suicune ex",
+    "name": {
+      "en": "Suicune ex",
+      "fr": "Suicune-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1274,7 +1655,10 @@
     "number": 128,
     "rarity": "SSR",
     "image": "cPK_20_010440_02_RAIKOUex_SSR.webp",
-    "name": "Raikou ex",
+    "name": {
+      "en": "Raikou ex",
+      "fr": "Raikou-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1284,7 +1668,10 @@
     "number": 129,
     "rarity": "SSR",
     "image": "cPK_20_005690_02_DEKANUCHANex_SSR.webp",
-    "name": "Tinkaton ex",
+    "name": {
+      "en": "Tinkaton ex",
+      "fr": "Forgelina-ex"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1294,7 +1681,10 @@
     "number": 130,
     "rarity": "UR",
     "image": "cPK_20_015450_00_SEGLAIVE_UR.webp",
-    "name": "Baxcalibur",
+    "name": {
+      "en": "Baxcalibur",
+      "fr": "Glaivodo"
+    },
     "packs": [
       "Paldean"
     ]
@@ -1304,7 +1694,10 @@
     "number": 131,
     "rarity": "UR",
     "image": "cTR_20_001170_00_ELECTRICGENERATOR_UR.webp",
-    "name": "Electric Generator",
+    "name": {
+      "en": "Electric Generator",
+      "fr": "Générateur Électrique"
+    },
     "packs": [
       "Paldean"
     ]

--- a/dist/cards/B2b.json
+++ b/dist/cards/B2b.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_016070_00_STRIKE_C.webp",
-    "name": "Scyther",
+    "name": {
+      "en": "Scyther",
+      "fr": "Insécateur"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "C",
     "image": "cPK_10_016080_00_KUNUGIDAMA_C.webp",
-    "name": "Pineco",
+    "name": {
+      "en": "Pineco",
+      "fr": "Pomdepik"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "C",
     "image": "cPK_10_016090_00_BARUBEAT_C.webp",
-    "name": "Volbeat",
+    "name": {
+      "en": "Volbeat",
+      "fr": "Muciole"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "C",
     "image": "cPK_10_016100_00_ILLUMISE_C.webp",
-    "name": "Illumise",
+    "name": {
+      "en": "Illumise",
+      "fr": "Lumivole"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "C",
     "image": "cPK_10_016110_00_BOKUREI_C.webp",
-    "name": "Phantump",
+    "name": {
+      "en": "Phantump",
+      "fr": "Brocélôme"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "U",
     "image": "cPK_10_016120_00_OHROT_U.webp",
-    "name": "Trevenant",
+    "name": {
+      "en": "Trevenant",
+      "fr": "Desséliande"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "C",
     "image": "cPK_10_016130_00_HITOKAGE_C.webp",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "U",
     "image": "cPK_10_016140_00_LIZARDO_U.webp",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "RR",
     "image": "cPK_10_016150_00_MEGALIZARDONXex_RR.webp",
-    "name": "Mega Charizard X ex",
+    "name": {
+      "en": "Mega Charizard X ex",
+      "fr": "Méga-Dracaufeu X-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "C",
     "image": "cPK_10_016160_00_PONYTA_C.webp",
-    "name": "Ponyta",
+    "name": {
+      "en": "Ponyta",
+      "fr": "Ponyta"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "C",
     "image": "cPK_10_016170_00_GALLOP_C.webp",
-    "name": "Rapidash",
+    "name": {
+      "en": "Rapidash",
+      "fr": "Galopa"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "C",
     "image": "cPK_10_016180_00_BOOBER_C.webp",
-    "name": "Magmar",
+    "name": {
+      "en": "Magmar",
+      "fr": "Magmar"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "U",
     "image": "cPK_10_016190_00_BOOBURN_U.webp",
-    "name": "Magmortar",
+    "name": {
+      "en": "Magmortar",
+      "fr": "Maganon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "C",
     "image": "cPK_10_016200_00_PALDEAKENTAUROS_C.webp",
-    "name": "Paldean Tauros",
+    "name": {
+      "en": "Paldean Tauros",
+      "fr": "Tauros de Paldea"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "C",
     "image": "cPK_10_016000_00_YADON_C.webp",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "RR",
     "image": "cPK_10_016210_00_MEGAYADORANex_RR.webp",
-    "name": "Mega Slowbro ex",
+    "name": {
+      "en": "Mega Slowbro ex",
+      "fr": "Méga-Flagadoss-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "U",
     "image": "cPK_10_016220_00_LAPLACE_U.webp",
-    "name": "Lapras",
+    "name": {
+      "en": "Lapras",
+      "fr": "Lokhlass"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "C",
     "image": "cPK_10_016230_00_POCHAMA_C.webp",
-    "name": "Piplup",
+    "name": {
+      "en": "Piplup",
+      "fr": "Tiplouf"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "U",
     "image": "cPK_10_016240_00_POTTAISHI_U.webp",
-    "name": "Prinplup",
+    "name": {
+      "en": "Prinplup",
+      "fr": "Prinplouf"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "R",
     "image": "cPK_10_016250_00_EMPERTE_R.webp",
-    "name": "Empoleon",
+    "name": {
+      "en": "Empoleon",
+      "fr": "Pingoléon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "U",
     "image": "cPK_10_016260_00_PHIONE_U.webp",
-    "name": "Phione",
+    "name": {
+      "en": "Phione",
+      "fr": "Phione"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "C",
     "image": "cPK_10_016270_00_PIKACHU_C.webp",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "U",
     "image": "cPK_10_016280_00_RAICHU_U.webp",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "C",
     "image": "cPK_10_016290_00_ELEBOO_C.webp",
-    "name": "Electabuzz",
+    "name": {
+      "en": "Electabuzz",
+      "fr": "Élektek"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "U",
     "image": "cPK_10_016300_00_ELEKIBLE_U.webp",
-    "name": "Electivire",
+    "name": {
+      "en": "Electivire",
+      "fr": "Élekable"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "C",
     "image": "cPK_10_016310_00_RAKURAI_C.webp",
-    "name": "Electrike",
+    "name": {
+      "en": "Electrike",
+      "fr": "Dynavolt"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "RR",
     "image": "cPK_10_016320_00_MEGALIVOLTex_RR.webp",
-    "name": "Mega Manectric ex",
+    "name": {
+      "en": "Mega Manectric ex",
+      "fr": "Méga-Élecsprint-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "C",
     "image": "cPK_10_016330_00_SLEEPE_C.webp",
-    "name": "Drowzee",
+    "name": {
+      "en": "Drowzee",
+      "fr": "Soporifik"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "U",
     "image": "cPK_10_016340_00_SLEEPER_U.webp",
-    "name": "Hypno",
+    "name": {
+      "en": "Hypno",
+      "fr": "Hypnomade"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "R",
     "image": "cPK_10_016350_00_MEW_R.webp",
-    "name": "Mew",
+    "name": {
+      "en": "Mew",
+      "fr": "Mew"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "C",
     "image": "cPK_10_016360_00_BANEBOO_C.webp",
-    "name": "Spoink",
+    "name": {
+      "en": "Spoink",
+      "fr": "Spoink"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "U",
     "image": "cPK_10_016370_00_BOOPIG_U.webp",
-    "name": "Grumpig",
+    "name": {
+      "en": "Grumpig",
+      "fr": "Groret"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "C",
     "image": "cPK_10_016380_00_DIGDA_C.webp",
-    "name": "Diglett",
+    "name": {
+      "en": "Diglett",
+      "fr": "Taupiqueur"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "U",
     "image": "cPK_10_016390_00_DUGTRIO_U.webp",
-    "name": "Dugtrio",
+    "name": {
+      "en": "Dugtrio",
+      "fr": "Triopikeur"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "R",
     "image": "cPK_10_016400_00_GROUDON_R.webp",
-    "name": "Groudon",
+    "name": {
+      "en": "Groudon",
+      "fr": "Groudon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "C",
     "image": "cPK_10_016410_00_LUCHABULL_C.webp",
-    "name": "Hawlucha",
+    "name": {
+      "en": "Hawlucha",
+      "fr": "Brutalibré"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "C",
     "image": "cPK_10_016050_00_GHOS_C.webp",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "U",
     "image": "cPK_10_016420_00_GHOST_U.webp",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "RR",
     "image": "cPK_10_016430_00_MEGAGANGARex_RR.webp",
-    "name": "Mega Gengar ex",
+    "name": {
+      "en": "Mega Gengar ex",
+      "fr": "Méga-Ectoplasma-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "R",
     "image": "cPK_10_016440_00_DARKRAI_R.webp",
-    "name": "Darkrai",
+    "name": {
+      "en": "Darkrai",
+      "fr": "Darkrai"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "C",
     "image": "cPK_10_016450_00_YABUKURON_C.webp",
-    "name": "Trubbish",
+    "name": {
+      "en": "Trubbish",
+      "fr": "Miamiasme"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "C",
     "image": "cPK_10_016460_00_DUSTDAS_C.webp",
-    "name": "Garbodor",
+    "name": {
+      "en": "Garbodor",
+      "fr": "Miasmax"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "C",
     "image": "cPK_10_016470_00_ZORUA_C.webp",
-    "name": "Zorua",
+    "name": {
+      "en": "Zorua",
+      "fr": "Zorua"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "R",
     "image": "cPK_10_016480_00_ZOROARK_R.webp",
-    "name": "Zoroark",
+    "name": {
+      "en": "Zoroark",
+      "fr": "Zoroark"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "C",
     "image": "cPK_10_016490_00_MORPEKO_C.webp",
-    "name": "Morpeko",
+    "name": {
+      "en": "Morpeko",
+      "fr": "Morpeko"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "U",
     "image": "cPK_10_016500_00_FORETOS_U.webp",
-    "name": "Forretress",
+    "name": {
+      "en": "Forretress",
+      "fr": "Foretress"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "RR",
     "image": "cPK_10_016510_00_MEGAHASSAMex_RR.webp",
-    "name": "Mega Scizor ex",
+    "name": {
+      "en": "Mega Scizor ex",
+      "fr": "Méga-Cizayox-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "U",
     "image": "cPK_10_016520_00_KAMITURUGI_U.webp",
-    "name": "Kartana",
+    "name": {
+      "en": "Kartana",
+      "fr": "Katagami"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "C",
     "image": "cPK_10_016530_00_BURORON_C.webp",
-    "name": "Varoom",
+    "name": {
+      "en": "Varoom",
+      "fr": "Vrombi"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "R",
     "image": "cPK_10_016540_00_BUROROROOM_R.webp",
-    "name": "Revavroom",
+    "name": {
+      "en": "Revavroom",
+      "fr": "Vrombotor"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "C",
     "image": "cPK_10_016550_00_MINIRYU_C.webp",
-    "name": "Dratini",
+    "name": {
+      "en": "Dratini",
+      "fr": "Minidraco"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "U",
     "image": "cPK_10_016560_00_HAKURYU_U.webp",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "R",
     "image": "cPK_10_016570_00_KAIRYU_R.webp",
-    "name": "Dragonite",
+    "name": {
+      "en": "Dragonite",
+      "fr": "Dracolosse"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "C",
     "image": "cPK_10_016580_00_KIBAGO_C.webp",
-    "name": "Axew",
+    "name": {
+      "en": "Axew",
+      "fr": "Coupenotte"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "U",
     "image": "cPK_10_016590_00_ONONDO_U.webp",
-    "name": "Fraxure",
+    "name": {
+      "en": "Fraxure",
+      "fr": "Incisache"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "R",
     "image": "cPK_10_016030_00_ONONOKUS_R.webp",
-    "name": "Haxorus",
+    "name": {
+      "en": "Haxorus",
+      "fr": "Tranchodon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "C",
     "image": "cPK_10_016600_00_CRIMGAN_C.webp",
-    "name": "Druddigon",
+    "name": {
+      "en": "Druddigon",
+      "fr": "Drakkarmin"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "C",
     "image": "cPK_10_016610_00_PURIN_C.webp",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "C",
     "image": "cPK_10_016060_00_PUKURIN_C.webp",
-    "name": "Wigglytuff",
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "U",
     "image": "cPK_10_016620_00_MILTANK_U.webp",
-    "name": "Miltank",
+    "name": {
+      "en": "Miltank",
+      "fr": "Écrémeuh"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "C",
     "image": "cPK_10_016040_00_PERAP_C.webp",
-    "name": "Chatot",
+    "name": {
+      "en": "Chatot",
+      "fr": "Pijako"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "C",
     "image": "cPK_10_016630_00_CHILLARMY_C.webp",
-    "name": "Minccino",
+    "name": {
+      "en": "Minccino",
+      "fr": "Chinchidou"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "C",
     "image": "cPK_10_016640_00_CHILLACCINO_C.webp",
-    "name": "Cinccino",
+    "name": {
+      "en": "Cinccino",
+      "fr": "Pashmilla"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "U",
     "image": "cPK_10_016650_00_TRIMMIEN_U.webp",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "U",
     "image": "cTR_10_001230_00_IJIWARULETTER_U.webp",
-    "name": "Nasty Notice",
+    "name": {
+      "en": "Nasty Notice",
+      "fr": "Message Désagréable"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "U",
     "image": "cTR_10_001240_00_MAINTENANCE_U.webp",
-    "name": "Maintenance",
+    "name": {
+      "en": "Maintenance",
+      "fr": "Entretien"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "U",
     "image": "cTR_10_001250_00_IRIS_U.webp",
-    "name": "Iris",
+    "name": {
+      "en": "Iris",
+      "fr": "Iris"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "U",
     "image": "cTR_10_001260_00_CALME_U.webp",
-    "name": "Calem",
+    "name": {
+      "en": "Calem",
+      "fr": "Kalem"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "U",
     "image": "cTR_10_001270_00_HAIKINGUCOURSE_U.webp",
-    "name": "Hiking Trail",
+    "name": {
+      "en": "Hiking Trail",
+      "fr": "Chemin de Randonnée"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "AR",
     "image": "cPK_20_016220_00_LAPLACE_AR.webp",
-    "name": "Lapras",
+    "name": {
+      "en": "Lapras",
+      "fr": "Lokhlass"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "AR",
     "image": "cPK_20_016250_00_EMPERTE_AR.webp",
-    "name": "Empoleon",
+    "name": {
+      "en": "Empoleon",
+      "fr": "Pingoléon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "AR",
     "image": "cPK_20_016400_00_GROUDON_AR.webp",
-    "name": "Groudon",
+    "name": {
+      "en": "Groudon",
+      "fr": "Groudon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "AR",
     "image": "cPK_20_016490_00_MORPEKO_AR.webp",
-    "name": "Morpeko",
+    "name": {
+      "en": "Morpeko",
+      "fr": "Morpeko"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "AR",
     "image": "cPK_20_016540_00_BUROROROOM_AR.webp",
-    "name": "Revavroom",
+    "name": {
+      "en": "Revavroom",
+      "fr": "Vrombotor"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "AR",
     "image": "cPK_20_016620_00_MILTANK_AR.webp",
-    "name": "Miltank",
+    "name": {
+      "en": "Miltank",
+      "fr": "Écrémeuh"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "SR",
     "image": "cPK_20_016150_00_MEGALIZARDONXex_SR.webp",
-    "name": "Mega Charizard X ex",
+    "name": {
+      "en": "Mega Charizard X ex",
+      "fr": "Méga-Dracaufeu X-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "SR",
     "image": "cPK_20_016210_00_MEGAYADORANex_SR.webp",
-    "name": "Mega Slowbro ex",
+    "name": {
+      "en": "Mega Slowbro ex",
+      "fr": "Méga-Flagadoss-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "SR",
     "image": "cPK_20_016320_00_MEGALIVOLTex_SR.webp",
-    "name": "Mega Manectric ex",
+    "name": {
+      "en": "Mega Manectric ex",
+      "fr": "Méga-Élecsprint-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "SR",
     "image": "cPK_20_016430_00_MEGAGANGARex_SR.webp",
-    "name": "Mega Gengar ex",
+    "name": {
+      "en": "Mega Gengar ex",
+      "fr": "Méga-Ectoplasma-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "SR",
     "image": "cPK_20_016510_00_MEGAHASSAMex_SR.webp",
-    "name": "Mega Scizor ex",
+    "name": {
+      "en": "Mega Scizor ex",
+      "fr": "Méga-Cizayox-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "SR",
     "image": "cTR_20_001250_00_IRIS_SR.webp",
-    "name": "Iris",
+    "name": {
+      "en": "Iris",
+      "fr": "Iris"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "SR",
     "image": "cTR_20_001260_00_CALME_SR.webp",
-    "name": "Calem",
+    "name": {
+      "en": "Calem",
+      "fr": "Kalem"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "SAR",
     "image": "cPK_20_016210_01_MEGAYADORANex_SAR.webp",
-    "name": "Mega Slowbro ex",
+    "name": {
+      "en": "Mega Slowbro ex",
+      "fr": "Méga-Flagadoss-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "SAR",
     "image": "cPK_20_016320_01_MEGALIVOLTex_SAR.webp",
-    "name": "Mega Manectric ex",
+    "name": {
+      "en": "Mega Manectric ex",
+      "fr": "Méga-Élecsprint-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "IM",
     "image": "cPK_20_016350_00_MEW_IM.webp",
-    "name": "Mew",
+    "name": {
+      "en": "Mew",
+      "fr": "Mew"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "IM",
     "image": "cPK_20_016350_01_MEW_IM.webp",
-    "name": "Mew",
+    "name": {
+      "en": "Mew",
+      "fr": "Mew"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "S",
     "image": "cPK_20_016070_00_STRIKE_S.webp",
-    "name": "Scyther",
+    "name": {
+      "en": "Scyther",
+      "fr": "Insécateur"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "S",
     "image": "cPK_20_016080_00_KUNUGIDAMA_S.webp",
-    "name": "Pineco",
+    "name": {
+      "en": "Pineco",
+      "fr": "Pomdepik"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "S",
     "image": "cPK_20_016110_00_BOKUREI_S.webp",
-    "name": "Phantump",
+    "name": {
+      "en": "Phantump",
+      "fr": "Brocélôme"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "S",
     "image": "cPK_20_016120_00_OHROT_S.webp",
-    "name": "Trevenant",
+    "name": {
+      "en": "Trevenant",
+      "fr": "Desséliande"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "S",
     "image": "cPK_20_016130_00_HITOKAGE_S.webp",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "S",
     "image": "cPK_20_016140_00_LIZARDO_S.webp",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "S",
     "image": "cPK_20_016160_00_PONYTA_S.webp",
-    "name": "Ponyta",
+    "name": {
+      "en": "Ponyta",
+      "fr": "Ponyta"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "S",
     "image": "cPK_20_016170_00_GALLOP_S.webp",
-    "name": "Rapidash",
+    "name": {
+      "en": "Rapidash",
+      "fr": "Galopa"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "S",
     "image": "cPK_20_016000_00_YADON_S.webp",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "S",
     "image": "cPK_20_016270_00_PIKACHU_S.webp",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "S",
     "image": "cPK_20_016280_00_RAICHU_S.webp",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "S",
     "image": "cPK_20_016310_00_RAKURAI_S.webp",
-    "name": "Electrike",
+    "name": {
+      "en": "Electrike",
+      "fr": "Dynavolt"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "S",
     "image": "cPK_20_016410_00_LUCHABULL_S.webp",
-    "name": "Hawlucha",
+    "name": {
+      "en": "Hawlucha",
+      "fr": "Brutalibré"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "S",
     "image": "cPK_20_016050_00_GHOS_S.webp",
-    "name": "Gastly",
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "S",
     "image": "cPK_20_016420_00_GHOST_S.webp",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "S",
     "image": "cPK_20_016470_00_ZORUA_S.webp",
-    "name": "Zorua",
+    "name": {
+      "en": "Zorua",
+      "fr": "Zorua"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "S",
     "image": "cPK_20_016480_00_ZOROARK_S.webp",
-    "name": "Zoroark",
+    "name": {
+      "en": "Zoroark",
+      "fr": "Zoroark"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1034,7 +1343,10 @@
     "number": 104,
     "rarity": "S",
     "image": "cPK_20_016500_00_FORETOS_S.webp",
-    "name": "Forretress",
+    "name": {
+      "en": "Forretress",
+      "fr": "Foretress"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1044,7 +1356,10 @@
     "number": 105,
     "rarity": "S",
     "image": "cPK_20_016550_00_MINIRYU_S.webp",
-    "name": "Dratini",
+    "name": {
+      "en": "Dratini",
+      "fr": "Minidraco"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1054,7 +1369,10 @@
     "number": 106,
     "rarity": "S",
     "image": "cPK_20_016560_00_HAKURYU_S.webp",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1064,7 +1382,10 @@
     "number": 107,
     "rarity": "S",
     "image": "cPK_20_016570_00_KAIRYU_S.webp",
-    "name": "Dragonite",
+    "name": {
+      "en": "Dragonite",
+      "fr": "Dracolosse"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1074,7 +1395,10 @@
     "number": 108,
     "rarity": "S",
     "image": "cPK_20_016580_00_KIBAGO_S.webp",
-    "name": "Axew",
+    "name": {
+      "en": "Axew",
+      "fr": "Coupenotte"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1084,7 +1408,10 @@
     "number": 109,
     "rarity": "S",
     "image": "cPK_20_016590_00_ONONDO_S.webp",
-    "name": "Fraxure",
+    "name": {
+      "en": "Fraxure",
+      "fr": "Incisache"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1094,7 +1421,10 @@
     "number": 110,
     "rarity": "S",
     "image": "cPK_20_016030_00_ONONOKUS_S.webp",
-    "name": "Haxorus",
+    "name": {
+      "en": "Haxorus",
+      "fr": "Tranchodon"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1104,7 +1434,10 @@
     "number": 111,
     "rarity": "SSR",
     "image": "cPK_20_016150_01_MEGALIZARDONXex_SSR.webp",
-    "name": "Mega Charizard X ex",
+    "name": {
+      "en": "Mega Charizard X ex",
+      "fr": "Méga-Dracaufeu X-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1114,7 +1447,10 @@
     "number": 112,
     "rarity": "SSR",
     "image": "cPK_20_016210_02_MEGAYADORANex_SSR.webp",
-    "name": "Mega Slowbro ex",
+    "name": {
+      "en": "Mega Slowbro ex",
+      "fr": "Méga-Flagadoss-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1124,7 +1460,10 @@
     "number": 113,
     "rarity": "SSR",
     "image": "cPK_20_016320_02_MEGALIVOLTex_SSR.webp",
-    "name": "Mega Manectric ex",
+    "name": {
+      "en": "Mega Manectric ex",
+      "fr": "Méga-Élecsprint-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1134,7 +1473,10 @@
     "number": 114,
     "rarity": "SSR",
     "image": "cPK_20_016430_01_MEGAGANGARex_SSR.webp",
-    "name": "Mega Gengar ex",
+    "name": {
+      "en": "Mega Gengar ex",
+      "fr": "Méga-Ectoplasma-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1144,7 +1486,10 @@
     "number": 115,
     "rarity": "SSR",
     "image": "cPK_20_016510_01_MEGAHASSAMex_SSR.webp",
-    "name": "Mega Scizor ex",
+    "name": {
+      "en": "Mega Scizor ex",
+      "fr": "Méga-Cizayox-ex"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1154,7 +1499,10 @@
     "number": 116,
     "rarity": "UR",
     "image": "cPK_20_015180_00_OLIVA_UR.webp",
-    "name": "Arboliva",
+    "name": {
+      "en": "Arboliva",
+      "fr": "Arboliva"
+    },
     "packs": [
       "Mega Shine"
     ]
@@ -1164,7 +1512,10 @@
     "number": 117,
     "rarity": "UR",
     "image": "cTR_20_001090_00_METARUKOABARIA_UR.webp",
-    "name": "Metal Core Barrier",
+    "name": {
+      "en": "Metal Core Barrier",
+      "fr": "Barrière de Métal Renforcé"
+    },
     "packs": [
       "Mega Shine"
     ]

--- a/dist/cards/B3.json
+++ b/dist/cards/B3.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_016660_00_MONJARA_C.webp",
-    "name": "Tangela",
+    "name": {
+      "en": "Tangela",
+      "fr": "Saquedeneu"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "U",
     "image": "cPK_10_016670_00_MOJUMBO_U.webp",
-    "name": "Tangrowth",
+    "name": {
+      "en": "Tangrowth",
+      "fr": "Bouldeneu"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "U",
     "image": "cPK_10_016680_00_HERACROS_U.webp",
-    "name": "Heracross",
+    "name": {
+      "en": "Heracross",
+      "fr": "Scarhino"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "R",
     "image": "cPK_10_016690_00_CELEBI_R.webp",
-    "name": "Celebi",
+    "name": {
+      "en": "Celebi",
+      "fr": "Celebi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "C",
     "image": "cPK_10_016700_00_KIMORI_C.webp",
-    "name": "Treecko",
+    "name": {
+      "en": "Treecko",
+      "fr": "Arcko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "U",
     "image": "cPK_10_016710_00_JUPTILE_U.webp",
-    "name": "Grovyle",
+    "name": {
+      "en": "Grovyle",
+      "fr": "Massko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "R",
     "image": "cPK_10_016720_00_JUKAIN_R.webp",
-    "name": "Sceptile",
+    "name": {
+      "en": "Sceptile",
+      "fr": "Jungko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "RR",
     "image": "cPK_10_016730_00_MEGAJUKAINex_RR.webp",
-    "name": "Mega Sceptile ex",
+    "name": {
+      "en": "Mega Sceptile ex",
+      "fr": "Méga-Jungko-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "C",
     "image": "cPK_10_016740_00_AMETAMA_C.webp",
-    "name": "Surskit",
+    "name": {
+      "en": "Surskit",
+      "fr": "Arakdo"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "C",
     "image": "cPK_10_016750_00_AMEMOTH_C.webp",
-    "name": "Masquerain",
+    "name": {
+      "en": "Masquerain",
+      "fr": "Maskadra"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "C",
     "image": "cPK_10_016760_00_KINOCOCO_C.webp",
-    "name": "Shroomish",
+    "name": {
+      "en": "Shroomish",
+      "fr": "Balignon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "U",
     "image": "cPK_10_016770_00_KINOGASSA_U.webp",
-    "name": "Breloom",
+    "name": {
+      "en": "Breloom",
+      "fr": "Chapignon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "R",
     "image": "cPK_10_016780_00_SUBOMIE_R.webp",
-    "name": "Budew",
+    "name": {
+      "en": "Budew",
+      "fr": "Rozbouton"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "C",
     "image": "cPK_10_016790_00_MUSKIPPA_C.webp",
-    "name": "Carnivine",
+    "name": {
+      "en": "Carnivine",
+      "fr": "Vortente"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "C",
     "image": "cPK_10_016800_00_KURUMIRU_C.webp",
-    "name": "Sewaddle",
+    "name": {
+      "en": "Sewaddle",
+      "fr": "Larveyette"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "C",
     "image": "cPK_10_016810_00_KURUMAYU_C.webp",
-    "name": "Swadloon",
+    "name": {
+      "en": "Swadloon",
+      "fr": "Couverdure"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "U",
     "image": "cPK_10_016820_00_HAHAKOMORI_U.webp",
-    "name": "Leavanny",
+    "name": {
+      "en": "Leavanny",
+      "fr": "Manternel"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "C",
     "image": "cPK_10_016830_00_AIANT_C.webp",
-    "name": "Durant",
+    "name": {
+      "en": "Durant",
+      "fr": "Fermite"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "C",
     "image": "cPK_10_016840_00_KAJICCHU_C.webp",
-    "name": "Applin",
+    "name": {
+      "en": "Applin",
+      "fr": "Verpom"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "R",
     "image": "cPK_10_016850_00_APPRYU_R.webp",
-    "name": "Flapple",
+    "name": {
+      "en": "Flapple",
+      "fr": "Pomdrapi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "C",
     "image": "cPK_10_016860_00_DONMEL_C.webp",
-    "name": "Numel",
+    "name": {
+      "en": "Numel",
+      "fr": "Chamallot"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "U",
     "image": "cPK_10_016870_00_BAKUUDA_U.webp",
-    "name": "Camerupt",
+    "name": {
+      "en": "Camerupt",
+      "fr": "Camérupt"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "RR",
     "image": "cPK_10_016880_00_MEGABAKUUDAex_RR.webp",
-    "name": "Mega Camerupt ex",
+    "name": {
+      "en": "Mega Camerupt ex",
+      "fr": "Méga-Camérupt-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "C",
     "image": "cPK_10_016890_00_POWALENTAIYOUNOSUGATA_C.webp",
-    "name": "Castform Sunny Form",
+    "name": {
+      "en": "Castform Sunny Form",
+      "fr": "Morphéo Forme Solaire"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "R",
     "image": "cPK_10_016900_00_VICTINI_R.webp",
-    "name": "Victini",
+    "name": {
+      "en": "Victini",
+      "fr": "Victini"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "C",
     "image": "cPK_10_016910_00_POKABU_C.webp",
-    "name": "Tepig",
+    "name": {
+      "en": "Tepig",
+      "fr": "Gruikui"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "U",
     "image": "cPK_10_016920_00_CHAOBOO_U.webp",
-    "name": "Pignite",
+    "name": {
+      "en": "Pignite",
+      "fr": "Grotichon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "R",
     "image": "cPK_10_016930_00_ENBUOH_R.webp",
-    "name": "Emboar",
+    "name": {
+      "en": "Emboar",
+      "fr": "Roitiflam"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "C",
     "image": "cPK_10_016940_00_DARUMAKKA_C.webp",
-    "name": "Darumaka",
+    "name": {
+      "en": "Darumaka",
+      "fr": "Darumarond"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "U",
     "image": "cPK_10_016950_00_HIHIDARUMA_U.webp",
-    "name": "Darmanitan",
+    "name": {
+      "en": "Darmanitan",
+      "fr": "Darumacho"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "C",
     "image": "cPK_10_016960_00_MERLARVA_C.webp",
-    "name": "Larvesta",
+    "name": {
+      "en": "Larvesta",
+      "fr": "Pyronille"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "U",
     "image": "cPK_10_016970_00_ULGAMOTH_U.webp",
-    "name": "Volcarona",
+    "name": {
+      "en": "Volcarona",
+      "fr": "Pyrax"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "C",
     "image": "cPK_10_016980_00_NYOROMO_C.webp",
-    "name": "Poliwag",
+    "name": {
+      "en": "Poliwag",
+      "fr": "Ptitard"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "U",
     "image": "cPK_10_016990_00_NYOROZO_U.webp",
-    "name": "Poliwhirl",
+    "name": {
+      "en": "Poliwhirl",
+      "fr": "Têtarte"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "R",
     "image": "cPK_10_017000_00_NYOROTONO_R.webp",
-    "name": "Politoed",
+    "name": {
+      "en": "Politoed",
+      "fr": "Tarpaud"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "U",
     "image": "cPK_10_017010_00_PALDEAKENTAUROS_U.webp",
-    "name": "Paldean Tauros",
+    "name": {
+      "en": "Paldean Tauros",
+      "fr": "Tauros de Paldea"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "RR",
     "image": "cPK_10_017020_00_SHOWERSex_RR.webp",
-    "name": "Vaporeon ex",
+    "name": {
+      "en": "Vaporeon ex",
+      "fr": "Aquali-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "C",
     "image": "cPK_10_017030_00_UPAH_C.webp",
-    "name": "Wooper",
+    "name": {
+      "en": "Wooper",
+      "fr": "Axoloto"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "U",
     "image": "cPK_10_017040_00_NUOH_U.webp",
-    "name": "Quagsire",
+    "name": {
+      "en": "Quagsire",
+      "fr": "Maraiste"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "C",
     "image": "cPK_10_017050_00_POWALENAMAMIZUNOSUGATA_C.webp",
-    "name": "Castform Rainy Form",
+    "name": {
+      "en": "Castform Rainy Form",
+      "fr": "Morphéo Forme Eau de Pluie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "C",
     "image": "cPK_10_017060_00_POWALENYUKIGUMONOSUGATA_C.webp",
-    "name": "Castform Snowy Form",
+    "name": {
+      "en": "Castform Snowy Form",
+      "fr": "Morphéo Forme Blizzard"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "C",
     "image": "cPK_10_017070_00_PEARLULU_C.webp",
-    "name": "Clamperl",
+    "name": {
+      "en": "Clamperl",
+      "fr": "Coquiperl"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "U",
     "image": "cPK_10_017080_00_HUNTAIL_U.webp",
-    "name": "Huntail",
+    "name": {
+      "en": "Huntail",
+      "fr": "Serpang"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "U",
     "image": "cPK_10_017090_00_SAKURABYSS_U.webp",
-    "name": "Gorebyss",
+    "name": {
+      "en": "Gorebyss",
+      "fr": "Rosabyss"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "U",
     "image": "cPK_10_017100_00_REGICE_U.webp",
-    "name": "Regice",
+    "name": {
+      "en": "Regice",
+      "fr": "Regice"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "C",
     "image": "cPK_10_017110_00_KUMASYUN_C.webp",
-    "name": "Cubchoo",
+    "name": {
+      "en": "Cubchoo",
+      "fr": "Polarhume"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "U",
     "image": "cPK_10_017120_00_TUNBEAR_U.webp",
-    "name": "Beartic",
+    "name": {
+      "en": "Beartic",
+      "fr": "Polagriffe"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "C",
     "image": "cPK_10_017130_00_MESSON_C.webp",
-    "name": "Sobble",
+    "name": {
+      "en": "Sobble",
+      "fr": "Larméléon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "U",
     "image": "cPK_10_017140_00_JIMEREON_U.webp",
-    "name": "Drizzile",
+    "name": {
+      "en": "Drizzile",
+      "fr": "Arrozard"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "R",
     "image": "cPK_10_017150_00_INTEREON_R.webp",
-    "name": "Inteleon",
+    "name": {
+      "en": "Inteleon",
+      "fr": "Lézargus"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "R",
     "image": "cPK_10_017160_00_WULAOSURENGEKINOKATA_R.webp",
-    "name": "Rapid Strike Urshifu",
+    "name": {
+      "en": "Rapid Strike Urshifu",
+      "fr": "Shifours Mille Poings"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "C",
     "image": "cPK_10_017170_00_COIL_C.webp",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "U",
     "image": "cPK_10_017180_00_RARECOIL_U.webp",
-    "name": "Magneton",
+    "name": {
+      "en": "Magneton",
+      "fr": "Magnéton"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "RR",
     "image": "cPK_10_017190_00_JIBACOILex_RR.webp",
-    "name": "Magnezone ex",
+    "name": {
+      "en": "Magnezone ex",
+      "fr": "Magnézone-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "C",
     "image": "cPK_10_017200_00_BIRIRIDAMA_C.webp",
-    "name": "Voltorb",
+    "name": {
+      "en": "Voltorb",
+      "fr": "Voltorbe"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "C",
     "image": "cPK_10_017210_00_MARUMINE_C.webp",
-    "name": "Electrode",
+    "name": {
+      "en": "Electrode",
+      "fr": "Électrode"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "C",
     "image": "cPK_10_017220_00_CHONCHIE_C.webp",
-    "name": "Chinchou",
+    "name": {
+      "en": "Chinchou",
+      "fr": "Loupio"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "U",
     "image": "cPK_10_017230_00_LANTERN_U.webp",
-    "name": "Lanturn",
+    "name": {
+      "en": "Lanturn",
+      "fr": "Lanturn"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "R",
     "image": "cPK_10_017240_00_ZEKROM_R.webp",
-    "name": "Zekrom",
+    "name": {
+      "en": "Zekrom",
+      "fr": "Zekrom"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "C",
     "image": "cPK_10_017250_00_ELESON_C.webp",
-    "name": "Toxel",
+    "name": {
+      "en": "Toxel",
+      "fr": "Toxizap"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "R",
     "image": "cPK_10_017260_00_STRINDER_R.webp",
-    "name": "Toxtricity",
+    "name": {
+      "en": "Toxtricity",
+      "fr": "Salarsen"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "C",
     "image": "cPK_10_017270_00_MORPEKO_C.webp",
-    "name": "Morpeko",
+    "name": {
+      "en": "Morpeko",
+      "fr": "Morpeko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "C",
     "image": "cPK_10_017280_00_RALTS_C.webp",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "U",
     "image": "cPK_10_017290_00_KIRLIA_U.webp",
-    "name": "Kirlia",
+    "name": {
+      "en": "Kirlia",
+      "fr": "Kirlia"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "C",
     "image": "cPK_10_017300_00_NYASPER_C.webp",
-    "name": "Espurr",
+    "name": {
+      "en": "Espurr",
+      "fr": "Psystigri"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "R",
     "image": "cPK_10_017310_00_NYAONIX_R.webp",
-    "name": "Meowstic",
+    "name": {
+      "en": "Meowstic",
+      "fr": "Mistigrix"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "R",
     "image": "cPK_10_017320_00_DIANCIE_R.webp",
-    "name": "Diancie",
+    "name": {
+      "en": "Diancie",
+      "fr": "Diancie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "C",
     "image": "cPK_10_017330_00_ODORIDORI_C.webp",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "C",
     "image": "cPK_10_017340_00_MIBRIM_C.webp",
-    "name": "Hatenna",
+    "name": {
+      "en": "Hatenna",
+      "fr": "Bibichut"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "U",
     "image": "cPK_10_017350_00_TEBRIM_U.webp",
-    "name": "Hattrem",
+    "name": {
+      "en": "Hattrem",
+      "fr": "Chapotus"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "R",
     "image": "cPK_10_017360_00_BRIMUON_R.webp",
-    "name": "Hatterene",
+    "name": {
+      "en": "Hatterene",
+      "fr": "Sorcilence"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "C",
     "image": "cPK_10_017370_00_ANOKUSA_C.webp",
-    "name": "Bramblin",
+    "name": {
+      "en": "Bramblin",
+      "fr": "Virovent"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "R",
     "image": "cPK_10_017380_00_ANOHORAGUSA_R.webp",
-    "name": "Brambleghast",
+    "name": {
+      "en": "Brambleghast",
+      "fr": "Virevorreur"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "C",
     "image": "cPK_10_017390_00_GLIGER_C.webp",
-    "name": "Gligar",
+    "name": {
+      "en": "Gligar",
+      "fr": "Scorplane"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "U",
     "image": "cPK_10_017400_00_GLION_U.webp",
-    "name": "Gliscor",
+    "name": {
+      "en": "Gliscor",
+      "fr": "Scorvol"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "C",
     "image": "cPK_10_017410_00_NUCKRAR_C.webp",
-    "name": "Trapinch",
+    "name": {
+      "en": "Trapinch",
+      "fr": "Kraknoix"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "U",
     "image": "cPK_10_017420_00_REGIROCK_U.webp",
-    "name": "Regirock",
+    "name": {
+      "en": "Regirock",
+      "fr": "Regirock"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "R",
     "image": "cPK_10_017430_00_USOHACHI_R.webp",
-    "name": "Bonsly",
+    "name": {
+      "en": "Bonsly",
+      "fr": "Manzaï"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "C",
     "image": "cPK_10_017440_00_RIOLU_C.webp",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "R",
     "image": "cPK_10_017450_00_LUCARIO_R.webp",
-    "name": "Lucario",
+    "name": {
+      "en": "Lucario",
+      "fr": "Lucario"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "RR",
     "image": "cPK_10_017460_00_MEGALUCARIOex_RR.webp",
-    "name": "Mega Lucario ex",
+    "name": {
+      "en": "Mega Lucario ex",
+      "fr": "Méga-Lucario-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "C",
     "image": "cPK_10_017470_00_GUREGGRU_C.webp",
-    "name": "Croagunk",
+    "name": {
+      "en": "Croagunk",
+      "fr": "Cradopaud"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "U",
     "image": "cPK_10_017480_00_DOKUROG_U.webp",
-    "name": "Toxicroak",
+    "name": {
+      "en": "Toxicroak",
+      "fr": "Coatox"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "R",
     "image": "cPK_10_017490_00_ERUREIDO_R.webp",
-    "name": "Gallade",
+    "name": {
+      "en": "Gallade",
+      "fr": "Gallame"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "C",
     "image": "cPK_10_017500_00_NAGEKI_C.webp",
-    "name": "Throh",
+    "name": {
+      "en": "Throh",
+      "fr": "Judokrak"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "C",
     "image": "cPK_10_017510_00_DAGEKI_C.webp",
-    "name": "Sawk",
+    "name": {
+      "en": "Sawk",
+      "fr": "Karaclée"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "C",
     "image": "cPK_10_017520_00_ISHIZUMAI_C.webp",
-    "name": "Dwebble",
+    "name": {
+      "en": "Dwebble",
+      "fr": "Crabicoque"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "RR",
     "image": "cPK_10_017530_00_IWAPALACEex_RR.webp",
-    "name": "Crustle ex",
+    "name": {
+      "en": "Crustle ex",
+      "fr": "Crabaraque-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "R",
     "image": "cPK_10_017540_00_MELOETTA_R.webp",
-    "name": "Meloetta",
+    "name": {
+      "en": "Meloetta",
+      "fr": "Meloetta"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "C",
     "image": "cPK_10_017550_00_NUIKOGUMA_C.webp",
-    "name": "Stufful",
+    "name": {
+      "en": "Stufful",
+      "fr": "Nounourson"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "U",
     "image": "cPK_10_017560_00_KITERUGUMA_U.webp",
-    "name": "Bewear",
+    "name": {
+      "en": "Bewear",
+      "fr": "Chelours"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "C",
     "image": "cPK_10_017570_00_TANDON_C.webp",
-    "name": "Rolycoly",
+    "name": {
+      "en": "Rolycoly",
+      "fr": "Charbi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "U",
     "image": "cPK_10_017580_00_TOROGGON_U.webp",
-    "name": "Carkol",
+    "name": {
+      "en": "Carkol",
+      "fr": "Wagomine"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "R",
     "image": "cPK_10_017590_00_SEKITANZAN_R.webp",
-    "name": "Coalossal",
+    "name": {
+      "en": "Coalossal",
+      "fr": "Monthracite"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "C",
     "image": "cPK_10_017600_00_SUNAHEBI_C.webp",
-    "name": "Silicobra",
+    "name": {
+      "en": "Silicobra",
+      "fr": "Dunaja"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "U",
     "image": "cPK_10_017610_00_SADAIJA_U.webp",
-    "name": "Sandaconda",
+    "name": {
+      "en": "Sandaconda",
+      "fr": "Dunaconda"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "C",
     "image": "cPK_10_017620_00_DAKUMA_C.webp",
-    "name": "Kubfu",
+    "name": {
+      "en": "Kubfu",
+      "fr": "Wushours"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "C",
     "image": "cPK_10_017630_00_ZUBAT_C.webp",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "U",
     "image": "cPK_10_017640_00_GOLBAT_U.webp",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "R",
     "image": "cPK_10_017650_00_CROBAT_R.webp",
-    "name": "Crobat",
+    "name": {
+      "en": "Crobat",
+      "fr": "Nostenfer"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "C",
     "image": "cPK_10_017660_00_DOGARS_C.webp",
-    "name": "Koffing",
+    "name": {
+      "en": "Koffing",
+      "fr": "Smogo"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "U",
     "image": "cPK_10_017670_00_MATADOGAS_U.webp",
-    "name": "Weezing",
+    "name": {
+      "en": "Weezing",
+      "fr": "Smogogo"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "C",
     "image": "cPK_10_017680_00_HARYSEN_C.webp",
-    "name": "Qwilfish",
+    "name": {
+      "en": "Qwilfish",
+      "fr": "Qwilfish"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1034,7 +1343,10 @@
     "number": 104,
     "rarity": "C",
     "image": "cPK_10_017690_00_HABUNAKE_C.webp",
-    "name": "Seviper",
+    "name": {
+      "en": "Seviper",
+      "fr": "Séviper"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1044,7 +1356,10 @@
     "number": 105,
     "rarity": "C",
     "image": "cPK_10_017700_00_ZORUA_C.webp",
-    "name": "Zorua",
+    "name": {
+      "en": "Zorua",
+      "fr": "Zorua"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1054,7 +1369,10 @@
     "number": 106,
     "rarity": "RR",
     "image": "cPK_10_017710_00_ZOROARKex_RR.webp",
-    "name": "Zoroark ex",
+    "name": {
+      "en": "Zoroark ex",
+      "fr": "Zoroark-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1064,7 +1382,10 @@
     "number": 107,
     "rarity": "C",
     "image": "cPK_10_017720_00_TAMAGETAKE_C.webp",
-    "name": "Foongus",
+    "name": {
+      "en": "Foongus",
+      "fr": "Trompignon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1074,7 +1395,10 @@
     "number": 108,
     "rarity": "U",
     "image": "cPK_10_017730_00_MOROBARERU_U.webp",
-    "name": "Amoonguss",
+    "name": {
+      "en": "Amoonguss",
+      "fr": "Gaulet"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1084,7 +1408,10 @@
     "number": 109,
     "rarity": "C",
     "image": "cPK_10_017740_00_VALCHAI_C.webp",
-    "name": "Vullaby",
+    "name": {
+      "en": "Vullaby",
+      "fr": "Vostourno"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1094,7 +1421,10 @@
     "number": 110,
     "rarity": "U",
     "image": "cPK_10_017750_00_VULGINA_U.webp",
-    "name": "Mandibuzz",
+    "name": {
+      "en": "Mandibuzz",
+      "fr": "Vaututrice"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1104,7 +1434,10 @@
     "number": 111,
     "rarity": "C",
     "image": "cPK_10_017760_00_MAAIIKA_C.webp",
-    "name": "Inkay",
+    "name": {
+      "en": "Inkay",
+      "fr": "Sepiatop"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1114,7 +1447,10 @@
     "number": 112,
     "rarity": "U",
     "image": "cPK_10_017770_00_CALAMANERO_U.webp",
-    "name": "Malamar",
+    "name": {
+      "en": "Malamar",
+      "fr": "Sepiatroce"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1124,7 +1460,10 @@
     "number": 113,
     "rarity": "R",
     "image": "cPK_10_017780_00_WULAOSUICHIGEKINOKATA_R.webp",
-    "name": "Single Strike Urshifu",
+    "name": {
+      "en": "Single Strike Urshifu",
+      "fr": "Shifours Poing Final"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1134,7 +1473,10 @@
     "number": 114,
     "rarity": "R",
     "image": "cPK_10_017790_00_ZARUDE_R.webp",
-    "name": "Zarude",
+    "name": {
+      "en": "Zarude",
+      "fr": "Zarude"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1144,7 +1486,10 @@
     "number": 115,
     "rarity": "R",
     "image": "cPK_10_017800_00_OTOSHIDORI_R.webp",
-    "name": "Bombirdier",
+    "name": {
+      "en": "Bombirdier",
+      "fr": "Lestombaile"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1154,7 +1499,10 @@
     "number": 116,
     "rarity": "U",
     "image": "cPK_10_017810_00_REGISTEEL_U.webp",
-    "name": "Registeel",
+    "name": {
+      "en": "Registeel",
+      "fr": "Registeel"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1164,7 +1512,10 @@
     "number": 117,
     "rarity": "C",
     "image": "cPK_10_017820_00_DOHMIRROR_C.webp",
-    "name": "Bronzor",
+    "name": {
+      "en": "Bronzor",
+      "fr": "Archéomire"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1174,7 +1525,10 @@
     "number": 118,
     "rarity": "U",
     "image": "cPK_10_017830_00_DOHTAKUN_U.webp",
-    "name": "Bronzong",
+    "name": {
+      "en": "Bronzong",
+      "fr": "Archéodong"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1184,7 +1538,10 @@
     "number": 119,
     "rarity": "C",
     "image": "cPK_10_017840_00_KOMATANA_C.webp",
-    "name": "Pawniard",
+    "name": {
+      "en": "Pawniard",
+      "fr": "Scalpion"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1194,7 +1551,10 @@
     "number": 120,
     "rarity": "U",
     "image": "cPK_10_017850_00_KIRIKIZAN_U.webp",
-    "name": "Bisharp",
+    "name": {
+      "en": "Bisharp",
+      "fr": "Scalproie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1204,7 +1564,10 @@
     "number": 121,
     "rarity": "U",
     "image": "cPK_10_017860_00_MAGEARNA_U.webp",
-    "name": "Magearna",
+    "name": {
+      "en": "Magearna",
+      "fr": "Magearna"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1214,7 +1577,10 @@
     "number": 122,
     "rarity": "C",
     "image": "cPK_10_017870_00_MELTAN_C.webp",
-    "name": "Meltan",
+    "name": {
+      "en": "Meltan",
+      "fr": "Meltan"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1224,7 +1590,10 @@
     "number": 123,
     "rarity": "R",
     "image": "cPK_10_017880_00_MELMETAL_R.webp",
-    "name": "Melmetal",
+    "name": {
+      "en": "Melmetal",
+      "fr": "Melmetal"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1234,7 +1603,10 @@
     "number": 124,
     "rarity": "RR",
     "image": "cPK_10_017890_00_ARMORGAex_RR.webp",
-    "name": "Corviknight ex",
+    "name": {
+      "en": "Corviknight ex",
+      "fr": "Corvaillus-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1244,7 +1616,10 @@
     "number": 125,
     "rarity": "U",
     "image": "cPK_10_017900_00_VIBRAVA_U.webp",
-    "name": "Vibrava",
+    "name": {
+      "en": "Vibrava",
+      "fr": "Vibraninf"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1254,7 +1629,10 @@
     "number": 126,
     "rarity": "RR",
     "image": "cPK_10_017910_00_FLYGONex_RR.webp",
-    "name": "Flygon ex",
+    "name": {
+      "en": "Flygon ex",
+      "fr": "Libégon-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1264,7 +1642,10 @@
     "number": 127,
     "rarity": "C",
     "image": "cPK_10_017920_00_LUCKY_C.webp",
-    "name": "Chansey",
+    "name": {
+      "en": "Chansey",
+      "fr": "Leveinard"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1274,7 +1655,10 @@
     "number": 128,
     "rarity": "R",
     "image": "cPK_10_017930_00_HAPPINAS_R.webp",
-    "name": "Blissey",
+    "name": {
+      "en": "Blissey",
+      "fr": "Leuphorie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1284,7 +1668,10 @@
     "number": 129,
     "rarity": "C",
     "image": "cPK_10_017940_00_EIEVUI_C.webp",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1294,7 +1681,10 @@
     "number": 130,
     "rarity": "R",
     "image": "cPK_10_017950_00_NOKOCCHI_R.webp",
-    "name": "Dunsparce",
+    "name": {
+      "en": "Dunsparce",
+      "fr": "Insolourdo"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1304,7 +1694,10 @@
     "number": 131,
     "rarity": "C",
     "image": "cPK_10_017960_00_HIMEGUMA_C.webp",
-    "name": "Teddiursa",
+    "name": {
+      "en": "Teddiursa",
+      "fr": "Teddiursa"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1314,7 +1707,10 @@
     "number": 132,
     "rarity": "U",
     "image": "cPK_10_017970_00_RINGUMA_U.webp",
-    "name": "Ursaring",
+    "name": {
+      "en": "Ursaring",
+      "fr": "Ursaring"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1324,7 +1720,10 @@
     "number": 133,
     "rarity": "C",
     "image": "cPK_10_017980_00_POWALEN_C.webp",
-    "name": "Castform",
+    "name": {
+      "en": "Castform",
+      "fr": "Morphéo"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1334,7 +1733,10 @@
     "number": 134,
     "rarity": "R",
     "image": "cPK_10_017990_00_REGIGIGAS_R.webp",
-    "name": "Regigigas",
+    "name": {
+      "en": "Regigigas",
+      "fr": "Regigigas"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1344,7 +1746,10 @@
     "number": 135,
     "rarity": "C",
     "image": "cPK_10_018000_00_MINEZUMI_C.webp",
-    "name": "Patrat",
+    "name": {
+      "en": "Patrat",
+      "fr": "Ratentif"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1354,7 +1759,10 @@
     "number": 136,
     "rarity": "C",
     "image": "cPK_10_018010_00_MIRUHOG_C.webp",
-    "name": "Watchog",
+    "name": {
+      "en": "Watchog",
+      "fr": "Miradar"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1364,7 +1772,10 @@
     "number": 137,
     "rarity": "C",
     "image": "cPK_10_018020_00_YORTERRIE_C.webp",
-    "name": "Lillipup",
+    "name": {
+      "en": "Lillipup",
+      "fr": "Ponchiot"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1374,7 +1785,10 @@
     "number": 138,
     "rarity": "U",
     "image": "cPK_10_018030_00_HERDERRIE_U.webp",
-    "name": "Herdier",
+    "name": {
+      "en": "Herdier",
+      "fr": "Ponchien"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1384,7 +1798,10 @@
     "number": 139,
     "rarity": "R",
     "image": "cPK_10_018040_00_MOOLAND_R.webp",
-    "name": "Stoutland",
+    "name": {
+      "en": "Stoutland",
+      "fr": "Mastouffe"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1394,7 +1811,10 @@
     "number": 140,
     "rarity": "U",
     "image": "cPK_10_018050_00_TABUNNE_U.webp",
-    "name": "Audino",
+    "name": {
+      "en": "Audino",
+      "fr": "Nanméouïe"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1404,7 +1824,10 @@
     "number": 141,
     "rarity": "RR",
     "image": "cPK_10_018060_00_MEGATABUNNEex_RR.webp",
-    "name": "Mega Audino ex",
+    "name": {
+      "en": "Mega Audino ex",
+      "fr": "Méga-Nanméouïe-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1414,7 +1837,10 @@
     "number": 142,
     "rarity": "C",
     "image": "cPK_10_018070_00_CHILLARMY_C.webp",
-    "name": "Minccino",
+    "name": {
+      "en": "Minccino",
+      "fr": "Chinchidou"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1424,7 +1850,10 @@
     "number": 143,
     "rarity": "C",
     "image": "cPK_10_018080_00_CHILLACCINO_C.webp",
-    "name": "Cinccino",
+    "name": {
+      "en": "Cinccino",
+      "fr": "Pashmilla"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1434,7 +1863,10 @@
     "number": 144,
     "rarity": "U",
     "image": "cPK_10_018090_00_TRIMMIEN_U.webp",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1444,7 +1876,10 @@
     "number": 145,
     "rarity": "C",
     "image": "cPK_10_018100_00_KOKOGARA_C.webp",
-    "name": "Rookidee",
+    "name": {
+      "en": "Rookidee",
+      "fr": "Minisange"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1454,7 +1889,10 @@
     "number": 146,
     "rarity": "U",
     "image": "cPK_10_018110_00_AOGARASU_U.webp",
-    "name": "Corvisquire",
+    "name": {
+      "en": "Corvisquire",
+      "fr": "Bleuseille"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1464,7 +1902,10 @@
     "number": 147,
     "rarity": "U",
     "image": "cTR_10_001280_00_FIELDBLOWER_U.webp",
-    "name": "Field Blower",
+    "name": {
+      "en": "Field Blower",
+      "fr": "Nettoyage de Terrain"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1474,7 +1915,10 @@
     "number": 148,
     "rarity": "U",
     "image": "cTR_10_001290_00_HAPPINESSEGG_U.webp",
-    "name": "Lucky Egg",
+    "name": {
+      "en": "Lucky Egg",
+      "fr": "Œuf Chance"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1484,7 +1928,10 @@
     "number": 149,
     "rarity": "U",
     "image": "cTR_10_001300_00_CORNI_U.webp",
-    "name": "Korrina",
+    "name": {
+      "en": "Korrina",
+      "fr": "Cornélia"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1494,7 +1941,10 @@
     "number": 150,
     "rarity": "U",
     "image": "cTR_10_001310_00_TAXIDRIVER_U.webp",
-    "name": "Cabbie",
+    "name": {
+      "en": "Cabbie",
+      "fr": "Chauffeur de Taxi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1504,7 +1954,10 @@
     "number": 151,
     "rarity": "U",
     "image": "cTR_10_001320_00_CHEREN_U.webp",
-    "name": "Cheren",
+    "name": {
+      "en": "Cheren",
+      "fr": "Tcheren"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1514,7 +1967,10 @@
     "number": 152,
     "rarity": "U",
     "image": "cTR_10_001330_00_PARASOLGIRL_U.webp",
-    "name": "Parasol Lady",
+    "name": {
+      "en": "Parasol Lady",
+      "fr": "Fille au Parapluie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1524,7 +1980,10 @@
     "number": 153,
     "rarity": "U",
     "image": "cTR_10_001340_00_AMAKUKAORUMORI_U.webp",
-    "name": "Fragrant Forest",
+    "name": {
+      "en": "Fragrant Forest",
+      "fr": "Forêt Parfumée"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1534,7 +1993,10 @@
     "number": 154,
     "rarity": "U",
     "image": "cTR_10_001350_00_INISHIENOTOUGIJYOU_U.webp",
-    "name": "Arena of Antiquity",
+    "name": {
+      "en": "Arena of Antiquity",
+      "fr": "Colisée Antique"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1544,7 +2006,10 @@
     "number": 155,
     "rarity": "U",
     "image": "cTR_10_001360_00_KEKKAINOFIELD_U.webp",
-    "name": "Bounded Field",
+    "name": {
+      "en": "Bounded Field",
+      "fr": "Champ Barrière"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1554,7 +2019,10 @@
     "number": 156,
     "rarity": "AR",
     "image": "cPK_20_016700_00_KIMORI_AR.webp",
-    "name": "Treecko",
+    "name": {
+      "en": "Treecko",
+      "fr": "Arcko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1564,7 +2032,10 @@
     "number": 157,
     "rarity": "AR",
     "image": "cPK_20_016710_00_JUPTILE_AR.webp",
-    "name": "Grovyle",
+    "name": {
+      "en": "Grovyle",
+      "fr": "Massko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1574,7 +2045,10 @@
     "number": 158,
     "rarity": "AR",
     "image": "cPK_20_016760_00_KINOCOCO_AR.webp",
-    "name": "Shroomish",
+    "name": {
+      "en": "Shroomish",
+      "fr": "Balignon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1584,7 +2058,10 @@
     "number": 159,
     "rarity": "AR",
     "image": "cPK_20_016780_00_SUBOMIE_AR.webp",
-    "name": "Budew",
+    "name": {
+      "en": "Budew",
+      "fr": "Rozbouton"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1594,7 +2071,10 @@
     "number": 160,
     "rarity": "AR",
     "image": "cPK_20_016850_00_APPRYU_AR.webp",
-    "name": "Flapple",
+    "name": {
+      "en": "Flapple",
+      "fr": "Pomdrapi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1604,7 +2084,10 @@
     "number": 161,
     "rarity": "AR",
     "image": "cPK_20_016910_00_POKABU_AR.webp",
-    "name": "Tepig",
+    "name": {
+      "en": "Tepig",
+      "fr": "Gruikui"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1614,7 +2097,10 @@
     "number": 162,
     "rarity": "AR",
     "image": "cPK_20_017040_00_NUOH_AR.webp",
-    "name": "Quagsire",
+    "name": {
+      "en": "Quagsire",
+      "fr": "Maraiste"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1624,7 +2110,10 @@
     "number": 163,
     "rarity": "AR",
     "image": "cPK_20_017240_00_ZEKROM_AR.webp",
-    "name": "Zekrom",
+    "name": {
+      "en": "Zekrom",
+      "fr": "Zekrom"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1634,7 +2123,10 @@
     "number": 164,
     "rarity": "AR",
     "image": "cPK_20_017270_00_MORPEKO_AR.webp",
-    "name": "Morpeko",
+    "name": {
+      "en": "Morpeko",
+      "fr": "Morpeko"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1644,7 +2136,10 @@
     "number": 165,
     "rarity": "AR",
     "image": "cPK_20_017310_00_NYAONIX_AR.webp",
-    "name": "Meowstic",
+    "name": {
+      "en": "Meowstic",
+      "fr": "Mistigrix"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1654,7 +2149,10 @@
     "number": 166,
     "rarity": "AR",
     "image": "cPK_20_017330_00_ODORIDORI_AR.webp",
-    "name": "Oricorio",
+    "name": {
+      "en": "Oricorio",
+      "fr": "Plumeline"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1664,7 +2162,10 @@
     "number": 167,
     "rarity": "AR",
     "image": "cPK_20_017380_00_ANOHORAGUSA_AR.webp",
-    "name": "Brambleghast",
+    "name": {
+      "en": "Brambleghast",
+      "fr": "Virevorreur"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1674,7 +2175,10 @@
     "number": 168,
     "rarity": "AR",
     "image": "cPK_20_017430_00_USOHACHI_AR.webp",
-    "name": "Bonsly",
+    "name": {
+      "en": "Bonsly",
+      "fr": "Manzaï"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1684,7 +2188,10 @@
     "number": 169,
     "rarity": "AR",
     "image": "cPK_20_017440_00_RIOLU_AR.webp",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1694,7 +2201,10 @@
     "number": 170,
     "rarity": "AR",
     "image": "cPK_20_017540_00_MELOETTA_AR.webp",
-    "name": "Meloetta",
+    "name": {
+      "en": "Meloetta",
+      "fr": "Meloetta"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1704,7 +2214,10 @@
     "number": 171,
     "rarity": "AR",
     "image": "cPK_20_017580_00_TOROGGON_AR.webp",
-    "name": "Carkol",
+    "name": {
+      "en": "Carkol",
+      "fr": "Wagomine"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1714,7 +2227,10 @@
     "number": 172,
     "rarity": "AR",
     "image": "cPK_20_017620_00_DAKUMA_AR.webp",
-    "name": "Kubfu",
+    "name": {
+      "en": "Kubfu",
+      "fr": "Wushours"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1724,7 +2240,10 @@
     "number": 173,
     "rarity": "AR",
     "image": "cPK_20_017690_00_HABUNAKE_AR.webp",
-    "name": "Seviper",
+    "name": {
+      "en": "Seviper",
+      "fr": "Séviper"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1734,7 +2253,10 @@
     "number": 174,
     "rarity": "AR",
     "image": "cPK_20_017700_00_ZORUA_AR.webp",
-    "name": "Zorua",
+    "name": {
+      "en": "Zorua",
+      "fr": "Zorua"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1744,7 +2266,10 @@
     "number": 175,
     "rarity": "AR",
     "image": "cPK_20_017770_00_CALAMANERO_AR.webp",
-    "name": "Malamar",
+    "name": {
+      "en": "Malamar",
+      "fr": "Sepiatroce"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1754,7 +2279,10 @@
     "number": 176,
     "rarity": "AR",
     "image": "cPK_20_017850_00_KIRIKIZAN_AR.webp",
-    "name": "Bisharp",
+    "name": {
+      "en": "Bisharp",
+      "fr": "Scalproie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1764,7 +2292,10 @@
     "number": 177,
     "rarity": "AR",
     "image": "cPK_20_017870_00_MELTAN_AR.webp",
-    "name": "Meltan",
+    "name": {
+      "en": "Meltan",
+      "fr": "Meltan"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1774,7 +2305,10 @@
     "number": 178,
     "rarity": "AR",
     "image": "cPK_20_017980_00_POWALEN_AR.webp",
-    "name": "Castform",
+    "name": {
+      "en": "Castform",
+      "fr": "Morphéo"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1784,7 +2318,10 @@
     "number": 179,
     "rarity": "AR",
     "image": "cPK_20_018080_00_CHILLACCINO_AR.webp",
-    "name": "Cinccino",
+    "name": {
+      "en": "Cinccino",
+      "fr": "Pashmilla"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1794,7 +2331,10 @@
     "number": 180,
     "rarity": "SR",
     "image": "cPK_20_016730_00_MEGAJUKAINex_SR.webp",
-    "name": "Mega Sceptile ex",
+    "name": {
+      "en": "Mega Sceptile ex",
+      "fr": "Méga-Jungko-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1804,7 +2344,10 @@
     "number": 181,
     "rarity": "SR",
     "image": "cPK_20_016880_00_MEGABAKUUDAex_SR.webp",
-    "name": "Mega Camerupt ex",
+    "name": {
+      "en": "Mega Camerupt ex",
+      "fr": "Méga-Camérupt-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1814,7 +2357,10 @@
     "number": 182,
     "rarity": "SR",
     "image": "cPK_20_017020_00_SHOWERSex_SR.webp",
-    "name": "Vaporeon ex",
+    "name": {
+      "en": "Vaporeon ex",
+      "fr": "Aquali-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1824,7 +2370,10 @@
     "number": 183,
     "rarity": "SR",
     "image": "cPK_20_017190_00_JIBACOILex_SR.webp",
-    "name": "Magnezone ex",
+    "name": {
+      "en": "Magnezone ex",
+      "fr": "Magnézone-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1834,7 +2383,10 @@
     "number": 184,
     "rarity": "SR",
     "image": "cPK_20_017460_00_MEGALUCARIOex_SR.webp",
-    "name": "Mega Lucario ex",
+    "name": {
+      "en": "Mega Lucario ex",
+      "fr": "Méga-Lucario-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1844,7 +2396,10 @@
     "number": 185,
     "rarity": "SR",
     "image": "cPK_20_017530_00_IWAPALACEex_SR.webp",
-    "name": "Crustle ex",
+    "name": {
+      "en": "Crustle ex",
+      "fr": "Crabaraque-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1854,7 +2409,10 @@
     "number": 186,
     "rarity": "SR",
     "image": "cPK_20_017710_00_ZOROARKex_SR.webp",
-    "name": "Zoroark ex",
+    "name": {
+      "en": "Zoroark ex",
+      "fr": "Zoroark-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1864,7 +2422,10 @@
     "number": 187,
     "rarity": "SR",
     "image": "cPK_20_017890_00_ARMORGAex_SR.webp",
-    "name": "Corviknight ex",
+    "name": {
+      "en": "Corviknight ex",
+      "fr": "Corvaillus-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1874,7 +2435,10 @@
     "number": 188,
     "rarity": "SR",
     "image": "cPK_20_017910_00_FLYGONex_SR.webp",
-    "name": "Flygon ex",
+    "name": {
+      "en": "Flygon ex",
+      "fr": "Libégon-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1884,7 +2448,10 @@
     "number": 189,
     "rarity": "SR",
     "image": "cPK_20_018060_00_MEGATABUNNEex_SR.webp",
-    "name": "Mega Audino ex",
+    "name": {
+      "en": "Mega Audino ex",
+      "fr": "Méga-Nanméouïe-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1894,7 +2461,10 @@
     "number": 190,
     "rarity": "SR",
     "image": "cTR_20_001300_00_CORNI_SR.webp",
-    "name": "Korrina",
+    "name": {
+      "en": "Korrina",
+      "fr": "Cornélia"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1904,7 +2474,10 @@
     "number": 191,
     "rarity": "SR",
     "image": "cTR_20_001310_00_TAXIDRIVER_SR.webp",
-    "name": "Cabbie",
+    "name": {
+      "en": "Cabbie",
+      "fr": "Chauffeur de Taxi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1914,7 +2487,10 @@
     "number": 192,
     "rarity": "SR",
     "image": "cTR_20_001320_00_CHEREN_SR.webp",
-    "name": "Cheren",
+    "name": {
+      "en": "Cheren",
+      "fr": "Tcheren"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1924,7 +2500,10 @@
     "number": 193,
     "rarity": "SR",
     "image": "cTR_20_001330_00_PARASOLGIRL_SR.webp",
-    "name": "Parasol Lady",
+    "name": {
+      "en": "Parasol Lady",
+      "fr": "Fille au Parapluie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1934,7 +2513,10 @@
     "number": 194,
     "rarity": "SAR",
     "image": "cPK_20_016730_01_MEGAJUKAINex_SAR.webp",
-    "name": "Mega Sceptile ex",
+    "name": {
+      "en": "Mega Sceptile ex",
+      "fr": "Méga-Jungko-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1944,7 +2526,10 @@
     "number": 195,
     "rarity": "SAR",
     "image": "cPK_20_016880_01_MEGABAKUUDAex_SAR.webp",
-    "name": "Mega Camerupt ex",
+    "name": {
+      "en": "Mega Camerupt ex",
+      "fr": "Méga-Camérupt-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1954,7 +2539,10 @@
     "number": 196,
     "rarity": "SAR",
     "image": "cPK_20_017020_01_SHOWERSex_SAR.webp",
-    "name": "Vaporeon ex",
+    "name": {
+      "en": "Vaporeon ex",
+      "fr": "Aquali-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1964,7 +2552,10 @@
     "number": 197,
     "rarity": "SAR",
     "image": "cPK_20_017190_01_JIBACOILex_SAR.webp",
-    "name": "Magnezone ex",
+    "name": {
+      "en": "Magnezone ex",
+      "fr": "Magnézone-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1974,7 +2565,10 @@
     "number": 198,
     "rarity": "SAR",
     "image": "cPK_20_017530_01_IWAPALACEex_SAR.webp",
-    "name": "Crustle ex",
+    "name": {
+      "en": "Crustle ex",
+      "fr": "Crabaraque-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1984,7 +2578,10 @@
     "number": 199,
     "rarity": "SAR",
     "image": "cPK_20_017710_01_ZOROARKex_SAR.webp",
-    "name": "Zoroark ex",
+    "name": {
+      "en": "Zoroark ex",
+      "fr": "Zoroark-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -1994,7 +2591,10 @@
     "number": 200,
     "rarity": "SAR",
     "image": "cPK_20_017890_01_ARMORGAex_SAR.webp",
-    "name": "Corviknight ex",
+    "name": {
+      "en": "Corviknight ex",
+      "fr": "Corvaillus-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2004,7 +2604,10 @@
     "number": 201,
     "rarity": "SAR",
     "image": "cPK_20_017910_01_FLYGONex_SAR.webp",
-    "name": "Flygon ex",
+    "name": {
+      "en": "Flygon ex",
+      "fr": "Libégon-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2014,7 +2617,10 @@
     "number": 202,
     "rarity": "SAR",
     "image": "cPK_20_018060_01_MEGATABUNNEex_SAR.webp",
-    "name": "Mega Audino ex",
+    "name": {
+      "en": "Mega Audino ex",
+      "fr": "Méga-Nanméouïe-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2024,7 +2630,10 @@
     "number": 203,
     "rarity": "IM",
     "image": "cPK_20_017130_00_MESSON_IM.webp",
-    "name": "Sobble",
+    "name": {
+      "en": "Sobble",
+      "fr": "Larméléon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2034,7 +2643,10 @@
     "number": 204,
     "rarity": "IM",
     "image": "cPK_20_017460_01_MEGALUCARIOex_IM.webp",
-    "name": "Mega Lucario ex",
+    "name": {
+      "en": "Mega Lucario ex",
+      "fr": "Méga-Lucario-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2044,7 +2656,10 @@
     "number": 205,
     "rarity": "S",
     "image": "cPK_20_010970_00_MONMEN_S.webp",
-    "name": "Cottonee",
+    "name": {
+      "en": "Cottonee",
+      "fr": "Doudouvet"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2054,7 +2669,10 @@
     "number": 206,
     "rarity": "S",
     "image": "cPK_20_011150_00_ACHAMO_S.webp",
-    "name": "Torchic",
+    "name": {
+      "en": "Torchic",
+      "fr": "Poussifeu"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2064,7 +2682,10 @@
     "number": 207,
     "rarity": "S",
     "image": "cPK_20_011160_00_WAKASYAMO_S.webp",
-    "name": "Combusken",
+    "name": {
+      "en": "Combusken",
+      "fr": "Galifeu"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2074,7 +2695,10 @@
     "number": 208,
     "rarity": "S",
     "image": "cPK_20_011170_00_BURSYAMO_S.webp",
-    "name": "Blaziken",
+    "name": {
+      "en": "Blaziken",
+      "fr": "Braségali"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2084,7 +2708,10 @@
     "number": 209,
     "rarity": "S",
     "image": "cPK_20_011500_00_PURURILL_S.webp",
-    "name": "Frillish",
+    "name": {
+      "en": "Frillish",
+      "fr": "Viskuse"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2094,7 +2721,10 @@
     "number": 210,
     "rarity": "S",
     "image": "cPK_20_011510_01_BURUNGEL_S.webp",
-    "name": "Jellicent",
+    "name": {
+      "en": "Jellicent",
+      "fr": "Moyade"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2104,7 +2734,10 @@
     "number": 211,
     "rarity": "S",
     "image": "cPK_20_013420_00_IWARK_S.webp",
-    "name": "Onix",
+    "name": {
+      "en": "Onix",
+      "fr": "Onix"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2114,7 +2747,10 @@
     "number": 212,
     "rarity": "S",
     "image": "cPK_20_017630_00_ZUBAT_S.webp",
-    "name": "Zubat",
+    "name": {
+      "en": "Zubat",
+      "fr": "Nosferapti"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2124,7 +2760,10 @@
     "number": 213,
     "rarity": "S",
     "image": "cPK_20_017640_00_GOLBAT_S.webp",
-    "name": "Golbat",
+    "name": {
+      "en": "Golbat",
+      "fr": "Nosferalto"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2134,7 +2773,10 @@
     "number": 214,
     "rarity": "S",
     "image": "cPK_20_017650_00_CROBAT_S.webp",
-    "name": "Crobat",
+    "name": {
+      "en": "Crobat",
+      "fr": "Nostenfer"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2144,7 +2786,10 @@
     "number": 215,
     "rarity": "S",
     "image": "cPK_20_013490_00_BETBETER_S.webp",
-    "name": "Grimer",
+    "name": {
+      "en": "Grimer",
+      "fr": "Tadmorv"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2154,7 +2799,10 @@
     "number": 216,
     "rarity": "S",
     "image": "cPK_20_013500_00_BETBETON_S.webp",
-    "name": "Muk",
+    "name": {
+      "en": "Muk",
+      "fr": "Grotadmorv"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2164,7 +2812,10 @@
     "number": 217,
     "rarity": "S",
     "image": "cPK_20_012320_00_ABSOL_S.webp",
-    "name": "Absol",
+    "name": {
+      "en": "Absol",
+      "fr": "Absol"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2174,7 +2825,10 @@
     "number": 218,
     "rarity": "S",
     "image": "cPK_20_012410_00_KUZUMO_S.webp",
-    "name": "Skrelp",
+    "name": {
+      "en": "Skrelp",
+      "fr": "Venalgue"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2184,7 +2838,10 @@
     "number": 219,
     "rarity": "S",
     "image": "cPK_20_013550_00_HAGANEIL_S.webp",
-    "name": "Steelix",
+    "name": {
+      "en": "Steelix",
+      "fr": "Steelix"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2194,7 +2851,10 @@
     "number": 220,
     "rarity": "S",
     "image": "cPK_20_017920_00_LUCKY_S.webp",
-    "name": "Chansey",
+    "name": {
+      "en": "Chansey",
+      "fr": "Leveinard"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2204,7 +2864,10 @@
     "number": 221,
     "rarity": "S",
     "image": "cPK_20_017930_00_HAPPINAS_S.webp",
-    "name": "Blissey",
+    "name": {
+      "en": "Blissey",
+      "fr": "Leuphorie"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2214,7 +2877,10 @@
     "number": 222,
     "rarity": "S",
     "image": "cPK_20_013580_00_PORYGON_S.webp",
-    "name": "Porygon",
+    "name": {
+      "en": "Porygon",
+      "fr": "Porygon"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2224,7 +2890,10 @@
     "number": 223,
     "rarity": "S",
     "image": "cPK_20_013590_00_PORYGON2_S.webp",
-    "name": "Porygon2",
+    "name": {
+      "en": "Porygon2",
+      "fr": "Porygon2"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2234,7 +2903,10 @@
     "number": 224,
     "rarity": "S",
     "image": "cPK_20_013600_00_PORYGON-Z_S.webp",
-    "name": "Porygon-Z",
+    "name": {
+      "en": "Porygon-Z",
+      "fr": "Porygon-Z"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2244,7 +2916,10 @@
     "number": 225,
     "rarity": "SSR",
     "image": "cPK_20_010980_02_ELFUUNex_SSR.webp",
-    "name": "Whimsicott ex",
+    "name": {
+      "en": "Whimsicott ex",
+      "fr": "Farfaduvet-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2254,7 +2929,10 @@
     "number": 226,
     "rarity": "SSR",
     "image": "cPK_20_011180_02_MEGABURSYAMOex_SSR.webp",
-    "name": "Mega Blaziken ex",
+    "name": {
+      "en": "Mega Blaziken ex",
+      "fr": "Méga-Braségali-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2264,7 +2942,10 @@
     "number": 227,
     "rarity": "SSR",
     "image": "cPK_20_011550_02_GEKKOUGAex_SSR.webp",
-    "name": "Greninja ex",
+    "name": {
+      "en": "Greninja ex",
+      "fr": "Amphinobi-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2274,7 +2955,10 @@
     "number": 228,
     "rarity": "SSR",
     "image": "cPK_20_011630_02_THUNDERSex_SSR.webp",
-    "name": "Jolteon ex",
+    "name": {
+      "en": "Jolteon ex",
+      "fr": "Voltali-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2284,7 +2968,10 @@
     "number": 229,
     "rarity": "SSR",
     "image": "cPK_20_012060_02_EBIWALARex_SSR.webp",
-    "name": "Hitmonchan ex",
+    "name": {
+      "en": "Hitmonchan ex",
+      "fr": "Tygnon-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2294,7 +2981,10 @@
     "number": 230,
     "rarity": "SSR",
     "image": "cPK_20_012330_02_MEGAABSOLex_SSR.webp",
-    "name": "Mega Absol ex",
+    "name": {
+      "en": "Mega Absol ex",
+      "fr": "Méga-Absol-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2304,7 +2994,10 @@
     "number": 231,
     "rarity": "SSR",
     "image": "cPK_20_012420_02_DRAMIDOROex_SSR.webp",
-    "name": "Dragalge ex",
+    "name": {
+      "en": "Dragalge ex",
+      "fr": "Kravarech-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2314,7 +3007,10 @@
     "number": 232,
     "rarity": "SSR",
     "image": "cPK_20_013560_02_MEGAHAGANEILex_SSR.webp",
-    "name": "Mega Steelix ex",
+    "name": {
+      "en": "Mega Steelix ex",
+      "fr": "Méga-Steelix-ex"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2324,7 +3020,10 @@
     "number": 233,
     "rarity": "UR",
     "image": "cPK_20_016690_00_CELEBI_UR.webp",
-    "name": "Celebi",
+    "name": {
+      "en": "Celebi",
+      "fr": "Celebi"
+    },
     "packs": [
       "Pulsing Aura"
     ]
@@ -2334,7 +3033,10 @@
     "number": 234,
     "rarity": "UR",
     "image": "cPK_20_017800_00_OTOSHIDORI_UR.webp",
-    "name": "Bombirdier",
+    "name": {
+      "en": "Bombirdier",
+      "fr": "Lestombaile"
+    },
     "packs": [
       "Pulsing Aura"
     ]

--- a/dist/cards/B3a.json
+++ b/dist/cards/B3a.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_018160_00_AMETAMA_C.webp",
-    "name": "Surskit",
+    "name": {
+      "en": "Surskit",
+      "fr": "Arakdo"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "C",
     "image": "cPK_10_018170_00_AMEMOTH_C.webp",
-    "name": "Masquerain",
+    "name": {
+      "en": "Masquerain",
+      "fr": "Maskadra"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "C",
     "image": "cPK_10_018180_00_ARABURUTAKE_C.webp",
-    "name": "Brute Bonnet",
+    "name": {
+      "en": "Brute Bonnet",
+      "fr": "Fongus-Furie"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "U",
     "image": "cPK_10_018190_00_CHIWOHAUHANE_U.webp",
-    "name": "Slither Wing",
+    "name": {
+      "en": "Slither Wing",
+      "fr": "Rampe-Ailes"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "U",
     "image": "cPK_10_018200_00_TETSUNODOKUGA_U.webp",
-    "name": "Iron Moth",
+    "name": {
+      "en": "Iron Moth",
+      "fr": "Mite-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "C",
     "image": "cPK_10_018210_00_KODUCK_C.webp",
-    "name": "Psyduck",
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "C",
     "image": "cPK_10_018220_00_GOLDUCK_C.webp",
-    "name": "Golduck",
+    "name": {
+      "en": "Golduck",
+      "fr": "Akwakwak"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "U",
     "image": "cPK_10_018230_00_SHOWERS_U.webp",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "C",
     "image": "cPK_10_018240_00_BUOYSEL_C.webp",
-    "name": "Buizel",
+    "name": {
+      "en": "Buizel",
+      "fr": "Mustébouée"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "C",
     "image": "cPK_10_018250_00_FLOAZEL_C.webp",
-    "name": "Floatzel",
+    "name": {
+      "en": "Floatzel",
+      "fr": "Mustéflott"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "C",
     "image": "cPK_10_018260_00_YUKIHAMI_C.webp",
-    "name": "Snom",
+    "name": {
+      "en": "Snom",
+      "fr": "Frissonille"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "C",
     "image": "cPK_10_018270_00_MOTHNOW_C.webp",
-    "name": "Frosmoth",
+    "name": {
+      "en": "Frosmoth",
+      "fr": "Beldeneige"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "RR",
     "image": "cPK_10_018280_00_TETSUNOTSUTSUMIex_RR.webp",
-    "name": "Iron Bundle ex",
+    "name": {
+      "en": "Iron Bundle ex",
+      "fr": "Hotte-de-Fer-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "C",
     "image": "cPK_10_018290_00_PAMO_C.webp",
-    "name": "Pawmi",
+    "name": {
+      "en": "Pawmi",
+      "fr": "Pohm"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "C",
     "image": "cPK_10_018300_00_PAMOT_C.webp",
-    "name": "Pawmo",
+    "name": {
+      "en": "Pawmo",
+      "fr": "Pohmotte"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "U",
     "image": "cPK_10_018310_00_PARMOT_U.webp",
-    "name": "Pawmot",
+    "name": {
+      "en": "Pawmot",
+      "fr": "Pohmarmotte"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "C",
     "image": "cPK_10_018320_00_TETSUNOKAINA_C.webp",
-    "name": "Iron Hands",
+    "name": {
+      "en": "Iron Hands",
+      "fr": "Paume-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "U",
     "image": "cPK_10_018330_00_TETSUNOIBARA_U.webp",
-    "name": "Iron Thorns",
+    "name": {
+      "en": "Iron Thorns",
+      "fr": "Épine-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "RR",
     "image": "cPK_10_018340_00_MIRAIDONex_RR.webp",
-    "name": "Miraidon ex",
+    "name": {
+      "en": "Miraidon ex",
+      "fr": "Miraidon-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "U",
     "image": "cPK_10_018350_00_EIFIE_U.webp",
-    "name": "Espeon",
+    "name": {
+      "en": "Espeon",
+      "fr": "Mentali"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "C",
     "image": "cPK_10_018360_00_HIRAHINA_C.webp",
-    "name": "Flittle",
+    "name": {
+      "en": "Flittle",
+      "fr": "Flotillon"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "U",
     "image": "cPK_10_018370_00_CUESPATRA_U.webp",
-    "name": "Espathra",
+    "name": {
+      "en": "Espathra",
+      "fr": "Cléopsytra"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "C",
     "image": "cPK_10_018380_00_BOCHI_C.webp",
-    "name": "Greavard",
+    "name": {
+      "en": "Greavard",
+      "fr": "Toutombe"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "U",
     "image": "cPK_10_018390_00_HAKADOG_U.webp",
-    "name": "Houndstone",
+    "name": {
+      "en": "Houndstone",
+      "fr": "Tomberro"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "C",
     "image": "cPK_10_018400_00_SAKEBUSHIPPO_C.webp",
-    "name": "Scream Tail",
+    "name": {
+      "en": "Scream Tail",
+      "fr": "Hurle-Queue"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "RR",
     "image": "cPK_10_018410_00_HABATAKUKAMIex_RR.webp",
-    "name": "Flutter Mane ex",
+    "name": {
+      "en": "Flutter Mane ex",
+      "fr": "Flotte-Mèche-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "R",
     "image": "cPK_10_018420_00_TETSUNOBUJIN_R.webp",
-    "name": "Iron Valiant",
+    "name": {
+      "en": "Iron Valiant",
+      "fr": "Garde-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "R",
     "image": "cPK_10_018430_00_TETSUNOISAHA_R.webp",
-    "name": "Iron Leaves",
+    "name": {
+      "en": "Iron Leaves",
+      "fr": "Vert-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "R",
     "image": "cPK_10_018440_00_TETSUNOIWAO_R.webp",
-    "name": "Iron Boulder",
+    "name": {
+      "en": "Iron Boulder",
+      "fr": "Roc-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "R",
     "image": "cPK_10_018450_00_TETSUNOKASHIRA_R.webp",
-    "name": "Iron Crown",
+    "name": {
+      "en": "Iron Crown",
+      "fr": "Chef-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "C",
     "image": "cPK_10_018460_00_KOJIO_C.webp",
-    "name": "Nacli",
+    "name": {
+      "en": "Nacli",
+      "fr": "Selutin"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "C",
     "image": "cPK_10_018470_00_JIODUMU_C.webp",
-    "name": "Naclstack",
+    "name": {
+      "en": "Naclstack",
+      "fr": "Amassel"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "R",
     "image": "cPK_10_018480_00_KYOJIOHN_R.webp",
-    "name": "Garganacl",
+    "name": {
+      "en": "Garganacl",
+      "fr": "Gigansel"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "U",
     "image": "cPK_10_018490_00_IDAINAKIBA_U.webp",
-    "name": "Great Tusk",
+    "name": {
+      "en": "Great Tusk",
+      "fr": "Fort-Ivoire"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "U",
     "image": "cPK_10_018500_00_SUNANOKEGAWA_U.webp",
-    "name": "Sandy Shocks",
+    "name": {
+      "en": "Sandy Shocks",
+      "fr": "Pelage-Sablé"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "RR",
     "image": "cPK_10_018510_00_KORAIDONex_RR.webp",
-    "name": "Koraidon ex",
+    "name": {
+      "en": "Koraidon ex",
+      "fr": "Koraidon-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "U",
     "image": "cPK_10_018520_00_BRACKY_U.webp",
-    "name": "Umbreon",
+    "name": {
+      "en": "Umbreon",
+      "fr": "Noctali"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "C",
     "image": "cPK_10_018530_00_NYULA_C.webp",
-    "name": "Sneasel",
+    "name": {
+      "en": "Sneasel",
+      "fr": "Farfuret"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "U",
     "image": "cPK_10_018540_00_MANYULA_U.webp",
-    "name": "Weavile",
+    "name": {
+      "en": "Weavile",
+      "fr": "Dimoret"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "U",
     "image": "cPK_10_018550_00_YAMIRAMI_U.webp",
-    "name": "Sableye",
+    "name": {
+      "en": "Sableye",
+      "fr": "Ténéfix"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "C",
     "image": "cPK_10_018560_00_KOMATANA_C.webp",
-    "name": "Pawniard",
+    "name": {
+      "en": "Pawniard",
+      "fr": "Scalpion"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "C",
     "image": "cPK_10_018570_00_KIRIKIZAN_C.webp",
-    "name": "Bisharp",
+    "name": {
+      "en": "Bisharp",
+      "fr": "Scalproie"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "R",
     "image": "cPK_10_018580_00_DODOGEZAN_R.webp",
-    "name": "Kingambit",
+    "name": {
+      "en": "Kingambit",
+      "fr": "Scalpereur"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "C",
     "image": "cPK_10_018590_00_KIRAME_C.webp",
-    "name": "Glimmet",
+    "name": {
+      "en": "Glimmet",
+      "fr": "Germéclat"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "R",
     "image": "cPK_10_018600_00_KIRAFLOR_R.webp",
-    "name": "Glimmora",
+    "name": {
+      "en": "Glimmora",
+      "fr": "Floréclat"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "U",
     "image": "cPK_10_018610_00_TETSUNOKOUBE_U.webp",
-    "name": "Iron Jugulis",
+    "name": {
+      "en": "Iron Jugulis",
+      "fr": "Têtes-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "R",
     "image": "cPK_10_018620_00_TODOROKUTSUKI_R.webp",
-    "name": "Roaring Moon",
+    "name": {
+      "en": "Roaring Moon",
+      "fr": "Rugit-Lune"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "U",
     "image": "cPK_10_018630_00_ARMORGA_U.webp",
-    "name": "Corviknight",
+    "name": {
+      "en": "Corviknight",
+      "fr": "Corvaillus"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "C",
     "image": "cPK_10_018640_00_ZOUDOU_C.webp",
-    "name": "Cufant",
+    "name": {
+      "en": "Cufant",
+      "fr": "Charibari"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "U",
     "image": "cPK_10_018650_00_DAIOUDOU_U.webp",
-    "name": "Copperajah",
+    "name": {
+      "en": "Copperajah",
+      "fr": "Pachyradjah"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "U",
     "image": "cPK_10_018660_00_TETSUNOWADACHI_U.webp",
-    "name": "Iron Treads",
+    "name": {
+      "en": "Iron Treads",
+      "fr": "Roue-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "U",
     "image": "cPK_10_018670_00_TYLTALIS_U.webp",
-    "name": "Altaria",
+    "name": {
+      "en": "Altaria",
+      "fr": "Altaria"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "R",
     "image": "cPK_10_018680_00_UNERUMINAMO_R.webp",
-    "name": "Walking Wake",
+    "name": {
+      "en": "Walking Wake",
+      "fr": "Serpente-Eau"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "R",
     "image": "cPK_10_018690_00_UGATSUHOMURA_R.webp",
-    "name": "Gouging Fire",
+    "name": {
+      "en": "Gouging Fire",
+      "fr": "Feu-Perçant"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "R",
     "image": "cPK_10_018700_00_TAKERURAIKO_R.webp",
-    "name": "Raging Bolt",
+    "name": {
+      "en": "Raging Bolt",
+      "fr": "Ire-Foudre"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "C",
     "image": "cPK_10_018710_00_EIEVUI_C.webp",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "C",
     "image": "cPK_10_018720_00_KIRINRIKI_C.webp",
-    "name": "Girafarig",
+    "name": {
+      "en": "Girafarig",
+      "fr": "Girafarig"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "C",
     "image": "cPK_10_018730_00_RIKIKIRIN_C.webp",
-    "name": "Farigiraf",
+    "name": {
+      "en": "Farigiraf",
+      "fr": "Farigiraf"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "U",
     "image": "cPK_10_018740_00_NOKOCCHI_U.webp",
-    "name": "Dunsparce",
+    "name": {
+      "en": "Dunsparce",
+      "fr": "Insolourdo"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "R",
     "image": "cPK_10_018750_00_NOKOKOCCHI_R.webp",
-    "name": "Dudunsparce",
+    "name": {
+      "en": "Dudunsparce",
+      "fr": "Deusolourdo"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "C",
     "image": "cPK_10_018760_00_TYLTTO_C.webp",
-    "name": "Swablu",
+    "name": {
+      "en": "Swablu",
+      "fr": "Tylton"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "C",
     "image": "cPK_10_018770_00_WASHIBON_C.webp",
-    "name": "Rufflet",
+    "name": {
+      "en": "Rufflet",
+      "fr": "Furaiglon"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "C",
     "image": "cPK_10_018780_00_WARRGLE_C.webp",
-    "name": "Braviary",
+    "name": {
+      "en": "Braviary",
+      "fr": "Gueriaigle"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "C",
     "image": "cPK_10_018790_00_LUCHABULL_C.webp",
-    "name": "Hawlucha",
+    "name": {
+      "en": "Hawlucha",
+      "fr": "Brutalibré"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "C",
     "image": "cPK_10_018800_00_KOKOGARA_C.webp",
-    "name": "Rookidee",
+    "name": {
+      "en": "Rookidee",
+      "fr": "Minisange"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "C",
     "image": "cPK_10_018810_00_AOGARASU_C.webp",
-    "name": "Corvisquire",
+    "name": {
+      "en": "Corvisquire",
+      "fr": "Bleuseille"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "C",
     "image": "cPK_10_018820_00_KARAMINGO_C.webp",
-    "name": "Flamigo",
+    "name": {
+      "en": "Flamigo",
+      "fr": "Flamenroule"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "RR",
     "image": "cPK_10_018830_00_TERAPAGOSex_RR.webp",
-    "name": "Terapagos ex",
+    "name": {
+      "en": "Terapagos ex",
+      "fr": "Terapagos-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "U",
     "image": "cTR_10_001370_00_BUSUTOENAJIKODAI_U.webp",
-    "name": "Ancient Booster Energy Capsule",
+    "name": {
+      "en": "Ancient Booster Energy Capsule",
+      "fr": "Capsule Énergie Booster Temps Passé"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "U",
     "image": "cTR_10_001380_00_BUSUTOENAJIMIRAI_U.webp",
-    "name": "Future Booster Energy Capsule",
+    "name": {
+      "en": "Future Booster Energy Capsule",
+      "fr": "Capsule Énergie Booster Temps Futur"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "U",
     "image": "cTR_10_001390_00_AOI_U.webp",
-    "name": "Juliana",
+    "name": {
+      "en": "Juliana",
+      "fr": "Juliana"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "U",
     "image": "cTR_10_001400_00_OLIMHAKASE_U.webp",
-    "name": "Professor Sada",
+    "name": {
+      "en": "Professor Sada",
+      "fr": "Professeure Olim"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "U",
     "image": "cTR_10_001410_00_FUTUHAKASE_U.webp",
-    "name": "Professor Turo",
+    "name": {
+      "en": "Professor Turo",
+      "fr": "Professeur Turum"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "U",
     "image": "cTR_10_001420_00_ERIAZERO_U.webp",
-    "name": "Area Zero",
+    "name": {
+      "en": "Area Zero",
+      "fr": "Zone Zéro"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "AR",
     "image": "cPK_20_018260_00_YUKIHAMI_AR.webp",
-    "name": "Snom",
+    "name": {
+      "en": "Snom",
+      "fr": "Frissonille"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "AR",
     "image": "cPK_20_018360_00_HIRAHINA_AR.webp",
-    "name": "Flittle",
+    "name": {
+      "en": "Flittle",
+      "fr": "Flotillon"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "AR",
     "image": "cPK_20_018440_00_TETSUNOIWAO_AR.webp",
-    "name": "Iron Boulder",
+    "name": {
+      "en": "Iron Boulder",
+      "fr": "Roc-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "AR",
     "image": "cPK_20_018600_00_KIRAFLOR_AR.webp",
-    "name": "Glimmora",
+    "name": {
+      "en": "Glimmora",
+      "fr": "Floréclat"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "AR",
     "image": "cPK_20_018700_00_TAKERURAIKO_AR.webp",
-    "name": "Raging Bolt",
+    "name": {
+      "en": "Raging Bolt",
+      "fr": "Ire-Foudre"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "AR",
     "image": "cPK_20_018790_00_LUCHABULL_AR.webp",
-    "name": "Hawlucha",
+    "name": {
+      "en": "Hawlucha",
+      "fr": "Brutalibré"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "SR",
     "image": "cPK_20_018280_00_TETSUNOTSUTSUMIex_SR.webp",
-    "name": "Iron Bundle ex",
+    "name": {
+      "en": "Iron Bundle ex",
+      "fr": "Hotte-de-Fer-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "SR",
     "image": "cPK_20_018340_00_MIRAIDONex_SR.webp",
-    "name": "Miraidon ex",
+    "name": {
+      "en": "Miraidon ex",
+      "fr": "Miraidon-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "SR",
     "image": "cPK_20_018410_00_HABATAKUKAMIex_SR.webp",
-    "name": "Flutter Mane ex",
+    "name": {
+      "en": "Flutter Mane ex",
+      "fr": "Flotte-Mèche-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "SR",
     "image": "cPK_20_018510_00_KORAIDONex_SR.webp",
-    "name": "Koraidon ex",
+    "name": {
+      "en": "Koraidon ex",
+      "fr": "Koraidon-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "SR",
     "image": "cPK_20_018830_00_TERAPAGOSex_SR.webp",
-    "name": "Terapagos ex",
+    "name": {
+      "en": "Terapagos ex",
+      "fr": "Terapagos-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "SR",
     "image": "cTR_20_001390_00_AOI_SR.webp",
-    "name": "Juliana",
+    "name": {
+      "en": "Juliana",
+      "fr": "Juliana"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "SR",
     "image": "cTR_20_001400_00_OLIMHAKASE_SR.webp",
-    "name": "Professor Sada",
+    "name": {
+      "en": "Professor Sada",
+      "fr": "Professeure Olim"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "SR",
     "image": "cTR_20_001410_00_FUTUHAKASE_SR.webp",
-    "name": "Professor Turo",
+    "name": {
+      "en": "Professor Turo",
+      "fr": "Professeur Turum"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "SAR",
     "image": "cPK_20_018280_01_TETSUNOTSUTSUMIex_SAR.webp",
-    "name": "Iron Bundle ex",
+    "name": {
+      "en": "Iron Bundle ex",
+      "fr": "Hotte-de-Fer-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "SAR",
     "image": "cPK_20_018340_01_MIRAIDONex_SAR.webp",
-    "name": "Miraidon ex",
+    "name": {
+      "en": "Miraidon ex",
+      "fr": "Miraidon-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "SAR",
     "image": "cPK_20_018410_01_HABATAKUKAMIex_SAR.webp",
-    "name": "Flutter Mane ex",
+    "name": {
+      "en": "Flutter Mane ex",
+      "fr": "Flotte-Mèche-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "SAR",
     "image": "cPK_20_018510_01_KORAIDONex_SAR.webp",
-    "name": "Koraidon ex",
+    "name": {
+      "en": "Koraidon ex",
+      "fr": "Koraidon-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "IM",
     "image": "cPK_20_018830_01_TERAPAGOSex_IM.webp",
-    "name": "Terapagos ex",
+    "name": {
+      "en": "Terapagos ex",
+      "fr": "Terapagos-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "S",
     "image": "cPK_20_015230_00_SHIGAROKO_S.webp",
-    "name": "Rellor",
+    "name": {
+      "en": "Rellor",
+      "fr": "Léboulérou"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "S",
     "image": "cPK_20_015280_00_CARBOU_S.webp",
-    "name": "Charcadet",
+    "name": {
+      "en": "Charcadet",
+      "fr": "Charbambin"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "S",
     "image": "cPK_20_014220_00_ZUPIKA_S.webp",
-    "name": "Tadbulb",
+    "name": {
+      "en": "Tadbulb",
+      "fr": "Têtampoule"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "S",
     "image": "cPK_20_015580_00_BERACAS_S.webp",
-    "name": "Rabsca",
+    "name": {
+      "en": "Rabsca",
+      "fr": "Bérasca"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "S",
     "image": "cPK_20_016380_00_DIGDA_S.webp",
-    "name": "Diglett",
+    "name": {
+      "en": "Diglett",
+      "fr": "Taupiqueur"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "S",
     "image": "cPK_20_016390_00_DUGTRIO_S.webp",
-    "name": "Dugtrio",
+    "name": {
+      "en": "Dugtrio",
+      "fr": "Triopikeur"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "S",
     "image": "cPK_20_015700_00_GAKEGANI_S.webp",
-    "name": "Klawf",
+    "name": {
+      "en": "Klawf",
+      "fr": "Craparoi"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "S",
     "image": "cPK_20_015860_01_MIMIZUZU_S.webp",
-    "name": "Orthworm",
+    "name": {
+      "en": "Orthworm",
+      "fr": "Ferdeter"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "S",
     "image": "cPK_20_012780_00_TYLTTO_S.webp",
-    "name": "Swablu",
+    "name": {
+      "en": "Swablu",
+      "fr": "Tylton"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "S",
     "image": "cPK_20_012790_00_TYLTALIS_S.webp",
-    "name": "Altaria",
+    "name": {
+      "en": "Altaria",
+      "fr": "Altaria"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1034,7 +1343,10 @@
     "number": 104,
     "rarity": "SSR",
     "image": "cPK_20_015120_02_MASQUERNYAex_SSR.webp",
-    "name": "Meowscarada ex",
+    "name": {
+      "en": "Meowscarada ex",
+      "fr": "Miascarade-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1044,7 +1356,10 @@
     "number": 105,
     "rarity": "SSR",
     "image": "cPK_20_015290_02_GURENARMAex_SSR.webp",
-    "name": "Armarouge ex",
+    "name": {
+      "en": "Armarouge ex",
+      "fr": "Carmadura-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1054,7 +1369,10 @@
     "number": 106,
     "rarity": "SSR",
     "image": "cPK_20_015510_02_HARABARIEex_SSR.webp",
-    "name": "Bellibolt ex",
+    "name": {
+      "en": "Bellibolt ex",
+      "fr": "Ampibidou-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1064,7 +1382,10 @@
     "number": 107,
     "rarity": "SSR",
     "image": "cPK_20_011840_02_MEGATYLTALISex_SSR.webp",
-    "name": "Mega Altaria ex",
+    "name": {
+      "en": "Mega Altaria ex",
+      "fr": "Méga-Altaria-ex"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1074,7 +1395,10 @@
     "number": 108,
     "rarity": "UR",
     "image": "cPK_20_018420_00_TETSUNOBUJIN_UR.webp",
-    "name": "Iron Valiant",
+    "name": {
+      "en": "Iron Valiant",
+      "fr": "Garde-de-Fer"
+    },
     "packs": [
       "Paradox Drive"
     ]
@@ -1084,7 +1408,10 @@
     "number": 109,
     "rarity": "UR",
     "image": "cPK_20_018620_00_TODOROKUTSUKI_UR.webp",
-    "name": "Roaring Moon",
+    "name": {
+      "en": "Roaring Moon",
+      "fr": "Rugit-Lune"
+    },
     "packs": [
       "Paradox Drive"
     ]

--- a/dist/cards/B3b.json
+++ b/dist/cards/B3b.json
@@ -4,7 +4,10 @@
     "number": 1,
     "rarity": "C",
     "image": "cPK_10_019040_00_CATERPIE_C.webp",
-    "name": "Caterpie",
+    "name": {
+      "en": "Caterpie",
+      "fr": "Chenipan"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -14,7 +17,10 @@
     "number": 2,
     "rarity": "U",
     "image": "cPK_10_019050_00_TRANSEL_U.webp",
-    "name": "Metapod",
+    "name": {
+      "en": "Metapod",
+      "fr": "Chrysacier"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -24,7 +30,10 @@
     "number": 3,
     "rarity": "R",
     "image": "cPK_10_019060_00_BUTTERFREE_R.webp",
-    "name": "Butterfree",
+    "name": {
+      "en": "Butterfree",
+      "fr": "Papilusion"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -34,7 +43,10 @@
     "number": 4,
     "rarity": "C",
     "image": "cPK_10_019070_00_SABONEA_C.webp",
-    "name": "Cacnea",
+    "name": {
+      "en": "Cacnea",
+      "fr": "Cacnea"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -44,7 +56,10 @@
     "number": 5,
     "rarity": "U",
     "image": "cPK_10_019080_00_TROPIUS_U.webp",
-    "name": "Tropius",
+    "name": {
+      "en": "Tropius",
+      "fr": "Tropius"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -54,7 +69,10 @@
     "number": 6,
     "rarity": "C",
     "image": "cPK_10_019090_00_CHURINE_C.webp",
-    "name": "Petilil",
+    "name": {
+      "en": "Petilil",
+      "fr": "Chlorobule"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -64,7 +82,10 @@
     "number": 7,
     "rarity": "U",
     "image": "cPK_10_019100_00_HISUIDREDEAR_U.webp",
-    "name": "Hisuian Lilligant",
+    "name": {
+      "en": "Hisuian Lilligant",
+      "fr": "Fragilady de Hisui"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -74,7 +95,10 @@
     "number": 8,
     "rarity": "C",
     "image": "cPK_10_019110_00_ROKON_C.webp",
-    "name": "Vulpix",
+    "name": {
+      "en": "Vulpix",
+      "fr": "Goupix"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -84,7 +108,10 @@
     "number": 9,
     "rarity": "U",
     "image": "cPK_10_019120_00_KYUKON_U.webp",
-    "name": "Ninetales",
+    "name": {
+      "en": "Ninetales",
+      "fr": "Feunard"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -94,7 +121,10 @@
     "number": 10,
     "rarity": "C",
     "image": "cPK_10_019010_00_GARDIE_C.webp",
-    "name": "Growlithe",
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -104,7 +134,10 @@
     "number": 11,
     "rarity": "C",
     "image": "cPK_10_019030_00_KODUCK_C.webp",
-    "name": "Psyduck",
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -114,7 +147,10 @@
     "number": 12,
     "rarity": "C",
     "image": "cPK_10_019130_00_TOSAKINTO_C.webp",
-    "name": "Goldeen",
+    "name": {
+      "en": "Goldeen",
+      "fr": "Poissirène"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -124,7 +160,10 @@
     "number": 13,
     "rarity": "U",
     "image": "cPK_10_019140_00_AZUMAO_U.webp",
-    "name": "Seaking",
+    "name": {
+      "en": "Seaking",
+      "fr": "Poissoroy"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -134,7 +173,10 @@
     "number": 14,
     "rarity": "C",
     "image": "cPK_10_019150_00_HINBASS_C.webp",
-    "name": "Feebas",
+    "name": {
+      "en": "Feebas",
+      "fr": "Barpau"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -144,7 +186,10 @@
     "number": 15,
     "rarity": "RR",
     "image": "cPK_10_019160_00_MILOKAROSSex_RR.webp",
-    "name": "Milotic ex",
+    "name": {
+      "en": "Milotic ex",
+      "fr": "Milobellus-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -154,7 +199,10 @@
     "number": 16,
     "rarity": "C",
     "image": "cPK_10_019170_00_YUKIWARASHI_C.webp",
-    "name": "Snorunt",
+    "name": {
+      "en": "Snorunt",
+      "fr": "Stalgamin"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -164,7 +212,10 @@
     "number": 17,
     "rarity": "R",
     "image": "cPK_10_018970_00_YUKIMENOKO_R.webp",
-    "name": "Froslass",
+    "name": {
+      "en": "Froslass",
+      "fr": "Momartik"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -174,7 +225,10 @@
     "number": 18,
     "rarity": "C",
     "image": "cPK_10_019180_00_LOVECUS_C.webp",
-    "name": "Luvdisc",
+    "name": {
+      "en": "Luvdisc",
+      "fr": "Lovdisc"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -184,7 +238,10 @@
     "number": 19,
     "rarity": "C",
     "image": "cPK_10_019190_00_POCHAMA_C.webp",
-    "name": "Piplup",
+    "name": {
+      "en": "Piplup",
+      "fr": "Tiplouf"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -194,7 +251,10 @@
     "number": 20,
     "rarity": "U",
     "image": "cPK_10_019200_00_TETSUNOTSUTSUMI_U.webp",
-    "name": "Iron Bundle",
+    "name": {
+      "en": "Iron Bundle",
+      "fr": "Hotte-de-Fer"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -204,7 +264,10 @@
     "number": 21,
     "rarity": "C",
     "image": "cPK_10_019210_00_PIKACHU_C.webp",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -214,7 +277,10 @@
     "number": 22,
     "rarity": "U",
     "image": "cPK_10_018980_00_RAICHU_U.webp",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -224,7 +290,10 @@
     "number": 23,
     "rarity": "C",
     "image": "cPK_10_019020_00_EMOLGA_C.webp",
-    "name": "Emolga",
+    "name": {
+      "en": "Emolga",
+      "fr": "Emolga"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -234,7 +303,10 @@
     "number": 24,
     "rarity": "RR",
     "image": "cPK_10_019220_00_DEDENNEex_RR.webp",
-    "name": "Dedenne ex",
+    "name": {
+      "en": "Dedenne ex",
+      "fr": "Dedenne-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -244,7 +316,10 @@
     "number": 25,
     "rarity": "C",
     "image": "cPK_10_019230_00_WANPACHI_C.webp",
-    "name": "Yamper",
+    "name": {
+      "en": "Yamper",
+      "fr": "Voltoutou"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -254,7 +329,10 @@
     "number": 26,
     "rarity": "C",
     "image": "cPK_10_019240_00_YADON_C.webp",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -264,7 +342,10 @@
     "number": 27,
     "rarity": "U",
     "image": "cPK_10_019250_00_YADORAN_U.webp",
-    "name": "Slowbro",
+    "name": {
+      "en": "Slowbro",
+      "fr": "Flagadoss"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -274,7 +355,10 @@
     "number": 28,
     "rarity": "C",
     "image": "cPK_10_019260_00_MUNNA_C.webp",
-    "name": "Munna",
+    "name": {
+      "en": "Munna",
+      "fr": "Munna"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -284,7 +368,10 @@
     "number": 29,
     "rarity": "U",
     "image": "cPK_10_019270_00_MUSHARNA_U.webp",
-    "name": "Musharna",
+    "name": {
+      "en": "Musharna",
+      "fr": "Mushana"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -294,7 +381,10 @@
     "number": 30,
     "rarity": "R",
     "image": "cPK_10_019280_00_NYMPHIA_R.webp",
-    "name": "Sylveon",
+    "name": {
+      "en": "Sylveon",
+      "fr": "Nymphali"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -304,7 +394,10 @@
     "number": 31,
     "rarity": "U",
     "image": "cPK_10_019290_00_MELECIE_U.webp",
-    "name": "Carbink",
+    "name": {
+      "en": "Carbink",
+      "fr": "Strassie"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -314,7 +407,10 @@
     "number": 32,
     "rarity": "RR",
     "image": "cPK_10_019300_00_MEGADIANCIEex_RR.webp",
-    "name": "Mega Diancie ex",
+    "name": {
+      "en": "Mega Diancie ex",
+      "fr": "Méga-Diancie-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -324,7 +420,10 @@
     "number": 33,
     "rarity": "R",
     "image": "cPK_10_019310_00_LOVETOLOS_R.webp",
-    "name": "Enamorus",
+    "name": {
+      "en": "Enamorus",
+      "fr": "Amovénus"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -334,7 +433,10 @@
     "number": 34,
     "rarity": "C",
     "image": "cPK_10_019320_00_PUPIMOCCHI_C.webp",
-    "name": "Fidough",
+    "name": {
+      "en": "Fidough",
+      "fr": "Pâtachiot"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -344,7 +446,10 @@
     "number": 35,
     "rarity": "U",
     "image": "cPK_10_019330_00_HABATAKUKAMI_U.webp",
-    "name": "Flutter Mane",
+    "name": {
+      "en": "Flutter Mane",
+      "fr": "Flotte-Mèche"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -354,7 +459,10 @@
     "number": 36,
     "rarity": "C",
     "image": "cPK_10_019340_00_UPAH_C.webp",
-    "name": "Wooper",
+    "name": {
+      "en": "Wooper",
+      "fr": "Axoloto"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -364,7 +472,10 @@
     "number": 37,
     "rarity": "U",
     "image": "cPK_10_019350_00_NUOH_U.webp",
-    "name": "Quagsire",
+    "name": {
+      "en": "Quagsire",
+      "fr": "Maraiste"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -374,7 +485,10 @@
     "number": 38,
     "rarity": "C",
     "image": "cPK_10_019360_00_IWANKO_C.webp",
-    "name": "Rockruff",
+    "name": {
+      "en": "Rockruff",
+      "fr": "Rocabot"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -384,7 +498,10 @@
     "number": 39,
     "rarity": "C",
     "image": "cPK_10_019370_00_SUNABA_C.webp",
-    "name": "Sandygast",
+    "name": {
+      "en": "Sandygast",
+      "fr": "Bacabouh"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -394,7 +511,10 @@
     "number": 40,
     "rarity": "U",
     "image": "cPK_10_019380_00_SIRODETHNA_U.webp",
-    "name": "Palossand",
+    "name": {
+      "en": "Palossand",
+      "fr": "Trépassable"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -404,7 +524,10 @@
     "number": 41,
     "rarity": "RR",
     "image": "cPK_10_019390_00_MEGAYAMIRAMIex_RR.webp",
-    "name": "Mega Sableye ex",
+    "name": {
+      "en": "Mega Sableye ex",
+      "fr": "Méga-Ténéfix-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -414,7 +537,10 @@
     "number": 42,
     "rarity": "U",
     "image": "cPK_10_019400_00_NOCTUS_U.webp",
-    "name": "Cacturne",
+    "name": {
+      "en": "Cacturne",
+      "fr": "Cacturne"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -424,7 +550,10 @@
     "number": 43,
     "rarity": "U",
     "image": "cPK_10_019410_00_MIKARUGE_U.webp",
-    "name": "Spiritomb",
+    "name": {
+      "en": "Spiritomb",
+      "fr": "Spiritomb"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -434,7 +563,10 @@
     "number": 44,
     "rarity": "C",
     "image": "cPK_10_019420_00_ZURUGGU_C.webp",
-    "name": "Scraggy",
+    "name": {
+      "en": "Scraggy",
+      "fr": "Baggiguane"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -444,7 +576,10 @@
     "number": 45,
     "rarity": "U",
     "image": "cPK_10_019430_00_ZURUZUKIN_U.webp",
-    "name": "Scrafty",
+    "name": {
+      "en": "Scrafty",
+      "fr": "Baggaïd"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -454,7 +589,10 @@
     "number": 46,
     "rarity": "C",
     "image": "cPK_10_019440_00_HIDOIDE_C.webp",
-    "name": "Mareanie",
+    "name": {
+      "en": "Mareanie",
+      "fr": "Vorastérie"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -464,7 +602,10 @@
     "number": 47,
     "rarity": "U",
     "image": "cPK_10_019450_00_DOHIDOIDE_U.webp",
-    "name": "Toxapex",
+    "name": {
+      "en": "Toxapex",
+      "fr": "Prédastérie"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -474,7 +615,10 @@
     "number": 48,
     "rarity": "C",
     "image": "cPK_10_019460_00_NUMERA_C.webp",
-    "name": "Goomy",
+    "name": {
+      "en": "Goomy",
+      "fr": "Mucuscule"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -484,7 +628,10 @@
     "number": 49,
     "rarity": "U",
     "image": "cPK_10_019470_00_HISUINUMEIL_U.webp",
-    "name": "Hisuian Sliggoo",
+    "name": {
+      "en": "Hisuian Sliggoo",
+      "fr": "Colimucus de Hisui"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -494,7 +641,10 @@
     "number": 50,
     "rarity": "R",
     "image": "cPK_10_019480_00_HISUINUMELGON_R.webp",
-    "name": "Hisuian Goodra",
+    "name": {
+      "en": "Hisuian Goodra",
+      "fr": "Muplodocus de Hisui"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -504,7 +654,10 @@
     "number": 51,
     "rarity": "C",
     "image": "cPK_10_019490_00_PURIN_C.webp",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -514,7 +667,10 @@
     "number": 52,
     "rarity": "U",
     "image": "cPK_10_019500_00_PUKURIN_U.webp",
-    "name": "Wigglytuff",
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -524,7 +680,10 @@
     "number": 53,
     "rarity": "C",
     "image": "cPK_10_019510_00_EIEVUI_C.webp",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -534,7 +693,10 @@
     "number": 54,
     "rarity": "R",
     "image": "cPK_10_019520_00_GONBE_R.webp",
-    "name": "Munchlax",
+    "name": {
+      "en": "Munchlax",
+      "fr": "Goinfrex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -544,7 +706,10 @@
     "number": 55,
     "rarity": "R",
     "image": "cPK_10_019530_00_KABIGON_R.webp",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -554,7 +719,10 @@
     "number": 56,
     "rarity": "C",
     "image": "cPK_10_019540_00_HIMEGUMA_C.webp",
-    "name": "Teddiursa",
+    "name": {
+      "en": "Teddiursa",
+      "fr": "Teddiursa"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -564,7 +732,10 @@
     "number": 57,
     "rarity": "U",
     "image": "cPK_10_019550_00_RINGUMA_U.webp",
-    "name": "Ursaring",
+    "name": {
+      "en": "Ursaring",
+      "fr": "Ursaring"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -574,7 +745,10 @@
     "number": 58,
     "rarity": "R",
     "image": "cPK_10_019560_00_GACHIGUMA_R.webp",
-    "name": "Ursaluna",
+    "name": {
+      "en": "Ursaluna",
+      "fr": "Ursaking"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -584,7 +758,10 @@
     "number": 59,
     "rarity": "C",
     "image": "cPK_10_019000_00_HISUIZORUA_C.webp",
-    "name": "Hisuian Zorua",
+    "name": {
+      "en": "Hisuian Zorua",
+      "fr": "Zorua de Hisui"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -594,7 +771,10 @@
     "number": 60,
     "rarity": "RR",
     "image": "cPK_10_019570_00_HISUIZOROARKex_RR.webp",
-    "name": "Hisuian Zoroark ex",
+    "name": {
+      "en": "Hisuian Zoroark ex",
+      "fr": "Zoroark de Hisui-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -604,7 +784,10 @@
     "number": 61,
     "rarity": "C",
     "image": "cPK_10_019580_00_TRIMMIEN_C.webp",
-    "name": "Furfrou",
+    "name": {
+      "en": "Furfrou",
+      "fr": "Couafarel"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -614,7 +797,10 @@
     "number": 62,
     "rarity": "C",
     "image": "cPK_10_019590_00_HOSHIGARISU_C.webp",
-    "name": "Skwovet",
+    "name": {
+      "en": "Skwovet",
+      "fr": "Rongourmand"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -624,7 +810,10 @@
     "number": 63,
     "rarity": "U",
     "image": "cPK_10_019600_00_YOKUBARISU_U.webp",
-    "name": "Greedent",
+    "name": {
+      "en": "Greedent",
+      "fr": "Rongrigou"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -634,7 +823,10 @@
     "number": 64,
     "rarity": "U",
     "image": "cTR_10_001430_00_CHIISANAFUUSEN_U.webp",
-    "name": "Small Balloon",
+    "name": {
+      "en": "Small Balloon",
+      "fr": "Petit Ballon"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -644,7 +836,10 @@
     "number": 65,
     "rarity": "U",
     "image": "cTR_10_001440_00_YUUGANAMANTO_U.webp",
-    "name": "Elegant Cape",
+    "name": {
+      "en": "Elegant Cape",
+      "fr": "Cape Élégante"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -654,7 +849,10 @@
     "number": 66,
     "rarity": "U",
     "image": "cTR_10_001450_00_KAMITSURE_U.webp",
-    "name": "Elesa",
+    "name": {
+      "en": "Elesa",
+      "fr": "Inezia"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -664,7 +862,10 @@
     "number": 67,
     "rarity": "U",
     "image": "cTR_10_001460_00_KOINUDAISUKIGARL_U.webp",
-    "name": "Puppy-Loving Girl",
+    "name": {
+      "en": "Puppy-Loving Girl",
+      "fr": "Fan de Chiots"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -674,7 +875,10 @@
     "number": 68,
     "rarity": "U",
     "image": "cTR_10_001470_00_MIKURI_U.webp",
-    "name": "Wallace",
+    "name": {
+      "en": "Wallace",
+      "fr": "Marc"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -684,7 +888,10 @@
     "number": 69,
     "rarity": "U",
     "image": "cTR_10_001480_00_KODOMOBEYA_U.webp",
-    "name": "Kid’s Room",
+    "name": {
+      "en": "Kid’s Room",
+      "fr": "Chambre d'Enfant"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -694,7 +901,10 @@
     "number": 70,
     "rarity": "AR",
     "image": "cPK_20_019110_00_ROKON_AR.webp",
-    "name": "Vulpix",
+    "name": {
+      "en": "Vulpix",
+      "fr": "Goupix"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -704,7 +914,10 @@
     "number": 71,
     "rarity": "AR",
     "image": "cPK_20_019190_00_POCHAMA_AR.webp",
-    "name": "Piplup",
+    "name": {
+      "en": "Piplup",
+      "fr": "Tiplouf"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -714,7 +927,10 @@
     "number": 72,
     "rarity": "AR",
     "image": "cPK_20_019210_00_PIKACHU_AR.webp",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -724,7 +940,10 @@
     "number": 73,
     "rarity": "AR",
     "image": "cPK_20_019280_00_NYMPHIA_AR.webp",
-    "name": "Sylveon",
+    "name": {
+      "en": "Sylveon",
+      "fr": "Nymphali"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -734,7 +953,10 @@
     "number": 74,
     "rarity": "AR",
     "image": "cPK_20_019440_00_HIDOIDE_AR.webp",
-    "name": "Mareanie",
+    "name": {
+      "en": "Mareanie",
+      "fr": "Vorastérie"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -744,7 +966,10 @@
     "number": 75,
     "rarity": "AR",
     "image": "cPK_20_019490_00_PURIN_AR.webp",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -754,7 +979,10 @@
     "number": 76,
     "rarity": "AR",
     "image": "cPK_20_019530_00_KABIGON_AR.webp",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -764,7 +992,10 @@
     "number": 77,
     "rarity": "AR",
     "image": "cPK_20_019600_00_YOKUBARISU_AR.webp",
-    "name": "Greedent",
+    "name": {
+      "en": "Greedent",
+      "fr": "Rongrigou"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -774,7 +1005,10 @@
     "number": 78,
     "rarity": "SR",
     "image": "cPK_20_019160_00_MILOKAROSSex_SR.webp",
-    "name": "Milotic ex",
+    "name": {
+      "en": "Milotic ex",
+      "fr": "Milobellus-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -784,7 +1018,10 @@
     "number": 79,
     "rarity": "SR",
     "image": "cPK_20_019220_00_DEDENNEex_SR.webp",
-    "name": "Dedenne ex",
+    "name": {
+      "en": "Dedenne ex",
+      "fr": "Dedenne-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -794,7 +1031,10 @@
     "number": 80,
     "rarity": "SR",
     "image": "cPK_20_019300_00_MEGADIANCIEex_SR.webp",
-    "name": "Mega Diancie ex",
+    "name": {
+      "en": "Mega Diancie ex",
+      "fr": "Méga-Diancie-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -804,7 +1044,10 @@
     "number": 81,
     "rarity": "SR",
     "image": "cPK_20_019390_00_MEGAYAMIRAMIex_SR.webp",
-    "name": "Mega Sableye ex",
+    "name": {
+      "en": "Mega Sableye ex",
+      "fr": "Méga-Ténéfix-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -814,7 +1057,10 @@
     "number": 82,
     "rarity": "SR",
     "image": "cPK_20_019570_00_HISUIZOROARKex_SR.webp",
-    "name": "Hisuian Zoroark ex",
+    "name": {
+      "en": "Hisuian Zoroark ex",
+      "fr": "Zoroark de Hisui-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -824,7 +1070,10 @@
     "number": 83,
     "rarity": "SR",
     "image": "cTR_20_001450_00_KAMITSURE_SR.webp",
-    "name": "Elesa",
+    "name": {
+      "en": "Elesa",
+      "fr": "Inezia"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -834,7 +1083,10 @@
     "number": 84,
     "rarity": "SR",
     "image": "cTR_20_001460_00_KOINUDAISUKIGARL_SR.webp",
-    "name": "Puppy-Loving Girl",
+    "name": {
+      "en": "Puppy-Loving Girl",
+      "fr": "Fan de Chiots"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -844,7 +1096,10 @@
     "number": 85,
     "rarity": "SR",
     "image": "cTR_20_001470_00_MIKURI_SR.webp",
-    "name": "Wallace",
+    "name": {
+      "en": "Wallace",
+      "fr": "Marc"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -854,7 +1109,10 @@
     "number": 86,
     "rarity": "SAR",
     "image": "cPK_20_019160_01_MILOKAROSSex_SAR.webp",
-    "name": "Milotic ex",
+    "name": {
+      "en": "Milotic ex",
+      "fr": "Milobellus-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -864,7 +1122,10 @@
     "number": 87,
     "rarity": "SAR",
     "image": "cPK_20_019300_01_MEGADIANCIEex_SAR.webp",
-    "name": "Mega Diancie ex",
+    "name": {
+      "en": "Mega Diancie ex",
+      "fr": "Méga-Diancie-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -874,7 +1135,10 @@
     "number": 88,
     "rarity": "SAR",
     "image": "cPK_20_019390_01_MEGAYAMIRAMIex_SAR.webp",
-    "name": "Mega Sableye ex",
+    "name": {
+      "en": "Mega Sableye ex",
+      "fr": "Méga-Ténéfix-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -884,7 +1148,10 @@
     "number": 89,
     "rarity": "SAR",
     "image": "cPK_20_019570_01_HISUIZOROARKex_SAR.webp",
-    "name": "Hisuian Zoroark ex",
+    "name": {
+      "en": "Hisuian Zoroark ex",
+      "fr": "Zoroark de Hisui-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -894,7 +1161,10 @@
     "number": 90,
     "rarity": "IM",
     "image": "cPK_20_019220_01_DEDENNEex_IM.webp",
-    "name": "Dedenne ex",
+    "name": {
+      "en": "Dedenne ex",
+      "fr": "Dedenne-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -904,7 +1174,10 @@
     "number": 91,
     "rarity": "S",
     "image": "cPK_20_019040_00_CATERPIE_S.webp",
-    "name": "Caterpie",
+    "name": {
+      "en": "Caterpie",
+      "fr": "Chenipan"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -914,7 +1187,10 @@
     "number": 92,
     "rarity": "S",
     "image": "cPK_20_019050_00_TRANSEL_S.webp",
-    "name": "Metapod",
+    "name": {
+      "en": "Metapod",
+      "fr": "Chrysacier"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -924,7 +1200,10 @@
     "number": 93,
     "rarity": "S",
     "image": "cPK_20_019060_00_BUTTERFREE_S.webp",
-    "name": "Butterfree",
+    "name": {
+      "en": "Butterfree",
+      "fr": "Papilusion"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -934,7 +1213,10 @@
     "number": 94,
     "rarity": "S",
     "image": "cPK_20_011640_00_MERRIEP_S.webp",
-    "name": "Mareep",
+    "name": {
+      "en": "Mareep",
+      "fr": "Wattouat"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -944,7 +1226,10 @@
     "number": 95,
     "rarity": "S",
     "image": "cPK_20_011650_00_MOKOKO_S.webp",
-    "name": "Flaaffy",
+    "name": {
+      "en": "Flaaffy",
+      "fr": "Lainergie"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -954,7 +1239,10 @@
     "number": 96,
     "rarity": "S",
     "image": "cPK_20_011660_00_DENRYU_S.webp",
-    "name": "Ampharos",
+    "name": {
+      "en": "Ampharos",
+      "fr": "Pharamp"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -964,7 +1252,10 @@
     "number": 97,
     "rarity": "S",
     "image": "cPK_20_019250_00_YADORAN_S.webp",
-    "name": "Slowbro",
+    "name": {
+      "en": "Slowbro",
+      "fr": "Flagadoss"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -974,7 +1265,10 @@
     "number": 98,
     "rarity": "S",
     "image": "cPK_20_014920_00_GARURA_S.webp",
-    "name": "Kangaskhan",
+    "name": {
+      "en": "Kangaskhan",
+      "fr": "Kangourex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -984,7 +1278,10 @@
     "number": 99,
     "rarity": "S",
     "image": "cPK_20_013060_00_METAMON_S.webp",
-    "name": "Ditto",
+    "name": {
+      "en": "Ditto",
+      "fr": "Métamorph"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -994,7 +1291,10 @@
     "number": 100,
     "rarity": "S",
     "image": "cPK_20_019530_01_KABIGON_S.webp",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -1004,7 +1304,10 @@
     "number": 101,
     "rarity": "SSR",
     "image": "cPK_20_011340_02_MEGAGYARADOSex_SSR.webp",
-    "name": "Mega Gyarados ex",
+    "name": {
+      "en": "Mega Gyarados ex",
+      "fr": "Méga-Léviator-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -1014,7 +1317,10 @@
     "number": 102,
     "rarity": "SSR",
     "image": "cPK_20_017020_02_SHOWERSex_SSR.webp",
-    "name": "Vaporeon ex",
+    "name": {
+      "en": "Vaporeon ex",
+      "fr": "Aquali-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -1024,7 +1330,10 @@
     "number": 103,
     "rarity": "SSR",
     "image": "cPK_20_011670_02_MEGADENRYUex_SSR.webp",
-    "name": "Mega Ampharos ex",
+    "name": {
+      "en": "Mega Ampharos ex",
+      "fr": "Méga-Pharamp-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -1034,7 +1343,10 @@
     "number": 104,
     "rarity": "SSR",
     "image": "cPK_20_012030_02_YESSANex_SSR.webp",
-    "name": "Indeedee ex",
+    "name": {
+      "en": "Indeedee ex",
+      "fr": "Wimessir-ex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -1044,7 +1356,10 @@
     "number": 105,
     "rarity": "UR",
     "image": "cPK_20_019520_00_GONBE_UR.webp",
-    "name": "Munchlax",
+    "name": {
+      "en": "Munchlax",
+      "fr": "Goinfrex"
+    },
     "packs": [
       "Everyday Wonders"
     ]
@@ -1054,7 +1369,10 @@
     "number": 106,
     "rarity": "UR",
     "image": "cTR_20_001430_00_CHIISANAFUUSEN_UR.webp",
-    "name": "Small Balloon",
+    "name": {
+      "en": "Small Balloon",
+      "fr": "Petit Ballon"
+    },
     "packs": [
       "Everyday Wonders"
     ]

--- a/dist/cards/PROMO-A.json
+++ b/dist/cards/PROMO-A.json
@@ -3,91 +3,130 @@
     "set": "PROMO-A",
     "number": 1,
     "rarity": "C",
-    "name": "Potion",
+    "name": {
+      "en": "Potion",
+      "fr": "Potion"
+    },
     "image": "cTR_90_000010_00_KIZUGUSURI_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 2,
     "rarity": "C",
-    "name": "X Speed",
+    "name": {
+      "en": "X Speed",
+      "fr": "Vitesse +"
+    },
     "image": "cTR_90_000020_00_SPEEDER_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 3,
     "rarity": "C",
-    "name": "Hand Scope",
+    "name": {
+      "en": "Hand Scope",
+      "fr": "Scrute Main"
+    },
     "image": "cTR_90_000050_00_HANDSCOPE_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 4,
     "rarity": "C",
-    "name": "Pokédex",
+    "name": {
+      "en": "Pokédex",
+      "fr": "Pokédex"
+    },
     "image": "cTR_90_000060_00_POKEMONZUKAN_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 5,
     "rarity": "C",
-    "name": "Poké Ball",
+    "name": {
+      "en": "Poké Ball",
+      "fr": "Poké Ball"
+    },
     "image": "cTR_90_000030_00_MONSTERBALL_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 6,
     "rarity": "C",
-    "name": "Red Card",
+    "name": {
+      "en": "Red Card",
+      "fr": "Carton Rouge"
+    },
     "image": "cTR_90_000070_00_REDCARD_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 7,
     "rarity": "C",
-    "name": "Professor’s Research",
+    "name": {
+      "en": "Professor’s Research",
+      "fr": "Recherches Professorales"
+    },
     "image": "cTR_90_000040_00_HAKASENOKENKYU_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 8,
     "rarity": "C",
-    "name": "Pokédex",
+    "name": {
+      "en": "Pokédex",
+      "fr": "Pokédex"
+    },
     "image": "cTR_90_000060_01_POKEMONZUKAN_C.webp"
   },
   {
     "set": "PROMO-A",
     "number": 9,
     "rarity": "AR",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_90_000940_02_PIKACHU_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 10,
     "rarity": "AR",
-    "name": "Mewtwo",
+    "name": {
+      "en": "Mewtwo",
+      "fr": "Mewtwo"
+    },
     "image": "cPK_90_001280_00_MEWTWO_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 11,
     "rarity": "R",
-    "name": "Chansey",
+    "name": {
+      "en": "Chansey",
+      "fr": "Leveinard"
+    },
     "image": "cPK_90_002020_00_LUCKY_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 12,
     "rarity": "R",
-    "name": "Meowth",
+    "name": {
+      "en": "Meowth",
+      "fr": "Miaouss"
+    },
     "image": "cPK_90_001960_00_NYARTH_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 13,
     "rarity": "R",
-    "name": "Butterfree",
+    "name": {
+      "en": "Butterfree",
+      "fr": "Papilusion"
+    },
     "image": "cPK_90_000070_00_BUTTERFREE_R.webp",
     "packs": [
       "Vol. 1"
@@ -97,7 +136,10 @@
     "set": "PROMO-A",
     "number": 14,
     "rarity": "RR",
-    "name": "Lapras ex",
+    "name": {
+      "en": "Lapras ex",
+      "fr": "Lokhlass-ex"
+    },
     "image": "cPK_90_002760_00_LAPLACEex_RR.webp",
     "packs": [
       "Vol. 1"
@@ -107,7 +149,10 @@
     "set": "PROMO-A",
     "number": 15,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_90_000940_01_PIKACHU_C.webp",
     "packs": [
       "Vol. 1"
@@ -117,7 +162,10 @@
     "set": "PROMO-A",
     "number": 16,
     "rarity": "C",
-    "name": "Clefairy",
+    "name": {
+      "en": "Clefairy",
+      "fr": "Mélofée"
+    },
     "image": "cPK_90_001130_00_PIPPI_C.webp",
     "packs": [
       "Vol. 1"
@@ -127,7 +175,10 @@
     "set": "PROMO-A",
     "number": 17,
     "rarity": "C",
-    "name": "Mankey",
+    "name": {
+      "en": "Mankey",
+      "fr": "Férosinge"
+    },
     "image": "cPK_90_002770_00_MANKEY_C.webp",
     "packs": [
       "Vol. 1"
@@ -137,7 +188,10 @@
     "set": "PROMO-A",
     "number": 18,
     "rarity": "AR",
-    "name": "Venusaur",
+    "name": {
+      "en": "Venusaur",
+      "fr": "Florizarre"
+    },
     "image": "cPK_90_000030_00_FUSHIGIBANA_AR.webp",
     "packs": [
       "Vol. 2"
@@ -147,7 +201,10 @@
     "set": "PROMO-A",
     "number": 19,
     "rarity": "R",
-    "name": "Greninja",
+    "name": {
+      "en": "Greninja",
+      "fr": "Amphinobi"
+    },
     "image": "cPK_90_000890_00_GEKKOUGA_R.webp",
     "packs": [
       "Vol. 2"
@@ -157,7 +214,10 @@
     "set": "PROMO-A",
     "number": 20,
     "rarity": "C",
-    "name": "Haunter",
+    "name": {
+      "en": "Haunter",
+      "fr": "Spectrum"
+    },
     "image": "cPK_90_002780_00_GHOST_C.webp",
     "packs": [
       "Vol. 2"
@@ -167,7 +227,10 @@
     "set": "PROMO-A",
     "number": 21,
     "rarity": "C",
-    "name": "Onix",
+    "name": {
+      "en": "Onix",
+      "fr": "Onix"
+    },
     "image": "cPK_90_001500_00_IWARK_C.webp",
     "packs": [
       "Vol. 2"
@@ -177,7 +240,10 @@
     "set": "PROMO-A",
     "number": 22,
     "rarity": "C",
-    "name": "Jigglypuff",
+    "name": {
+      "en": "Jigglypuff",
+      "fr": "Rondoudou"
+    },
     "image": "cPK_90_002790_00_PURIN_C.webp",
     "packs": [
       "Vol. 2"
@@ -187,35 +253,50 @@
     "set": "PROMO-A",
     "number": 23,
     "rarity": "R",
-    "name": "Bulbasaur",
+    "name": {
+      "en": "Bulbasaur",
+      "fr": "Bulbizarre"
+    },
     "image": "cPK_90_000010_00_FUSHIGIDANE_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 24,
     "rarity": "R",
-    "name": "Magnemite",
+    "name": {
+      "en": "Magnemite",
+      "fr": "Magnéti"
+    },
     "image": "cPK_90_000970_00_COIL_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 25,
     "rarity": "RR",
-    "name": "Moltres ex",
+    "name": {
+      "en": "Moltres ex",
+      "fr": "Sulfura-ex"
+    },
     "image": "cPK_90_000470_00_FIREex_RR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 26,
     "rarity": "AR",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_90_000940_00_PIKACHU_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 27,
     "rarity": "C",
-    "name": "Snivy",
+    "name": {
+      "en": "Snivy",
+      "fr": "Vipélierre"
+    },
     "image": "cPK_90_002800_00_TSUTARJA_C.webp",
     "packs": [
       "Vol. 3"
@@ -225,7 +306,10 @@
     "set": "PROMO-A",
     "number": 28,
     "rarity": "R",
-    "name": "Volcarona",
+    "name": {
+      "en": "Volcarona",
+      "fr": "Pyrax"
+    },
     "image": "cPK_90_002280_00_ULGAMOTH_R.webp",
     "packs": [
       "Vol. 3"
@@ -235,7 +319,10 @@
     "set": "PROMO-A",
     "number": 29,
     "rarity": "AR",
-    "name": "Blastoise",
+    "name": {
+      "en": "Blastoise",
+      "fr": "Tortank"
+    },
     "image": "cPK_90_000550_00_KAMEX_AR.webp",
     "packs": [
       "Vol. 3"
@@ -245,7 +332,10 @@
     "set": "PROMO-A",
     "number": 30,
     "rarity": "C",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_90_002810_00_EIEVUI_C.webp",
     "packs": [
       "Vol. 3"
@@ -255,7 +345,10 @@
     "set": "PROMO-A",
     "number": 31,
     "rarity": "C",
-    "name": "Cinccino",
+    "name": {
+      "en": "Cinccino",
+      "fr": "Pashmilla"
+    },
     "image": "cPK_90_002110_00_CHILLACCINO_C.webp",
     "packs": [
       "Vol. 3"
@@ -265,28 +358,40 @@
     "set": "PROMO-A",
     "number": 32,
     "rarity": "R",
-    "name": "Charmander",
+    "name": {
+      "en": "Charmander",
+      "fr": "Salamèche"
+    },
     "image": "cPK_90_000330_00_HITOKAGE_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 33,
     "rarity": "R",
-    "name": "Squirtle",
+    "name": {
+      "en": "Squirtle",
+      "fr": "Carapuce"
+    },
     "image": "cPK_90_000530_00_ZENIGAME_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 34,
     "rarity": "AR",
-    "name": "Piplup",
+    "name": {
+      "en": "Piplup",
+      "fr": "Tiplouf"
+    },
     "image": "cPK_90_003160_00_POCHAMA_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 35,
     "rarity": "C",
-    "name": "Turtwig",
+    "name": {
+      "en": "Turtwig",
+      "fr": "Tortipouss"
+    },
     "image": "cPK_90_002910_00_NAETLE_C.webp",
     "packs": [
       "Vol. 4"
@@ -296,7 +401,10 @@
     "set": "PROMO-A",
     "number": 36,
     "rarity": "R",
-    "name": "Electivire",
+    "name": {
+      "en": "Electivire",
+      "fr": "Élekable"
+    },
     "image": "cPK_90_003380_00_ELEKIBLE_R.webp",
     "packs": [
       "Vol. 4"
@@ -306,7 +414,10 @@
     "set": "PROMO-A",
     "number": 37,
     "rarity": "RR",
-    "name": "Cresselia ex",
+    "name": {
+      "en": "Cresselia ex",
+      "fr": "Cresselia-ex"
+    },
     "image": "cPK_90_004960_00_CRESSELIAex_RR.webp",
     "packs": [
       "Vol. 4"
@@ -316,7 +427,10 @@
     "set": "PROMO-A",
     "number": 38,
     "rarity": "C",
-    "name": "Misdreavus",
+    "name": {
+      "en": "Misdreavus",
+      "fr": "Feuforêve"
+    },
     "image": "cPK_90_004970_00_MUMA_C.webp",
     "packs": [
       "Vol. 4"
@@ -326,7 +440,10 @@
     "set": "PROMO-A",
     "number": 39,
     "rarity": "C",
-    "name": "Skarmory",
+    "name": {
+      "en": "Skarmory",
+      "fr": "Airmure"
+    },
     "image": "cPK_90_003920_00_AIRMD_C.webp",
     "packs": [
       "Vol. 4"
@@ -336,28 +453,40 @@
     "set": "PROMO-A",
     "number": 40,
     "rarity": "R",
-    "name": "Chimchar",
+    "name": {
+      "en": "Chimchar",
+      "fr": "Ouisticram"
+    },
     "image": "cPK_90_003080_00_HIKOZARU_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 41,
     "rarity": "R",
-    "name": "Togepi",
+    "name": {
+      "en": "Togepi",
+      "fr": "Togepi"
+    },
     "image": "cPK_90_003440_00_TOGEPY_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 42,
     "rarity": "RR",
-    "name": "Darkrai ex",
+    "name": {
+      "en": "Darkrai ex",
+      "fr": "Darkrai-ex"
+    },
     "image": "cPK_90_003910_00_DARKRAIex_RR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 43,
     "rarity": "C",
-    "name": "Cherrim",
+    "name": {
+      "en": "Cherrim",
+      "fr": "Ceriflor"
+    },
     "image": "cPK_90_004320_00_CHERRIM_C.webp",
     "packs": [
       "Vol. 5"
@@ -367,7 +496,10 @@
     "set": "PROMO-A",
     "number": 44,
     "rarity": "R",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "image": "cPK_90_004500_00_RAICHU_R.webp",
     "packs": [
       "Vol. 5"
@@ -377,7 +509,10 @@
     "set": "PROMO-A",
     "number": 45,
     "rarity": "C",
-    "name": "Nosepass",
+    "name": {
+      "en": "Nosepass",
+      "fr": "Tarinor"
+    },
     "image": "cPK_90_004980_00_NOSEPASS_C.webp",
     "packs": [
       "Vol. 5"
@@ -387,7 +522,10 @@
     "set": "PROMO-A",
     "number": 46,
     "rarity": "AR",
-    "name": "Gible",
+    "name": {
+      "en": "Gible",
+      "fr": "Griknot"
+    },
     "image": "cPK_90_004690_00_FUKAMARU_AR.webp",
     "packs": [
       "Vol. 5"
@@ -397,7 +535,10 @@
     "set": "PROMO-A",
     "number": 47,
     "rarity": "C",
-    "name": "Staraptor",
+    "name": {
+      "en": "Staraptor",
+      "fr": "Étouraptor"
+    },
     "image": "cPK_90_004990_00_MUKUHAWK_C.webp",
     "packs": [
       "Vol. 5"
@@ -407,42 +548,60 @@
     "set": "PROMO-A",
     "number": 48,
     "rarity": "R",
-    "name": "Manaphy",
+    "name": {
+      "en": "Manaphy",
+      "fr": "Manaphy"
+    },
     "image": "cPK_90_003310_00_MANAPHY_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 49,
     "rarity": "R",
-    "name": "Snorlax",
+    "name": {
+      "en": "Snorlax",
+      "fr": "Ronflex"
+    },
     "image": "cPK_90_004870_00_KABIGON_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 50,
     "rarity": "SSR",
-    "name": "Mewtwo ex",
+    "name": {
+      "en": "Mewtwo ex",
+      "fr": "Mewtwo-ex"
+    },
     "image": "cPK_90_001290_00_MEWTWOex_SSR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 51,
     "rarity": "S",
-    "name": "Cyclizar",
+    "name": {
+      "en": "Cyclizar",
+      "fr": "Motorizard"
+    },
     "image": "cPK_90_005090_00_MOTOTOKAGE_S.webp"
   },
   {
     "set": "PROMO-A",
     "number": 52,
     "rarity": "AR",
-    "name": "Sprigatito",
+    "name": {
+      "en": "Sprigatito",
+      "fr": "Poussacha"
+    },
     "image": "cPK_90_005080_00_NYAHOJA_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 53,
     "rarity": "C",
-    "name": "Floatzel",
+    "name": {
+      "en": "Floatzel",
+      "fr": "Mustéflott"
+    },
     "image": "cPK_90_005000_00_FLOAZEL_C.webp",
     "packs": [
       "Vol. 6"
@@ -452,7 +611,10 @@
     "set": "PROMO-A",
     "number": 54,
     "rarity": "AR",
-    "name": "Pawmot",
+    "name": {
+      "en": "Pawmot",
+      "fr": "Pohmarmotte"
+    },
     "image": "cPK_90_005010_00_PARMOT_AR.webp",
     "packs": [
       "Vol. 6"
@@ -462,7 +624,10 @@
     "set": "PROMO-A",
     "number": 55,
     "rarity": "R",
-    "name": "Machamp",
+    "name": {
+      "en": "Machamp",
+      "fr": "Mackogneur"
+    },
     "image": "cPK_90_005020_00_KAIRIKY_R.webp",
     "packs": [
       "Vol. 6"
@@ -472,7 +637,10 @@
     "set": "PROMO-A",
     "number": 56,
     "rarity": "C",
-    "name": "Ekans",
+    "name": {
+      "en": "Ekans",
+      "fr": "Abo"
+    },
     "image": "cPK_90_005030_00_ARBO_C.webp",
     "packs": [
       "Vol. 6"
@@ -482,7 +650,10 @@
     "set": "PROMO-A",
     "number": 57,
     "rarity": "C",
-    "name": "Bidoof",
+    "name": {
+      "en": "Bidoof",
+      "fr": "Keunotor"
+    },
     "image": "cPK_90_005040_00_BIPPA_C.webp",
     "packs": [
       "Vol. 6"
@@ -492,21 +663,30 @@
     "set": "PROMO-A",
     "number": 58,
     "rarity": "R",
-    "name": "Pachirisu",
+    "name": {
+      "en": "Pachirisu",
+      "fr": "Pachirisu"
+    },
     "image": "cPK_90_005060_00_PACHIRISU_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 59,
     "rarity": "R",
-    "name": "Riolu",
+    "name": {
+      "en": "Riolu",
+      "fr": "Riolu"
+    },
     "image": "cPK_90_005070_00_RIOLU_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 60,
     "rarity": "C",
-    "name": "Exeggcute",
+    "name": {
+      "en": "Exeggcute",
+      "fr": "Noeunoeuf"
+    },
     "image": "cPK_90_002150_00_TAMATAMA_C.webp",
     "packs": [
       "Vol. 7"
@@ -516,7 +696,10 @@
     "set": "PROMO-A",
     "number": 61,
     "rarity": "C",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_90_000870_00_KEROMATSU_C.webp",
     "packs": [
       "Vol. 7"
@@ -526,7 +709,10 @@
     "set": "PROMO-A",
     "number": 62,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": {
+      "en": "Farfetch’d",
+      "fr": "Canarticho"
+    },
     "image": "cPK_90_001980_00_KAMONEGI_C.webp",
     "packs": [
       "Vol. 7"
@@ -536,7 +722,10 @@
     "set": "PROMO-A",
     "number": 63,
     "rarity": "R",
-    "name": "Rayquaza",
+    "name": {
+      "en": "Rayquaza",
+      "fr": "Rayquaza"
+    },
     "image": "cPK_90_010810_00_RAYQUAZA_R.webp",
     "packs": [
       "Vol. 7"
@@ -546,7 +735,10 @@
     "set": "PROMO-A",
     "number": 64,
     "rarity": "RR",
-    "name": "Rayquaza ex",
+    "name": {
+      "en": "Rayquaza ex",
+      "fr": "Rayquaza-ex"
+    },
     "image": "cPK_90_010820_00_RAYQUAZAex_RR.webp",
     "packs": [
       "Vol. 7"
@@ -556,35 +748,50 @@
     "set": "PROMO-A",
     "number": 65,
     "rarity": "SR",
-    "name": "Rayquaza ex",
+    "name": {
+      "en": "Rayquaza ex",
+      "fr": "Rayquaza-ex"
+    },
     "image": "cPK_90_010820_01_RAYQUAZAex_SR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 66,
     "rarity": "AR",
-    "name": "Mimikyu",
+    "name": {
+      "en": "Mimikyu",
+      "fr": "Mimiqui"
+    },
     "image": "cPK_90_006640_00_MIMIKKYU_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 67,
     "rarity": "R",
-    "name": "Cosmog",
+    "name": {
+      "en": "Cosmog",
+      "fr": "Cosmog"
+    },
     "image": "cPK_90_006660_00_COSMOG_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 68,
     "rarity": "R",
-    "name": "Lycanroc",
+    "name": {
+      "en": "Lycanroc",
+      "fr": "Lougaroc"
+    },
     "image": "cPK_90_006810_00_LUGARUGAN_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 69,
     "rarity": "R",
-    "name": "Alolan Exeggutor",
+    "name": {
+      "en": "Alolan Exeggutor",
+      "fr": "Noadkoko d'Alola"
+    },
     "image": "cPK_90_005830_00_ALOLANASSY_R.webp",
     "packs": [
       "Vol. 8"
@@ -594,7 +801,10 @@
     "set": "PROMO-A",
     "number": 70,
     "rarity": "AR",
-    "name": "Alolan Ninetales",
+    "name": {
+      "en": "Alolan Ninetales",
+      "fr": "Feunard d'Alola"
+    },
     "image": "cPK_90_006220_00_ALOLAKYUKON_AR.webp",
     "packs": [
       "Vol. 8"
@@ -604,7 +814,10 @@
     "set": "PROMO-A",
     "number": 71,
     "rarity": "C",
-    "name": "Crabrawler",
+    "name": {
+      "en": "Crabrawler",
+      "fr": "Crabagarre"
+    },
     "image": "cPK_90_006780_00_MAKENKANI_C.webp",
     "packs": [
       "Vol. 8"
@@ -614,7 +827,10 @@
     "set": "PROMO-A",
     "number": 72,
     "rarity": "C",
-    "name": "Alolan Grimer",
+    "name": {
+      "en": "Alolan Grimer",
+      "fr": "Tadmorv d'Alola"
+    },
     "image": "cPK_90_007230_00_ALOLABETBETER_C.webp",
     "packs": [
       "Vol. 8"
@@ -624,7 +840,10 @@
     "set": "PROMO-A",
     "number": 73,
     "rarity": "C",
-    "name": "Toucannon",
+    "name": {
+      "en": "Toucannon",
+      "fr": "Bazoucan"
+    },
     "image": "cPK_90_007240_00_DODEKABASHI_C.webp",
     "packs": [
       "Vol. 8"
@@ -634,14 +853,20 @@
     "set": "PROMO-A",
     "number": 74,
     "rarity": "AR",
-    "name": "Zeraora",
+    "name": {
+      "en": "Zeraora",
+      "fr": "Zeraora"
+    },
     "image": "cPK_90_007410_00_ZERAORA_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 75,
     "rarity": "C",
-    "name": "Kartana",
+    "name": {
+      "en": "Kartana",
+      "fr": "Katagami"
+    },
     "image": "cPK_90_007250_00_KAMITURUGI_C.webp",
     "packs": [
       "Vol. 9"
@@ -651,7 +876,10 @@
     "set": "PROMO-A",
     "number": 76,
     "rarity": "C",
-    "name": "Blacephalon",
+    "name": {
+      "en": "Blacephalon",
+      "fr": "Pierroteknik"
+    },
     "image": "cPK_90_007260_00_ZUGADOON_C.webp",
     "packs": [
       "Vol. 9"
@@ -661,7 +889,10 @@
     "set": "PROMO-A",
     "number": 77,
     "rarity": "C",
-    "name": "Xurkitree",
+    "name": {
+      "en": "Xurkitree",
+      "fr": "Câblifère"
+    },
     "image": "cPK_90_007270_00_DENJYUMOKU_C.webp",
     "packs": [
       "Vol. 9"
@@ -671,7 +902,10 @@
     "set": "PROMO-A",
     "number": 78,
     "rarity": "R",
-    "name": "Dawn Wings Necrozma",
+    "name": {
+      "en": "Dawn Wings Necrozma",
+      "fr": "Necrozma Ailes de l'Aurore"
+    },
     "image": "cPK_90_007280_00_NECROZMAAKATSUKINOTSUBASA_R.webp",
     "packs": [
       "Vol. 9"
@@ -681,7 +915,10 @@
     "set": "PROMO-A",
     "number": 79,
     "rarity": "R",
-    "name": "Dusk Mane Necrozma",
+    "name": {
+      "en": "Dusk Mane Necrozma",
+      "fr": "Necrozma Crinière du Couchant"
+    },
     "image": "cPK_90_007290_00_NECROZMATASOGARENOTATEGAMI_R.webp",
     "packs": [
       "Vol. 9"
@@ -691,7 +928,10 @@
     "set": "PROMO-A",
     "number": 80,
     "rarity": "C",
-    "name": "Stakataka",
+    "name": {
+      "en": "Stakataka",
+      "fr": "Ama-Ama"
+    },
     "image": "cPK_90_007300_00_TUNDETUNDE_C.webp",
     "packs": [
       "Vol. 9"
@@ -701,7 +941,10 @@
     "set": "PROMO-A",
     "number": 81,
     "rarity": "RR",
-    "name": "Ultra Necrozma ex",
+    "name": {
+      "en": "Ultra Necrozma ex",
+      "fr": "Ultra-Necrozma-ex"
+    },
     "image": "cPK_90_007310_00_NECROZMAULTRANECROZMAex_RR.webp",
     "packs": [
       "Vol. 9"
@@ -711,28 +954,40 @@
     "set": "PROMO-A",
     "number": 82,
     "rarity": "R",
-    "name": "Poipole",
+    "name": {
+      "en": "Poipole",
+      "fr": "Vémini"
+    },
     "image": "cPK_90_007370_00_BEVENOM_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 83,
     "rarity": "R",
-    "name": "Stufful",
+    "name": {
+      "en": "Stufful",
+      "fr": "Nounourson"
+    },
     "image": "cPK_90_007380_00_NUIKOGUMA_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 84,
     "rarity": "RR",
-    "name": "Tapu Koko ex",
+    "name": {
+      "en": "Tapu Koko ex",
+      "fr": "Tokorico-ex"
+    },
     "image": "cPK_90_007420_00_KAPU-KOKEKOex_RR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 85,
     "rarity": "C",
-    "name": "Vanillite",
+    "name": {
+      "en": "Vanillite",
+      "fr": "Sorbébé"
+    },
     "image": "cPK_90_007320_00_VANIPETI_C.webp",
     "packs": [
       "Vol. 10"
@@ -742,7 +997,10 @@
     "set": "PROMO-A",
     "number": 86,
     "rarity": "R",
-    "name": "Jolteon",
+    "name": {
+      "en": "Jolteon",
+      "fr": "Voltali"
+    },
     "image": "cPK_90_007330_00_THUNDERS_R.webp",
     "packs": [
       "Vol. 10"
@@ -752,7 +1010,10 @@
     "set": "PROMO-A",
     "number": 87,
     "rarity": "AR",
-    "name": "Alcremie",
+    "name": {
+      "en": "Alcremie",
+      "fr": "Charmilly"
+    },
     "image": "cPK_90_007340_00_MAWHIP_AR.webp",
     "packs": [
       "Vol. 10"
@@ -762,7 +1023,10 @@
     "set": "PROMO-A",
     "number": 88,
     "rarity": "C",
-    "name": "Dragonair",
+    "name": {
+      "en": "Dragonair",
+      "fr": "Draco"
+    },
     "image": "cPK_90_007350_00_HAKURYU_C.webp",
     "packs": [
       "Vol. 10"
@@ -772,7 +1036,10 @@
     "set": "PROMO-A",
     "number": 89,
     "rarity": "C",
-    "name": "Audino",
+    "name": {
+      "en": "Audino",
+      "fr": "Nanméouïe"
+    },
     "image": "cPK_90_007360_00_TABUNNE_C.webp",
     "packs": [
       "Vol. 10"
@@ -782,35 +1049,50 @@
     "set": "PROMO-A",
     "number": 90,
     "rarity": "R",
-    "name": "Togedemaru",
+    "name": {
+      "en": "Togedemaru",
+      "fr": "Togedemaru"
+    },
     "image": "cPK_90_007390_00_TOGEDEMARU_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 91,
     "rarity": "R",
-    "name": "Greedent",
+    "name": {
+      "en": "Greedent",
+      "fr": "Rongrigou"
+    },
     "image": "cPK_90_007400_00_YOKUBARISU_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 92,
     "rarity": "R",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_90_002060_00_EIEVUI_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 93,
     "rarity": "AR",
-    "name": "Cleffa",
+    "name": {
+      "en": "Cleffa",
+      "fr": "Mélo"
+    },
     "image": "cPK_90_009330_00_PY_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 94,
     "rarity": "C",
-    "name": "Horsea",
+    "name": {
+      "en": "Horsea",
+      "fr": "Hypotrempe"
+    },
     "image": "cPK_90_010070_00_TATTU_C.webp",
     "packs": [
       "Vol. 11"
@@ -820,7 +1102,10 @@
     "set": "PROMO-A",
     "number": 95,
     "rarity": "C",
-    "name": "Chinchou",
+    "name": {
+      "en": "Chinchou",
+      "fr": "Loupio"
+    },
     "image": "cPK_90_010080_00_CHONCHIE_C.webp",
     "packs": [
       "Vol. 11"
@@ -830,7 +1115,10 @@
     "set": "PROMO-A",
     "number": 96,
     "rarity": "C",
-    "name": "Houndoom",
+    "name": {
+      "en": "Houndoom",
+      "fr": "Démolosse"
+    },
     "image": "cPK_90_009740_00_HELLGAR_C.webp",
     "packs": [
       "Vol. 11"
@@ -840,7 +1128,10 @@
     "set": "PROMO-A",
     "number": 97,
     "rarity": "R",
-    "name": "Kangaskhan",
+    "name": {
+      "en": "Kangaskhan",
+      "fr": "Kangourex"
+    },
     "image": "cPK_90_009890_00_GARURA_R.webp",
     "packs": [
       "Vol. 11"
@@ -850,7 +1141,10 @@
     "set": "PROMO-A",
     "number": 98,
     "rarity": "RR",
-    "name": "Blissey ex",
+    "name": {
+      "en": "Blissey ex",
+      "fr": "Leuphorie-ex"
+    },
     "image": "cPK_90_010090_00_HAPPINASex_RR.webp",
     "packs": [
       "Vol. 11"
@@ -860,28 +1154,40 @@
     "set": "PROMO-A",
     "number": 99,
     "rarity": "R",
-    "name": "Marill",
+    "name": {
+      "en": "Marill",
+      "fr": "Marill"
+    },
     "image": "cPK_90_009050_00_MARIL_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 100,
     "rarity": "R",
-    "name": "Weavile",
+    "name": {
+      "en": "Weavile",
+      "fr": "Dimoret"
+    },
     "image": "cPK_90_009720_00_MANYULA_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 101,
     "rarity": "AR",
-    "name": "Latias",
+    "name": {
+      "en": "Latias",
+      "fr": "Latias"
+    },
     "image": "cPK_90_010200_00_LATIAS_AR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 102,
     "rarity": "C",
-    "name": "Tropius",
+    "name": {
+      "en": "Tropius",
+      "fr": "Tropius"
+    },
     "image": "cPK_90_010100_00_TROPIUS_C.webp",
     "packs": [
       "Vol. 12"
@@ -891,7 +1197,10 @@
     "set": "PROMO-A",
     "number": 103,
     "rarity": "C",
-    "name": "Poliwag",
+    "name": {
+      "en": "Poliwag",
+      "fr": "Ptitard"
+    },
     "image": "cPK_90_010110_00_NYOROMO_C.webp",
     "packs": [
       "Vol. 12"
@@ -901,7 +1210,10 @@
     "set": "PROMO-A",
     "number": 104,
     "rarity": "R",
-    "name": "Milotic",
+    "name": {
+      "en": "Milotic",
+      "fr": "Milobellus"
+    },
     "image": "cPK_90_010120_00_MILOKAROSS_R.webp",
     "packs": [
       "Vol. 12"
@@ -911,7 +1223,10 @@
     "set": "PROMO-A",
     "number": 105,
     "rarity": "C",
-    "name": "Zorua",
+    "name": {
+      "en": "Zorua",
+      "fr": "Zorua"
+    },
     "image": "cPK_90_010130_00_ZORUA_C.webp",
     "packs": [
       "Vol. 12"
@@ -921,7 +1236,10 @@
     "set": "PROMO-A",
     "number": 106,
     "rarity": "AR",
-    "name": "Zoroark",
+    "name": {
+      "en": "Zoroark",
+      "fr": "Zoroark"
+    },
     "image": "cPK_90_010140_00_ZOROARK_AR.webp",
     "packs": [
       "Vol. 12"
@@ -931,35 +1249,50 @@
     "set": "PROMO-A",
     "number": 107,
     "rarity": "R",
-    "name": "Miltank",
+    "name": {
+      "en": "Miltank",
+      "fr": "Écrémeuh"
+    },
     "image": "cPK_90_010180_00_MILTANK_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 108,
     "rarity": "R",
-    "name": "Phanpy",
+    "name": {
+      "en": "Phanpy",
+      "fr": "Phanpy"
+    },
     "image": "cPK_90_010190_00_GOMAZOU_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 109,
     "rarity": "SAR",
-    "name": "Eevee ex",
+    "name": {
+      "en": "Eevee ex",
+      "fr": "Évoli-ex"
+    },
     "image": "cPK_90_008480_00_EIEVUIex_SAR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 110,
     "rarity": "RR",
-    "name": "Entei ex",
+    "name": {
+      "en": "Entei ex",
+      "fr": "Entei-ex"
+    },
     "image": "cPK_90_010210_00_ENTEIex_RR.webp"
   },
   {
     "set": "PROMO-A",
     "number": 111,
     "rarity": "C",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_90_010150_00_PIKACHU_C.webp",
     "packs": [
       "Vol. 13"
@@ -969,7 +1302,10 @@
     "set": "PROMO-A",
     "number": 112,
     "rarity": "RR",
-    "name": "Raichu ex",
+    "name": {
+      "en": "Raichu ex",
+      "fr": "Raichu-ex"
+    },
     "image": "cPK_90_010160_00_RAICHUex_RR.webp",
     "packs": [
       "Vol. 13"
@@ -979,7 +1315,10 @@
     "set": "PROMO-A",
     "number": 113,
     "rarity": "C",
-    "name": "Mimikyu",
+    "name": {
+      "en": "Mimikyu",
+      "fr": "Mimiqui"
+    },
     "image": "cPK_90_008290_00_MIMIKKYU_C.webp",
     "packs": [
       "Vol. 13"
@@ -989,7 +1328,10 @@
     "set": "PROMO-A",
     "number": 114,
     "rarity": "C",
-    "name": "Machamp",
+    "name": {
+      "en": "Machamp",
+      "fr": "Mackogneur"
+    },
     "image": "cPK_90_010170_00_KAIRIKY_C.webp",
     "packs": [
       "Vol. 13"
@@ -999,7 +1341,10 @@
     "set": "PROMO-A",
     "number": 115,
     "rarity": "R",
-    "name": "Regigigas",
+    "name": {
+      "en": "Regigigas",
+      "fr": "Regigigas"
+    },
     "image": "cPK_90_004240_00_REGIGIGAS_R.webp",
     "packs": [
       "Vol. 13"
@@ -1009,14 +1354,20 @@
     "set": "PROMO-A",
     "number": 116,
     "rarity": "R",
-    "name": "Shaymin",
+    "name": {
+      "en": "Shaymin",
+      "fr": "Shaymin"
+    },
     "image": "cPK_90_003030_00_SHAYMIN_R.webp"
   },
   {
     "set": "PROMO-A",
     "number": 117,
     "rarity": "R",
-    "name": "Absol",
+    "name": {
+      "en": "Absol",
+      "fr": "Absol"
+    },
     "image": "cPK_90_009760_00_ABSOL_R.webp"
   }
 ]

--- a/dist/cards/PROMO-B.json
+++ b/dist/cards/PROMO-B.json
@@ -3,14 +3,20 @@
     "set": "PROMO-B",
     "number": 1,
     "rarity": "AR",
-    "name": "Pikachu",
+    "name": {
+      "en": "Pikachu",
+      "fr": "Pikachu"
+    },
     "image": "cPK_90_004490_00_PIKACHU_AR.webp"
   },
   {
     "set": "PROMO-B",
     "number": 2,
     "rarity": "C",
-    "name": "Petilil",
+    "name": {
+      "en": "Petilil",
+      "fr": "Chlorobule"
+    },
     "image": "cPK_90_012930_00_CHURINE_C.webp",
     "packs": [
       "B Series Vol. 1"
@@ -20,7 +26,10 @@
     "set": "PROMO-B",
     "number": 3,
     "rarity": "C",
-    "name": "Froakie",
+    "name": {
+      "en": "Froakie",
+      "fr": "Grenousse"
+    },
     "image": "cPK_90_012940_00_KEROMATSU_C.webp",
     "packs": [
       "B Series Vol. 1"
@@ -30,7 +39,10 @@
     "set": "PROMO-B",
     "number": 4,
     "rarity": "R",
-    "name": "Luxray",
+    "name": {
+      "en": "Luxray",
+      "fr": "Luxray"
+    },
     "image": "cPK_90_011700_00_RENTORAR_R.webp",
     "packs": [
       "B Series Vol. 1"
@@ -40,7 +52,10 @@
     "set": "PROMO-B",
     "number": 5,
     "rarity": "C",
-    "name": "Pidgey",
+    "name": {
+      "en": "Pidgey",
+      "fr": "Roucool"
+    },
     "image": "cPK_90_012620_00_POPPO_C.webp",
     "packs": [
       "B Series Vol. 1"
@@ -50,7 +65,10 @@
     "set": "PROMO-B",
     "number": 6,
     "rarity": "RR",
-    "name": "Mega Pidgeot ex",
+    "name": {
+      "en": "Mega Pidgeot ex",
+      "fr": "Méga-Roucarnage-ex"
+    },
     "image": "cPK_90_012950_00_MEGAPIGEOTex_RR.webp",
     "packs": [
       "B Series Vol. 1"
@@ -60,35 +78,50 @@
     "set": "PROMO-B",
     "number": 7,
     "rarity": "R",
-    "name": "Torchic",
+    "name": {
+      "en": "Torchic",
+      "fr": "Poussifeu"
+    },
     "image": "cPK_90_011150_00_ACHAMO_R.webp"
   },
   {
     "set": "PROMO-B",
     "number": 8,
     "rarity": "R",
-    "name": "Psyduck",
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    },
     "image": "cPK_90_011300_00_KODUCK_R.webp"
   },
   {
     "set": "PROMO-B",
     "number": 9,
     "rarity": "RR",
-    "name": "Mega Absol ex",
+    "name": {
+      "en": "Mega Absol ex",
+      "fr": "Méga-Absol-ex"
+    },
     "image": "cPK_90_012330_00_MEGAABSOLex_RR.webp"
   },
   {
     "set": "PROMO-B",
     "number": 10,
     "rarity": "R",
-    "name": "Drifblim",
+    "name": {
+      "en": "Drifblim",
+      "fr": "Grodrive"
+    },
     "image": "cPK_90_011900_00_FUWARIDE_R.webp"
   },
   {
     "set": "PROMO-B",
     "number": 11,
     "rarity": "R",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "image": "cPK_90_012660_00_EIEVUI_R.webp"
   },
   {
@@ -96,14 +129,20 @@
     "number": 12,
     "rarity": "AR",
     "image": "cPK_90_013060_00_METAMON_AR.webp",
-    "name": "Ditto"
+    "name": {
+      "en": "Ditto",
+      "fr": "Métamorph"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 13,
     "rarity": "C",
     "image": "cPK_90_011110_00_WINDIE_C.webp",
-    "name": "Arcanine",
+    "name": {
+      "en": "Arcanine",
+      "fr": "Arcanin"
+    },
     "packs": [
       "B Series Vol. 2"
     ]
@@ -113,7 +152,10 @@
     "number": 14,
     "rarity": "C",
     "image": "cPK_90_012960_00_KOIKING_C.webp",
-    "name": "Magikarp",
+    "name": {
+      "en": "Magikarp",
+      "fr": "Magicarpe"
+    },
     "packs": [
       "B Series Vol. 2"
     ]
@@ -123,7 +165,10 @@
     "number": 15,
     "rarity": "AR",
     "image": "cPK_90_011640_00_MERRIEP_AR.webp",
-    "name": "Mareep",
+    "name": {
+      "en": "Mareep",
+      "fr": "Wattouat"
+    },
     "packs": [
       "B Series Vol. 2"
     ]
@@ -133,7 +178,10 @@
     "number": 16,
     "rarity": "R",
     "image": "cPK_90_012140_00_WARUVIAL_R.webp",
-    "name": "Krookodile",
+    "name": {
+      "en": "Krookodile",
+      "fr": "Crocorible"
+    },
     "packs": [
       "B Series Vol. 2"
     ]
@@ -143,7 +191,10 @@
     "number": 17,
     "rarity": "C",
     "image": "cPK_90_012970_00_TYLTTO_C.webp",
-    "name": "Swablu",
+    "name": {
+      "en": "Swablu",
+      "fr": "Tylton"
+    },
     "packs": [
       "B Series Vol. 2"
     ]
@@ -153,21 +204,30 @@
     "number": 18,
     "rarity": "R",
     "image": "cPK_90_013030_00_ELEZARD_R.webp",
-    "name": "Heliolisk"
+    "name": {
+      "en": "Heliolisk",
+      "fr": "Iguolta"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 19,
     "rarity": "R",
     "image": "cPK_90_013040_00_MIMIROL_R.webp",
-    "name": "Buneary"
+    "name": {
+      "en": "Buneary",
+      "fr": "Laporeille"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 20,
     "rarity": "C",
     "image": "cPK_90_012980_00_LIZARDO_C.webp",
-    "name": "Charmeleon",
+    "name": {
+      "en": "Charmeleon",
+      "fr": "Reptincel"
+    },
     "packs": [
       "B Series Vol. 3"
     ]
@@ -177,7 +237,10 @@
     "number": 21,
     "rarity": "C",
     "image": "cPK_90_012990_00_IWARK_C.webp",
-    "name": "Onix",
+    "name": {
+      "en": "Onix",
+      "fr": "Onix"
+    },
     "packs": [
       "B Series Vol. 3"
     ]
@@ -187,7 +250,10 @@
     "number": 22,
     "rarity": "C",
     "image": "cPK_90_013000_00_LUCHABULL_C.webp",
-    "name": "Hawlucha",
+    "name": {
+      "en": "Hawlucha",
+      "fr": "Brutalibré"
+    },
     "packs": [
       "B Series Vol. 3"
     ]
@@ -197,7 +263,10 @@
     "number": 23,
     "rarity": "R",
     "image": "cPK_90_013010_00_GENESECT_R.webp",
-    "name": "Genesect",
+    "name": {
+      "en": "Genesect",
+      "fr": "Genesect"
+    },
     "packs": [
       "B Series Vol. 3"
     ]
@@ -207,7 +276,10 @@
     "number": 24,
     "rarity": "RR",
     "image": "cPK_90_013020_00_MEGALATIOSex_RR.webp",
-    "name": "Mega Latios ex",
+    "name": {
+      "en": "Mega Latios ex",
+      "fr": "Méga-Latios-ex"
+    },
     "packs": [
       "B Series Vol. 3"
     ]
@@ -217,14 +289,20 @@
     "number": 25,
     "rarity": "AR",
     "image": "cPK_90_011880_00_JIRACHI_AR.webp",
-    "name": "Jirachi"
+    "name": {
+      "en": "Jirachi",
+      "fr": "Jirachi"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 26,
     "rarity": "C",
     "image": "cPK_90_015950_00_MIZUGOROU_C.webp",
-    "name": "Mudkip",
+    "name": {
+      "en": "Mudkip",
+      "fr": "Gobou"
+    },
     "packs": [
       "B Series Vol. 4"
     ]
@@ -234,7 +312,10 @@
     "number": 27,
     "rarity": "C",
     "image": "cPK_90_014180_00_PRASLE_C.webp",
-    "name": "Plusle",
+    "name": {
+      "en": "Plusle",
+      "fr": "Posipi"
+    },
     "packs": [
       "B Series Vol. 4"
     ]
@@ -244,7 +325,10 @@
     "number": 28,
     "rarity": "C",
     "image": "cPK_90_015960_00_RALTS_C.webp",
-    "name": "Ralts",
+    "name": {
+      "en": "Ralts",
+      "fr": "Tarsal"
+    },
     "packs": [
       "B Series Vol. 4"
     ]
@@ -254,7 +338,10 @@
     "number": 29,
     "rarity": "RR",
     "image": "cPK_90_015970_00_MEGACHAREMex_RR.webp",
-    "name": "Mega Medicham ex",
+    "name": {
+      "en": "Mega Medicham ex",
+      "fr": "Méga-Charmina-ex"
+    },
     "packs": [
       "B Series Vol. 4"
     ]
@@ -264,7 +351,10 @@
     "number": 30,
     "rarity": "R",
     "image": "cPK_90_015040_00_TORNELOS_R.webp",
-    "name": "Tornadus",
+    "name": {
+      "en": "Tornadus",
+      "fr": "Boréas"
+    },
     "packs": [
       "B Series Vol. 4"
     ]
@@ -274,28 +364,40 @@
     "number": 31,
     "rarity": "R",
     "image": "cPK_90_013920_00_ACEBURN_R.webp",
-    "name": "Cinderace"
+    "name": {
+      "en": "Cinderace",
+      "fr": "Pyrobut"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 32,
     "rarity": "R",
     "image": "cPK_90_013940_00_ALOLAROKON_R.webp",
-    "name": "Alolan Vulpix"
+    "name": {
+      "en": "Alolan Vulpix",
+      "fr": "Goupix d'Alola"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 33,
     "rarity": "AR",
     "image": "cPK_90_015310_00_KUWASSU_AR.webp",
-    "name": "Quaxly"
+    "name": {
+      "en": "Quaxly",
+      "fr": "Coiffeton"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 34,
     "rarity": "C",
     "image": "cPK_90_015980_00_MINIVE_C.webp",
-    "name": "Smoliv",
+    "name": {
+      "en": "Smoliv",
+      "fr": "Olivini"
+    },
     "packs": [
       "B Series Vol. 5"
     ]
@@ -305,7 +407,10 @@
     "number": 35,
     "rarity": "AR",
     "image": "cPK_90_015280_00_CARBOU_AR.webp",
-    "name": "Charcadet",
+    "name": {
+      "en": "Charcadet",
+      "fr": "Charbambin"
+    },
     "packs": [
       "B Series Vol. 5"
     ]
@@ -315,7 +420,10 @@
     "number": 36,
     "rarity": "C",
     "image": "cPK_90_015420_00_SYARITATSU_C.webp",
-    "name": "Tatsugiri",
+    "name": {
+      "en": "Tatsugiri",
+      "fr": "Nigirigon"
+    },
     "packs": [
       "B Series Vol. 5"
     ]
@@ -325,7 +433,10 @@
     "number": 37,
     "rarity": "C",
     "image": "cPK_90_015990_00_SEBIE_C.webp",
-    "name": "Frigibax",
+    "name": {
+      "en": "Frigibax",
+      "fr": "Frigodo"
+    },
     "packs": [
       "B Series Vol. 5"
     ]
@@ -335,7 +446,10 @@
     "number": 38,
     "rarity": "R",
     "image": "cPK_90_015830_00_DEKANUCHAN_R.webp",
-    "name": "Tinkaton",
+    "name": {
+      "en": "Tinkaton",
+      "fr": "Forgelina"
+    },
     "packs": [
       "B Series Vol. 5"
     ]
@@ -345,28 +459,40 @@
     "number": 39,
     "rarity": "R",
     "image": "cPK_90_015470_00_PAMO_R.webp",
-    "name": "Pawmi"
+    "name": {
+      "en": "Pawmi",
+      "fr": "Pohm"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 40,
     "rarity": "R",
     "image": "cPK_90_015740_00_PALDEADOOH_R.webp",
-    "name": "Paldean Clodsire"
+    "name": {
+      "en": "Paldean Clodsire",
+      "fr": "Terraiste de Paldea"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 41,
     "rarity": "RR",
     "image": "cPK_90_015460_00_PAOJIANex_RR.webp",
-    "name": "Chien-Pao ex"
+    "name": {
+      "en": "Chien-Pao ex",
+      "fr": "Baojian-ex"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 42,
     "rarity": "AR",
     "image": "cPK_90_016000_00_YADON_AR.webp",
-    "name": "Slowpoke",
+    "name": {
+      "en": "Slowpoke",
+      "fr": "Ramoloss"
+    },
     "packs": [
       "B Series Vol. 6"
     ]
@@ -376,7 +502,10 @@
     "number": 43,
     "rarity": "C",
     "image": "cPK_90_016010_00_RAKURAI_C.webp",
-    "name": "Electrike",
+    "name": {
+      "en": "Electrike",
+      "fr": "Dynavolt"
+    },
     "packs": [
       "B Series Vol. 6"
     ]
@@ -386,7 +515,10 @@
     "number": 44,
     "rarity": "C",
     "image": "cPK_90_016020_00_BURORON_C.webp",
-    "name": "Varoom",
+    "name": {
+      "en": "Varoom",
+      "fr": "Vrombi"
+    },
     "packs": [
       "B Series Vol. 6"
     ]
@@ -396,7 +528,10 @@
     "number": 45,
     "rarity": "R",
     "image": "cPK_90_016030_00_ONONOKUS_R.webp",
-    "name": "Haxorus",
+    "name": {
+      "en": "Haxorus",
+      "fr": "Tranchodon"
+    },
     "packs": [
       "B Series Vol. 6"
     ]
@@ -406,7 +541,10 @@
     "number": 46,
     "rarity": "C",
     "image": "cPK_90_016040_00_PERAP_C.webp",
-    "name": "Chatot",
+    "name": {
+      "en": "Chatot",
+      "fr": "Pijako"
+    },
     "packs": [
       "B Series Vol. 6"
     ]
@@ -416,28 +554,40 @@
     "number": 47,
     "rarity": "R",
     "image": "cPK_90_016050_00_GHOS_R.webp",
-    "name": "Gastly"
+    "name": {
+      "en": "Gastly",
+      "fr": "Fantominus"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 48,
     "rarity": "R",
     "image": "cPK_90_016060_00_PUKURIN_R.webp",
-    "name": "Wigglytuff"
+    "name": {
+      "en": "Wigglytuff",
+      "fr": "Grodoudou"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 49,
     "rarity": "AR",
     "image": "cPK_90_016900_00_VICTINI_AR.webp",
-    "name": "Victini"
+    "name": {
+      "en": "Victini",
+      "fr": "Victini"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 50,
     "rarity": "U",
     "image": "cPK_90_014360_00_MELOETTA_U.webp",
-    "name": "Meloetta",
+    "name": {
+      "en": "Meloetta",
+      "fr": "Meloetta"
+    },
     "packs": [
       "B Series Vol. 7"
     ]
@@ -447,7 +597,10 @@
     "number": 51,
     "rarity": "C",
     "image": "cPK_90_018860_00_ZYGARDE10%EF%BC%85FORME_C.webp",
-    "name": "Zygarde",
+    "name": {
+      "en": "Zygarde",
+      "fr": "Zygarde"
+    },
     "packs": [
       "B Series Vol. 7"
     ]
@@ -457,7 +610,10 @@
     "number": 52,
     "rarity": "R",
     "image": "cPK_90_018870_00_ZYGARDE50%EF%BC%85FORME_R.webp",
-    "name": "Zygarde",
+    "name": {
+      "en": "Zygarde",
+      "fr": "Zygarde"
+    },
     "packs": [
       "B Series Vol. 7"
     ]
@@ -467,7 +623,10 @@
     "number": 53,
     "rarity": "RR",
     "image": "cPK_90_018880_00_ZYGARDEPERFECTFORMEex_RR.webp",
-    "name": "Zygarde ex",
+    "name": {
+      "en": "Zygarde ex",
+      "fr": "Zygarde-ex"
+    },
     "packs": [
       "B Series Vol. 7"
     ]
@@ -477,7 +636,10 @@
     "number": 54,
     "rarity": "C",
     "image": "cPK_90_012660_01_EIEVUI_C.webp",
-    "name": "Eevee",
+    "name": {
+      "en": "Eevee",
+      "fr": "Évoli"
+    },
     "packs": [
       "B Series Vol. 7"
     ]
@@ -487,14 +649,20 @@
     "number": 55,
     "rarity": "SR",
     "image": "cPK_90_018880_01_ZYGARDEPERFECTFORMEex_SR.webp",
-    "name": "Zygarde ex"
+    "name": {
+      "en": "Zygarde ex",
+      "fr": "Zygarde-ex"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 56,
     "rarity": "RR",
     "image": "cPK_90_018900_00_MEGAHERACROSex_RR.webp",
-    "name": "Mega Heracross ex",
+    "name": {
+      "en": "Mega Heracross ex",
+      "fr": "Méga-Scarhino-ex"
+    },
     "packs": [
       "B Series Vol. 8"
     ]
@@ -504,7 +672,10 @@
     "number": 57,
     "rarity": "C",
     "image": "cPK_90_016890_00_POWALENTAIYOUNOSUGATA_C.webp",
-    "name": "Castform Sunny Form",
+    "name": {
+      "en": "Castform Sunny Form",
+      "fr": "Morphéo Forme Solaire"
+    },
     "packs": [
       "B Series Vol. 8"
     ]
@@ -514,7 +685,10 @@
     "number": 58,
     "rarity": "C",
     "image": "cPK_90_018910_00_POKABU_C.webp",
-    "name": "Tepig",
+    "name": {
+      "en": "Tepig",
+      "fr": "Gruikui"
+    },
     "packs": [
       "B Series Vol. 8"
     ]
@@ -524,7 +698,10 @@
     "number": 59,
     "rarity": "C",
     "image": "cPK_90_018920_00_ISHIZUMAI_C.webp",
-    "name": "Dwebble",
+    "name": {
+      "en": "Dwebble",
+      "fr": "Crabicoque"
+    },
     "packs": [
       "B Series Vol. 8"
     ]
@@ -534,7 +711,10 @@
     "number": 60,
     "rarity": "R",
     "image": "cPK_90_017790_00_ZARUDE_R.webp",
-    "name": "Zarude",
+    "name": {
+      "en": "Zarude",
+      "fr": "Zarude"
+    },
     "packs": [
       "B Series Vol. 8"
     ]
@@ -544,28 +724,40 @@
     "number": 61,
     "rarity": "R",
     "image": "cPK_90_016700_00_KIMORI_R.webp",
-    "name": "Treecko"
+    "name": {
+      "en": "Treecko",
+      "fr": "Arcko"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 62,
     "rarity": "R",
     "image": "cPK_90_017490_00_ERUREIDO_R.webp",
-    "name": "Gallade"
+    "name": {
+      "en": "Gallade",
+      "fr": "Gallame"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 63,
     "rarity": "RR",
     "image": "cPK_90_015120_00_MASQUERNYAex_RR.webp",
-    "name": "Meowscarada ex"
+    "name": {
+      "en": "Meowscarada ex",
+      "fr": "Miascarade-ex"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 64,
     "rarity": "C",
     "image": "cPK_90_018930_00_CARBOU_C.webp",
-    "name": "Charcadet",
+    "name": {
+      "en": "Charcadet",
+      "fr": "Charbambin"
+    },
     "packs": [
       "B Series Vol. 9"
     ]
@@ -575,7 +767,10 @@
     "number": 65,
     "rarity": "C",
     "image": "cPK_90_018230_00_SHOWERS_C.webp",
-    "name": "Vaporeon",
+    "name": {
+      "en": "Vaporeon",
+      "fr": "Aquali"
+    },
     "packs": [
       "B Series Vol. 9"
     ]
@@ -585,7 +780,10 @@
     "number": 66,
     "rarity": "RR",
     "image": "cPK_90_018940_00_SOUBLADESex_RR.webp",
-    "name": "Ceruledge ex",
+    "name": {
+      "en": "Ceruledge ex",
+      "fr": "Malvalame-ex"
+    },
     "packs": [
       "B Series Vol. 9"
     ]
@@ -595,7 +793,10 @@
     "number": 67,
     "rarity": "C",
     "image": "cPK_90_018950_00_KOMATANA_C.webp",
-    "name": "Pawniard",
+    "name": {
+      "en": "Pawniard",
+      "fr": "Scalpion"
+    },
     "packs": [
       "B Series Vol. 9"
     ]
@@ -605,7 +806,10 @@
     "number": 68,
     "rarity": "R",
     "image": "cPK_90_018750_00_NOKOKOCCHI_R.webp",
-    "name": "Dudunsparce",
+    "name": {
+      "en": "Dudunsparce",
+      "fr": "Deusolourdo"
+    },
     "packs": [
       "B Series Vol. 9"
     ]
@@ -615,28 +819,40 @@
     "number": 69,
     "rarity": "R",
     "image": "cPK_90_015110_00_NYAROTE_R.webp",
-    "name": "Floragato"
+    "name": {
+      "en": "Floragato",
+      "fr": "Matourgeon"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 70,
     "rarity": "R",
     "image": "cPK_90_018550_00_YAMIRAMI_R.webp",
-    "name": "Sableye"
+    "name": {
+      "en": "Sableye",
+      "fr": "Ténéfix"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 71,
     "rarity": "AR",
     "image": "cPK_90_019030_00_KODUCK_AR.webp",
-    "name": "Psyduck"
+    "name": {
+      "en": "Psyduck",
+      "fr": "Psykokwak"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 72,
     "rarity": "C",
     "image": "cPK_90_018960_00_HINBASS_C.webp",
-    "name": "Feebas",
+    "name": {
+      "en": "Feebas",
+      "fr": "Barpau"
+    },
     "packs": [
       "B Series Vol. 10"
     ]
@@ -646,7 +862,10 @@
     "number": 73,
     "rarity": "R",
     "image": "cPK_90_018970_00_YUKIMENOKO_R.webp",
-    "name": "Froslass",
+    "name": {
+      "en": "Froslass",
+      "fr": "Momartik"
+    },
     "packs": [
       "B Series Vol. 10"
     ]
@@ -656,7 +875,10 @@
     "number": 74,
     "rarity": "U",
     "image": "cPK_90_018980_00_RAICHU_U.webp",
-    "name": "Raichu",
+    "name": {
+      "en": "Raichu",
+      "fr": "Raichu"
+    },
     "packs": [
       "B Series Vol. 10"
     ]
@@ -666,7 +888,10 @@
     "number": 75,
     "rarity": "C",
     "image": "cPK_90_018990_00_NUOH_C.webp",
-    "name": "Quagsire",
+    "name": {
+      "en": "Quagsire",
+      "fr": "Maraiste"
+    },
     "packs": [
       "B Series Vol. 10"
     ]
@@ -676,7 +901,10 @@
     "number": 76,
     "rarity": "AR",
     "image": "cPK_90_019000_00_HISUIZORUA_AR.webp",
-    "name": "Hisuian Zorua",
+    "name": {
+      "en": "Hisuian Zorua",
+      "fr": "Zorua de Hisui"
+    },
     "packs": [
       "B Series Vol. 10"
     ]
@@ -686,13 +914,19 @@
     "number": 77,
     "rarity": "R",
     "image": "cPK_90_019010_00_GARDIE_R.webp",
-    "name": "Growlithe"
+    "name": {
+      "en": "Growlithe",
+      "fr": "Caninos"
+    }
   },
   {
     "set": "PROMO-B",
     "number": 78,
     "rarity": "R",
     "image": "cPK_90_019020_00_EMOLGA_R.webp",
-    "name": "Emolga"
+    "name": {
+      "en": "Emolga",
+      "fr": "Emolga"
+    }
   }
 ]


### PR DESCRIPTION
Add French translation for sets:
* A1  - Genetic Apex
* A1a - Mythical Island
* A2 - Space-Time Smackdown
* A2a - Triumphant Light
* A2b - Shining Revelry
* A3 - Celestial Guardians
* A3a - Extradimensional Crisis
* A3b - Eevee Grove
* A4 - Wisdom of Sea and Sky
* A4a - Secluded Springs
* A4b - Deluxe Pack: ex