### PR TITLE
Add additional attributes

### DIFF
--- a/dist/cards.json
+++ b/dist/cards.json
@@ -5,7 +5,8 @@
     "rarity": "C",
     "name": "Bulbasaur",
     "image": "cPK_10_000010_00_FUSHIGIDANE_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -13,7 +14,8 @@
     "rarity": "U",
     "name": "Ivysaur",
     "image": "cPK_10_000020_00_FUSHIGISOU_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -21,7 +23,8 @@
     "rarity": "R",
     "name": "Venusaur",
     "image": "cPK_10_000030_00_FUSHIGIBANA_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -29,7 +32,8 @@
     "rarity": "RR",
     "name": "Venusaur ex",
     "image": "cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -37,7 +41,8 @@
     "rarity": "C",
     "name": "Caterpie",
     "image": "cPK_10_000050_00_CATERPIE_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -45,7 +50,8 @@
     "rarity": "C",
     "name": "Metapod",
     "image": "cPK_10_000060_00_TRANSEL_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -53,7 +59,8 @@
     "rarity": "R",
     "name": "Butterfree",
     "image": "cPK_10_000070_00_BUTTERFREE_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -61,7 +68,8 @@
     "rarity": "C",
     "name": "Weedle",
     "image": "cPK_10_000080_00_BEEDLE_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -69,7 +77,8 @@
     "rarity": "C",
     "name": "Kakuna",
     "image": "cPK_10_000090_00_COCOON_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -77,7 +86,8 @@
     "rarity": "R",
     "name": "Beedrill",
     "image": "cPK_10_000100_00_SPEAR_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -85,7 +95,8 @@
     "rarity": "C",
     "name": "Oddish",
     "image": "cPK_10_000110_00_NAZONOKUSA_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -93,7 +104,8 @@
     "rarity": "U",
     "name": "Gloom",
     "image": "cPK_10_000120_00_KUSAIHANA_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -101,7 +113,8 @@
     "rarity": "R",
     "name": "Vileplume",
     "image": "cPK_10_000130_00_RUFFRESIA_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -109,7 +122,8 @@
     "rarity": "C",
     "name": "Paras",
     "image": "cPK_10_000140_00_PARAS_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -117,7 +131,8 @@
     "rarity": "U",
     "name": "Parasect",
     "image": "cPK_10_000150_00_PARASECT_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -125,7 +140,8 @@
     "rarity": "C",
     "name": "Venonat",
     "image": "cPK_10_000160_00_KONGPANG_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -133,7 +149,8 @@
     "rarity": "U",
     "name": "Venomoth",
     "image": "cPK_10_000170_00_MORPHON_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -141,7 +158,8 @@
     "rarity": "C",
     "name": "Bellsprout",
     "image": "cPK_10_000180_00_MADATSUBOMI_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -149,7 +167,8 @@
     "rarity": "U",
     "name": "Weepinbell",
     "image": "cPK_10_000190_00_UTSUDON_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -157,7 +176,8 @@
     "rarity": "R",
     "name": "Victreebel",
     "image": "cPK_10_000200_00_UTSUBOT_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -165,7 +185,8 @@
     "rarity": "C",
     "name": "Exeggcute",
     "image": "cPK_10_000210_00_TAMATAMA_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -173,7 +194,8 @@
     "rarity": "R",
     "name": "Exeggutor",
     "image": "cPK_10_000220_00_NASSY_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -181,7 +203,8 @@
     "rarity": "RR",
     "name": "Exeggutor ex",
     "image": "cPK_10_000230_00_NASSYex_RR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -189,7 +212,8 @@
     "rarity": "C",
     "name": "Tangela",
     "image": "cPK_10_000240_00_MONJARA_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -197,7 +221,8 @@
     "rarity": "C",
     "name": "Scyther",
     "image": "cPK_10_000250_00_STRIKE_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -205,7 +230,8 @@
     "rarity": "U",
     "name": "Pinsir",
     "image": "cPK_10_000260_00_KAILIOS_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -213,7 +239,8 @@
     "rarity": "C",
     "name": "Cottonee",
     "image": "cPK_10_000270_00_MONMEN_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -221,7 +248,8 @@
     "rarity": "U",
     "name": "Whimsicott",
     "image": "cPK_10_000280_00_ELFUUN_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -229,7 +257,8 @@
     "rarity": "C",
     "name": "Petilil",
     "image": "cPK_10_000290_00_CHURINE_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -237,7 +266,8 @@
     "rarity": "U",
     "name": "Lilligant",
     "image": "cPK_10_000300_00_DREDEAR_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -245,7 +275,8 @@
     "rarity": "C",
     "name": "Skiddo",
     "image": "cPK_10_000310_00_MEECLE_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -253,7 +284,8 @@
     "rarity": "C",
     "name": "Gogoat",
     "image": "cPK_10_000320_00_GOGOAT_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -261,7 +293,8 @@
     "rarity": "C",
     "name": "Charmander",
     "image": "cPK_10_000330_00_HITOKAGE_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -269,7 +302,8 @@
     "rarity": "U",
     "name": "Charmeleon",
     "image": "cPK_10_000340_00_LIZARDO_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -277,7 +311,8 @@
     "rarity": "R",
     "name": "Charizard",
     "image": "cPK_10_000350_00_LIZARDON_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -285,7 +320,8 @@
     "rarity": "RR",
     "name": "Charizard ex",
     "image": "cPK_10_000360_00_LIZARDONex_RR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -293,7 +329,8 @@
     "rarity": "C",
     "name": "Vulpix",
     "image": "cPK_10_000370_00_ROKON_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -301,7 +338,8 @@
     "rarity": "U",
     "name": "Ninetales",
     "image": "cPK_10_000380_00_KYUKON_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -309,7 +347,8 @@
     "rarity": "C",
     "name": "Growlithe",
     "image": "cPK_10_000390_00_GARDIE_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -317,7 +356,8 @@
     "rarity": "R",
     "name": "Arcanine",
     "image": "cPK_10_000400_00_WINDIE_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -325,7 +365,8 @@
     "rarity": "RR",
     "name": "Arcanine ex",
     "image": "cPK_10_000410_00_WINDIEex_RR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -333,7 +374,8 @@
     "rarity": "C",
     "name": "Ponyta",
     "image": "cPK_10_000420_00_PONYTA_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -341,7 +383,8 @@
     "rarity": "U",
     "name": "Rapidash",
     "image": "cPK_10_000430_00_GALLOP_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -349,7 +392,8 @@
     "rarity": "C",
     "name": "Magmar",
     "image": "cPK_10_000440_00_BOOBER_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -357,7 +401,8 @@
     "rarity": "R",
     "name": "Flareon",
     "image": "cPK_10_000450_00_BOOSTER_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -365,7 +410,8 @@
     "rarity": "R",
     "name": "Moltres",
     "image": "cPK_10_000460_00_FIRE_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -373,7 +419,8 @@
     "rarity": "RR",
     "name": "Moltres ex",
     "image": "cPK_10_000470_00_FIREex_RR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -381,7 +428,8 @@
     "rarity": "C",
     "name": "Heatmor",
     "image": "cPK_10_000480_00_KUITARAN_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -389,7 +437,8 @@
     "rarity": "C",
     "name": "Salandit",
     "image": "cPK_10_000490_00_YATOUMORI_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -397,7 +446,8 @@
     "rarity": "C",
     "name": "Salazzle",
     "image": "cPK_10_000500_00_ENNEWT_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -405,7 +455,8 @@
     "rarity": "C",
     "name": "Sizzlipede",
     "image": "cPK_10_000510_00_YAKUDE_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -413,7 +464,8 @@
     "rarity": "U",
     "name": "Centiskorch",
     "image": "cPK_10_000520_00_MARUYAKUDE_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -421,7 +473,8 @@
     "rarity": "C",
     "name": "Squirtle",
     "image": "cPK_10_000530_00_ZENIGAME_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -429,7 +482,8 @@
     "rarity": "U",
     "name": "Wartortle",
     "image": "cPK_10_000540_00_KAMEIL_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -437,7 +491,8 @@
     "rarity": "R",
     "name": "Blastoise",
     "image": "cPK_10_000550_00_KAMEX_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -445,7 +500,8 @@
     "rarity": "RR",
     "name": "Blastoise ex",
     "image": "cPK_10_000560_00_KAMEXex_RR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -453,7 +509,8 @@
     "rarity": "C",
     "name": "Psyduck",
     "image": "cPK_10_000570_00_KODUCK_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -461,7 +518,8 @@
     "rarity": "U",
     "name": "Golduck",
     "image": "cPK_10_000580_00_GOLDUCK_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -469,7 +527,8 @@
     "rarity": "C",
     "name": "Poliwag",
     "image": "cPK_10_000590_00_NYOROMO_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -477,7 +536,8 @@
     "rarity": "U",
     "name": "Poliwhirl",
     "image": "cPK_10_000600_00_NYOROZO_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -485,7 +545,8 @@
     "rarity": "R",
     "name": "Poliwrath",
     "image": "cPK_10_000610_00_NYOROBON_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -493,7 +554,8 @@
     "rarity": "C",
     "name": "Tentacool",
     "image": "cPK_10_000620_00_MENOKURAGE_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -501,7 +563,8 @@
     "rarity": "U",
     "name": "Tentacruel",
     "image": "cPK_10_000630_00_DOKUKURAGE_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -509,7 +572,8 @@
     "rarity": "C",
     "name": "Seel",
     "image": "cPK_10_000640_00_PAWOU_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -517,7 +581,8 @@
     "rarity": "U",
     "name": "Dewgong",
     "image": "cPK_10_000650_00_JUGON_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -525,7 +590,8 @@
     "rarity": "C",
     "name": "Shellder",
     "image": "cPK_10_000660_00_SHELLDER_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -533,7 +599,8 @@
     "rarity": "U",
     "name": "Cloyster",
     "image": "cPK_10_000670_00_PARSHEN_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -541,7 +608,8 @@
     "rarity": "C",
     "name": "Krabby",
     "image": "cPK_10_000680_00_CRAB_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -549,7 +617,8 @@
     "rarity": "U",
     "name": "Kingler",
     "image": "cPK_10_000690_00_KINGLER_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -557,7 +626,8 @@
     "rarity": "C",
     "name": "Horsea",
     "image": "cPK_10_000700_00_TATTU_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -565,7 +635,8 @@
     "rarity": "U",
     "name": "Seadra",
     "image": "cPK_10_000710_00_SEADRA_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -573,7 +644,8 @@
     "rarity": "C",
     "name": "Goldeen",
     "image": "cPK_10_000720_00_TOSAKINTO_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -581,7 +653,8 @@
     "rarity": "C",
     "name": "Seaking",
     "image": "cPK_10_000730_00_AZUMAO_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -589,7 +662,8 @@
     "rarity": "C",
     "name": "Staryu",
     "image": "cPK_10_000740_00_HITODEMAN_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -597,7 +671,8 @@
     "rarity": "U",
     "name": "Starmie",
     "image": "cPK_10_000750_00_STARMIE_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -605,7 +680,8 @@
     "rarity": "RR",
     "name": "Starmie ex",
     "image": "cPK_10_000760_00_STARMIEex_RR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -613,7 +689,8 @@
     "rarity": "C",
     "name": "Magikarp",
     "image": "cPK_10_000770_00_KOIKING_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -621,7 +698,8 @@
     "rarity": "R",
     "name": "Gyarados",
     "image": "cPK_10_000780_00_GYARADOS_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -629,7 +707,8 @@
     "rarity": "R",
     "name": "Lapras",
     "image": "cPK_10_000790_00_LAPLACE_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -637,7 +716,8 @@
     "rarity": "R",
     "name": "Vaporeon",
     "image": "cPK_10_000800_00_SHOWERS_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -645,7 +725,8 @@
     "rarity": "U",
     "name": "Omanyte",
     "image": "cPK_10_000810_00_OMNITE_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -653,7 +734,8 @@
     "rarity": "R",
     "name": "Omastar",
     "image": "cPK_10_000820_00_OMSTAR_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -661,7 +743,8 @@
     "rarity": "R",
     "name": "Articuno",
     "image": "cPK_10_000830_00_FREEZER_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -669,7 +752,8 @@
     "rarity": "RR",
     "name": "Articuno ex",
     "image": "cPK_10_000840_00_FREEZERex_RR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -677,7 +761,8 @@
     "rarity": "C",
     "name": "Ducklett",
     "image": "cPK_10_000850_00_KOARUHIE_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -685,7 +770,8 @@
     "rarity": "U",
     "name": "Swanna",
     "image": "cPK_10_000860_00_SWANNA_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -693,7 +779,8 @@
     "rarity": "C",
     "name": "Froakie",
     "image": "cPK_10_000870_00_KEROMATSU_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -701,7 +788,8 @@
     "rarity": "U",
     "name": "Frogadier",
     "image": "cPK_10_000880_00_GEKOGASHIRA_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -709,7 +797,8 @@
     "rarity": "R",
     "name": "Greninja",
     "image": "cPK_10_000890_00_GEKKOUGA_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -717,7 +806,8 @@
     "rarity": "C",
     "name": "Pyukumuku",
     "image": "cPK_10_000900_00_NAMAKOBUSHI_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -725,7 +815,8 @@
     "rarity": "U",
     "name": "Bruxish",
     "image": "cPK_10_000910_00_HAGIGISHIRI_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -733,7 +824,8 @@
     "rarity": "C",
     "name": "Snom",
     "image": "cPK_10_000920_00_YUKIHAMI_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -741,7 +833,8 @@
     "rarity": "U",
     "name": "Frosmoth",
     "image": "cPK_10_000930_00_MOTHNOW_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -749,7 +842,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_10_000940_00_PIKACHU_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -757,7 +851,8 @@
     "rarity": "R",
     "name": "Raichu",
     "image": "cPK_10_000950_00_RAICHU_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -765,7 +860,8 @@
     "rarity": "RR",
     "name": "Pikachu ex",
     "image": "cPK_10_000960_00_PIKACHUex_RR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -773,7 +869,8 @@
     "rarity": "C",
     "name": "Magnemite",
     "image": "cPK_10_000970_00_COIL_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -781,7 +878,8 @@
     "rarity": "R",
     "name": "Magneton",
     "image": "cPK_10_000980_00_RARECOIL_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -789,7 +887,8 @@
     "rarity": "C",
     "name": "Voltorb",
     "image": "cPK_10_000990_00_BIRIRIDAMA_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -797,7 +896,8 @@
     "rarity": "U",
     "name": "Electrode",
     "image": "cPK_10_001000_00_MARUMINE_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -805,7 +905,8 @@
     "rarity": "C",
     "name": "Electabuzz",
     "image": "cPK_10_001010_00_ELEBOO_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -813,7 +914,8 @@
     "rarity": "R",
     "name": "Jolteon",
     "image": "cPK_10_001020_00_THUNDERS_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -821,7 +923,8 @@
     "rarity": "R",
     "name": "Zapdos",
     "image": "cPK_10_001030_00_THUNDER_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -829,7 +932,8 @@
     "rarity": "RR",
     "name": "Zapdos ex",
     "image": "cPK_10_001040_00_THUNDERex_RR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -837,7 +941,8 @@
     "rarity": "C",
     "name": "Blitzle",
     "image": "cPK_10_001050_00_SHIMAMA_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -845,7 +950,8 @@
     "rarity": "U",
     "name": "Zebstrika",
     "image": "cPK_10_001060_00_ZEBRAIKA_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -853,7 +959,8 @@
     "rarity": "C",
     "name": "Tynamo",
     "image": "cPK_10_001070_00_SHIBISHIRASU_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -861,7 +968,8 @@
     "rarity": "U",
     "name": "Eelektrik",
     "image": "cPK_10_001080_00_SHIBIBEEL_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -869,7 +977,8 @@
     "rarity": "R",
     "name": "Eelektross",
     "image": "cPK_10_001090_00_SHIBIRUDON_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -877,7 +986,8 @@
     "rarity": "C",
     "name": "Helioptile",
     "image": "cPK_10_001100_00_ERIKITERU_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -885,7 +995,8 @@
     "rarity": "C",
     "name": "Heliolisk",
     "image": "cPK_10_001110_00_ELEZARD_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -893,7 +1004,8 @@
     "rarity": "U",
     "name": "Pincurchin",
     "image": "cPK_10_001120_00_BACHINUNI_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -901,7 +1013,8 @@
     "rarity": "C",
     "name": "Clefairy",
     "image": "cPK_10_001130_00_PIPPI_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -909,7 +1022,8 @@
     "rarity": "U",
     "name": "Clefable",
     "image": "cPK_10_001140_00_PIXY_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -917,7 +1031,8 @@
     "rarity": "C",
     "name": "Abra",
     "image": "cPK_10_001150_00_CASEY_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -925,7 +1040,8 @@
     "rarity": "U",
     "name": "Kadabra",
     "image": "cPK_10_001160_00_YUNGERER_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -933,7 +1049,8 @@
     "rarity": "R",
     "name": "Alakazam",
     "image": "cPK_10_001170_00_FOODIN_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -941,7 +1058,8 @@
     "rarity": "C",
     "name": "Slowpoke",
     "image": "cPK_10_001180_00_YADON_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -949,7 +1067,8 @@
     "rarity": "U",
     "name": "Slowbro",
     "image": "cPK_10_001190_00_YADORAN_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -957,7 +1076,8 @@
     "rarity": "C",
     "name": "Gastly",
     "image": "cPK_10_001200_00_GHOS_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -965,7 +1085,8 @@
     "rarity": "U",
     "name": "Haunter",
     "image": "cPK_10_001210_00_GHOST_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -973,7 +1094,8 @@
     "rarity": "R",
     "name": "Gengar",
     "image": "cPK_10_001220_00_GANGAR_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -981,7 +1103,8 @@
     "rarity": "RR",
     "name": "Gengar ex",
     "image": "cPK_10_001230_00_GANGARex_RR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -989,7 +1112,8 @@
     "rarity": "C",
     "name": "Drowzee",
     "image": "cPK_10_001240_00_SLEEPE_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -997,7 +1121,8 @@
     "rarity": "R",
     "name": "Hypno",
     "image": "cPK_10_001250_00_SLEEPER_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1005,7 +1130,8 @@
     "rarity": "U",
     "name": "Mr. Mime",
     "image": "cPK_10_001260_00_BARRIERD_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1013,7 +1139,8 @@
     "rarity": "C",
     "name": "Jynx",
     "image": "cPK_10_001270_00_ROUGELA_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1021,7 +1148,8 @@
     "rarity": "R",
     "name": "Mewtwo",
     "image": "cPK_10_001280_00_MEWTWO_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1029,7 +1157,8 @@
     "rarity": "RR",
     "name": "Mewtwo ex",
     "image": "cPK_10_001290_00_MEWTWOex_RR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1037,7 +1166,8 @@
     "rarity": "C",
     "name": "Ralts",
     "image": "cPK_10_001300_00_RALTS_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1045,7 +1175,8 @@
     "rarity": "U",
     "name": "Kirlia",
     "image": "cPK_10_001310_00_KIRLIA_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1053,7 +1184,8 @@
     "rarity": "R",
     "name": "Gardevoir",
     "image": "cPK_10_001320_00_SIRNIGHT_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1061,7 +1193,8 @@
     "rarity": "C",
     "name": "Woobat",
     "image": "cPK_10_001330_00_KOROMORI_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1069,7 +1202,8 @@
     "rarity": "C",
     "name": "Swoobat",
     "image": "cPK_10_001340_00_KOKOROMORI_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1077,7 +1211,8 @@
     "rarity": "C",
     "name": "Golett",
     "image": "cPK_10_001350_00_GOBIT_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1085,7 +1220,8 @@
     "rarity": "U",
     "name": "Golurk",
     "image": "cPK_10_001360_00_GOLOOG_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1093,7 +1229,8 @@
     "rarity": "C",
     "name": "Sandshrew",
     "image": "cPK_10_001370_00_SAND_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1101,7 +1238,8 @@
     "rarity": "U",
     "name": "Sandslash",
     "image": "cPK_10_001380_00_SANDPAN_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1109,7 +1247,8 @@
     "rarity": "C",
     "name": "Diglett",
     "image": "cPK_10_001390_00_DIGDA_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1117,7 +1256,8 @@
     "rarity": "U",
     "name": "Dugtrio",
     "image": "cPK_10_001400_00_DUGTRIO_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1125,7 +1265,8 @@
     "rarity": "C",
     "name": "Mankey",
     "image": "cPK_10_001410_00_MANKEY_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1133,7 +1274,8 @@
     "rarity": "U",
     "name": "Primeape",
     "image": "cPK_10_001420_00_OKORIZARU_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1141,7 +1283,8 @@
     "rarity": "C",
     "name": "Machop",
     "image": "cPK_10_001430_00_WANRIKY_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1149,7 +1292,8 @@
     "rarity": "U",
     "name": "Machoke",
     "image": "cPK_10_001440_00_GORIKY_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1157,7 +1301,8 @@
     "rarity": "R",
     "name": "Machamp",
     "image": "cPK_10_001450_00_KAIRIKY_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1165,7 +1310,8 @@
     "rarity": "RR",
     "name": "Machamp ex",
     "image": "cPK_10_001460_00_KAIRIKYex_RR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1173,7 +1319,8 @@
     "rarity": "C",
     "name": "Geodude",
     "image": "cPK_10_001470_00_ISITSUBUTE_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1181,7 +1328,8 @@
     "rarity": "U",
     "name": "Graveler",
     "image": "cPK_10_001480_00_GOLONE_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1189,7 +1337,8 @@
     "rarity": "R",
     "name": "Golem",
     "image": "cPK_10_001490_00_GOLONYA_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1197,7 +1346,8 @@
     "rarity": "U",
     "name": "Onix",
     "image": "cPK_10_001500_00_IWARK_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1205,7 +1355,8 @@
     "rarity": "C",
     "name": "Cubone",
     "image": "cPK_10_001510_00_KARAKARA_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1213,7 +1364,8 @@
     "rarity": "U",
     "name": "Marowak",
     "image": "cPK_10_001520_00_GARAGARA_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1221,7 +1373,8 @@
     "rarity": "RR",
     "name": "Marowak ex",
     "image": "cPK_10_001530_00_GARAGARAex_RR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1229,7 +1382,8 @@
     "rarity": "C",
     "name": "Hitmonlee",
     "image": "cPK_10_001540_00_SAWAMULAR_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1237,7 +1391,8 @@
     "rarity": "C",
     "name": "Hitmonchan",
     "image": "cPK_10_001550_00_EBIWALAR_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1245,7 +1400,8 @@
     "rarity": "C",
     "name": "Rhyhorn",
     "image": "cPK_10_001560_00_SIHORN_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1253,7 +1409,8 @@
     "rarity": "U",
     "name": "Rhydon",
     "image": "cPK_10_001570_00_SIDON_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1261,7 +1418,8 @@
     "rarity": "U",
     "name": "Kabuto",
     "image": "cPK_10_001580_00_KABUTO_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1269,7 +1427,8 @@
     "rarity": "R",
     "name": "Kabutops",
     "image": "cPK_10_001590_00_KABUTOPS_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1277,7 +1436,8 @@
     "rarity": "C",
     "name": "Mienfoo",
     "image": "cPK_10_001600_00_KOJOFU_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1285,7 +1445,8 @@
     "rarity": "U",
     "name": "Mienshao",
     "image": "cPK_10_001610_00_KOJONDO_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1293,7 +1454,8 @@
     "rarity": "C",
     "name": "Clobbopus",
     "image": "cPK_10_001620_00_TATAKKO_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1301,7 +1463,8 @@
     "rarity": "U",
     "name": "Grapploct",
     "image": "cPK_10_001630_00_OTOSUPUS_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1309,7 +1472,8 @@
     "rarity": "C",
     "name": "Ekans",
     "image": "cPK_10_001640_00_ARBO_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1317,15 +1481,17 @@
     "rarity": "U",
     "name": "Arbok",
     "image": "cPK_10_001650_00_ARBOK_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
     "number": 166,
     "rarity": "C",
-    "name": "Nidoran♀",
-    "image": "cPK_10_001660_00_NIDORAN♀_C.webp",
-    "packs": ["Pikachu"]
+    "name": "Nidoran\u2640",
+    "image": "cPK_10_001660_00_NIDORAN\u2640_C.webp",
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1333,7 +1499,8 @@
     "rarity": "U",
     "name": "Nidorina",
     "image": "cPK_10_001670_00_NIDORINA_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1341,15 +1508,17 @@
     "rarity": "R",
     "name": "Nidoqueen",
     "image": "cPK_10_001680_00_NIDOQUEEN_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
     "number": 169,
     "rarity": "C",
-    "name": "Nidoran♂",
-    "image": "cPK_10_001690_00_NIDORAN♂_C.webp",
-    "packs": ["Pikachu"]
+    "name": "Nidoran\u2642",
+    "image": "cPK_10_001690_00_NIDORAN\u2642_C.webp",
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1357,7 +1526,8 @@
     "rarity": "U",
     "name": "Nidorino",
     "image": "cPK_10_001700_00_NIDORINO_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1365,7 +1535,8 @@
     "rarity": "R",
     "name": "Nidoking",
     "image": "cPK_10_001710_00_NIDOKING_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1373,7 +1544,8 @@
     "rarity": "C",
     "name": "Zubat",
     "image": "cPK_10_001720_00_ZUBAT_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1381,7 +1553,8 @@
     "rarity": "U",
     "name": "Golbat",
     "image": "cPK_10_001730_00_GOLBAT_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1389,7 +1562,8 @@
     "rarity": "C",
     "name": "Grimer",
     "image": "cPK_10_001740_00_BETBETER_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1397,7 +1571,8 @@
     "rarity": "R",
     "name": "Muk",
     "image": "cPK_10_001750_00_BETBETON_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1405,7 +1580,8 @@
     "rarity": "C",
     "name": "Koffing",
     "image": "cPK_10_001760_00_DOGARS_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1413,7 +1589,8 @@
     "rarity": "R",
     "name": "Weezing",
     "image": "cPK_10_001770_00_MATADOGAS_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1421,7 +1598,8 @@
     "rarity": "C",
     "name": "Mawile",
     "image": "cPK_10_001780_00_KUCHEAT_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1429,7 +1607,8 @@
     "rarity": "C",
     "name": "Pawniard",
     "image": "cPK_10_001790_00_KOMATANA_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1437,7 +1616,8 @@
     "rarity": "U",
     "name": "Bisharp",
     "image": "cPK_10_001800_00_KIRIKIZAN_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1445,7 +1625,8 @@
     "rarity": "C",
     "name": "Meltan",
     "image": "cPK_10_001810_00_MELTAN_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1453,7 +1634,8 @@
     "rarity": "R",
     "name": "Melmetal",
     "image": "cPK_10_001820_00_MELMETAL_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1461,7 +1643,8 @@
     "rarity": "C",
     "name": "Dratini",
     "image": "cPK_10_001830_00_MINIRYU_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1469,7 +1652,8 @@
     "rarity": "U",
     "name": "Dragonair",
     "image": "cPK_10_001840_00_HAKURYU_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1477,7 +1661,8 @@
     "rarity": "R",
     "name": "Dragonite",
     "image": "cPK_10_001850_00_KAIRYU_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1485,7 +1670,8 @@
     "rarity": "C",
     "name": "Pidgey",
     "image": "cPK_10_001860_00_POPPO_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1493,7 +1679,8 @@
     "rarity": "C",
     "name": "Pidgeotto",
     "image": "cPK_10_001870_00_PIGEON_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1501,7 +1688,8 @@
     "rarity": "R",
     "name": "Pidgeot",
     "image": "cPK_10_001880_00_PIGEOT_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1509,7 +1697,8 @@
     "rarity": "C",
     "name": "Rattata",
     "image": "cPK_10_001890_00_KORATTA_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1517,7 +1706,8 @@
     "rarity": "C",
     "name": "Raticate",
     "image": "cPK_10_001900_00_RATTA_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1525,7 +1715,8 @@
     "rarity": "C",
     "name": "Spearow",
     "image": "cPK_10_001910_00_ONISUZUME_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1533,7 +1724,8 @@
     "rarity": "C",
     "name": "Fearow",
     "image": "cPK_10_001920_00_ONIDRILL_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1541,7 +1733,8 @@
     "rarity": "C",
     "name": "Jigglypuff",
     "image": "cPK_10_001930_00_PURIN_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1549,7 +1742,8 @@
     "rarity": "C",
     "name": "Wigglytuff",
     "image": "cPK_10_001940_00_PUKURIN_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1557,7 +1751,8 @@
     "rarity": "RR",
     "name": "Wigglytuff ex",
     "image": "cPK_10_001950_00_PUKURINex_RR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1565,7 +1760,8 @@
     "rarity": "C",
     "name": "Meowth",
     "image": "cPK_10_001960_00_NYARTH_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1573,15 +1769,17 @@
     "rarity": "U",
     "name": "Persian",
     "image": "cPK_10_001970_00_PERSIAN_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
     "number": 198,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_10_001980_00_KAMONEGI_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1589,7 +1787,8 @@
     "rarity": "C",
     "name": "Doduo",
     "image": "cPK_10_001990_00_DODO_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1597,7 +1796,8 @@
     "rarity": "U",
     "name": "Dodrio",
     "image": "cPK_10_002000_00_DODORIO_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1605,7 +1805,8 @@
     "rarity": "U",
     "name": "Lickitung",
     "image": "cPK_10_002010_00_BERORINGA_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1613,7 +1814,8 @@
     "rarity": "U",
     "name": "Chansey",
     "image": "cPK_10_002020_00_LUCKY_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1621,7 +1823,8 @@
     "rarity": "R",
     "name": "Kangaskhan",
     "image": "cPK_10_002030_00_GARURA_R.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1629,7 +1832,8 @@
     "rarity": "U",
     "name": "Tauros",
     "image": "cPK_10_002040_00_KENTAUROS_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1637,7 +1841,8 @@
     "rarity": "R",
     "name": "Ditto",
     "image": "cPK_10_002050_00_METAMON_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1645,7 +1850,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_002060_00_EIEVUI_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1653,7 +1859,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_002060_01_EIEVUI_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1661,7 +1868,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_002060_02_EIEVUI_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1669,7 +1877,8 @@
     "rarity": "U",
     "name": "Porygon",
     "image": "cPK_10_002070_00_PORYGON_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1677,7 +1886,8 @@
     "rarity": "R",
     "name": "Aerodactyl",
     "image": "cPK_10_002080_00_PTERA_R.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1685,7 +1895,8 @@
     "rarity": "R",
     "name": "Snorlax",
     "image": "cPK_10_002090_00_KABIGON_R.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1693,7 +1904,8 @@
     "rarity": "C",
     "name": "Minccino",
     "image": "cPK_10_002100_00_CHILLARMY_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1701,7 +1913,8 @@
     "rarity": "U",
     "name": "Cinccino",
     "image": "cPK_10_002110_00_CHILLACCINO_U.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1709,7 +1922,8 @@
     "rarity": "C",
     "name": "Wooloo",
     "image": "cPK_10_002120_00_WOOLUU_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1717,7 +1931,8 @@
     "rarity": "C",
     "name": "Dubwool",
     "image": "cPK_10_002130_00_BAIWOOLUU_C.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1725,7 +1940,8 @@
     "rarity": "C",
     "name": "Helix Fossil",
     "image": "cTR_10_000080_00_KAINOKASEKI_C.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1733,7 +1949,8 @@
     "rarity": "C",
     "name": "Dome Fossil",
     "image": "cTR_10_000090_00_KOURANOKASEKI_C.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1741,7 +1958,8 @@
     "rarity": "C",
     "name": "Old Amber",
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1749,7 +1967,8 @@
     "rarity": "U",
     "name": "Erika",
     "image": "cTR_10_000110_00_ERIKA_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1757,7 +1976,8 @@
     "rarity": "U",
     "name": "Misty",
     "image": "cTR_10_000120_00_KASUMI_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1765,7 +1985,8 @@
     "rarity": "U",
     "name": "Blaine",
     "image": "cTR_10_000130_00_KATSURA_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1773,7 +1994,8 @@
     "rarity": "U",
     "name": "Koga",
     "image": "cTR_10_000140_00_KYOU_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1781,7 +2003,8 @@
     "rarity": "U",
     "name": "Giovanni",
     "image": "cTR_10_000150_00_SAKAKI_U.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1789,7 +2012,8 @@
     "rarity": "U",
     "name": "Brock",
     "image": "cTR_10_000160_00_TAKESHI_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1797,7 +2021,8 @@
     "rarity": "U",
     "name": "Sabrina",
     "image": "cTR_10_000170_00_NATSUME_U.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1805,7 +2030,8 @@
     "rarity": "U",
     "name": "Lt. Surge",
     "image": "cTR_10_000180_00_MATISSE_U.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1813,7 +2039,8 @@
     "rarity": "AR",
     "name": "Bulbasaur",
     "image": "cPK_20_000010_00_FUSHIGIDANE_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1821,7 +2048,8 @@
     "rarity": "AR",
     "name": "Gloom",
     "image": "cPK_20_000120_00_KUSAIHANA_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1829,7 +2057,8 @@
     "rarity": "AR",
     "name": "Pinsir",
     "image": "cPK_20_000260_00_KAILIOS_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1837,7 +2066,8 @@
     "rarity": "AR",
     "name": "Charmander",
     "image": "cPK_20_000330_00_HITOKAGE_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1845,7 +2075,8 @@
     "rarity": "AR",
     "name": "Rapidash",
     "image": "cPK_20_000430_00_GALLOP_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1853,7 +2084,8 @@
     "rarity": "AR",
     "name": "Squirtle",
     "image": "cPK_20_000530_00_ZENIGAME_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1861,7 +2093,8 @@
     "rarity": "AR",
     "name": "Gyarados",
     "image": "cPK_20_000780_00_GYARADOS_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1869,7 +2102,8 @@
     "rarity": "AR",
     "name": "Lapras",
     "image": "cPK_20_000790_00_LAPLACE_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1877,7 +2111,8 @@
     "rarity": "AR",
     "name": "Electrode",
     "image": "cPK_20_001000_00_MARUMINE_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1885,7 +2120,8 @@
     "rarity": "AR",
     "name": "Alakazam",
     "image": "cPK_20_001170_00_FOODIN_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1893,7 +2129,8 @@
     "rarity": "AR",
     "name": "Slowpoke",
     "image": "cPK_20_001180_00_YADON_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1901,7 +2138,8 @@
     "rarity": "AR",
     "name": "Diglett",
     "image": "cPK_20_001390_00_DIGDA_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1909,7 +2147,8 @@
     "rarity": "AR",
     "name": "Cubone",
     "image": "cPK_20_001510_00_KARAKARA_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1917,7 +2156,8 @@
     "rarity": "AR",
     "name": "Nidoqueen",
     "image": "cPK_20_001680_00_NIDOQUEEN_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1925,7 +2165,8 @@
     "rarity": "AR",
     "name": "Nidoking",
     "image": "cPK_20_001710_00_NIDOKING_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1933,7 +2174,8 @@
     "rarity": "AR",
     "name": "Golbat",
     "image": "cPK_20_001730_00_GOLBAT_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1941,7 +2183,8 @@
     "rarity": "AR",
     "name": "Weezing",
     "image": "cPK_20_001770_00_MATADOGAS_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1949,7 +2192,8 @@
     "rarity": "AR",
     "name": "Dragonite",
     "image": "cPK_20_001850_00_KAIRYU_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1957,7 +2201,8 @@
     "rarity": "AR",
     "name": "Pidgeot",
     "image": "cPK_20_001880_00_PIGEOT_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1965,7 +2210,8 @@
     "rarity": "AR",
     "name": "Meowth",
     "image": "cPK_20_001960_00_NYARTH_AR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1973,7 +2219,8 @@
     "rarity": "AR",
     "name": "Ditto",
     "image": "cPK_20_002050_00_METAMON_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1981,7 +2228,8 @@
     "rarity": "AR",
     "name": "Eevee",
     "image": "cPK_20_002060_00_EIEVUI_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1989,7 +2237,8 @@
     "rarity": "AR",
     "name": "Porygon",
     "image": "cPK_20_002070_00_PORYGON_AR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -1997,7 +2246,8 @@
     "rarity": "AR",
     "name": "Snorlax",
     "image": "cPK_20_002090_00_KABIGON_AR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2005,7 +2255,8 @@
     "rarity": "SR",
     "name": "Venusaur ex",
     "image": "cPK_20_000040_00_FUSHIGIBANAex_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2013,7 +2264,8 @@
     "rarity": "SR",
     "name": "Exeggutor ex",
     "image": "cPK_20_000230_00_NASSYex_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2021,7 +2273,8 @@
     "rarity": "SR",
     "name": "Charizard ex",
     "image": "cPK_20_000360_00_LIZARDONex_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2029,7 +2282,8 @@
     "rarity": "SR",
     "name": "Arcanine ex",
     "image": "cPK_20_000410_00_WINDIEex_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2037,7 +2291,8 @@
     "rarity": "SR",
     "name": "Moltres ex",
     "image": "cPK_20_000470_00_FIREex_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2045,7 +2300,8 @@
     "rarity": "SR",
     "name": "Blastoise ex",
     "image": "cPK_20_000560_00_KAMEXex_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2053,7 +2309,8 @@
     "rarity": "SR",
     "name": "Starmie ex",
     "image": "cPK_20_000760_00_STARMIEex_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2061,7 +2318,8 @@
     "rarity": "SR",
     "name": "Articuno ex",
     "image": "cPK_20_000840_00_FREEZERex_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2069,7 +2327,8 @@
     "rarity": "SR",
     "name": "Pikachu ex",
     "image": "cPK_20_000960_00_PIKACHUex_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2077,7 +2336,8 @@
     "rarity": "SR",
     "name": "Zapdos ex",
     "image": "cPK_20_001040_00_THUNDERex_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2085,7 +2345,8 @@
     "rarity": "SR",
     "name": "Gengar ex",
     "image": "cPK_20_001230_00_GANGARex_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2093,7 +2354,8 @@
     "rarity": "SR",
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_00_MEWTWOex_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2101,7 +2363,8 @@
     "rarity": "SR",
     "name": "Machamp ex",
     "image": "cPK_20_001460_00_KAIRIKYex_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2109,7 +2372,8 @@
     "rarity": "SR",
     "name": "Marowak ex",
     "image": "cPK_20_001530_00_GARAGARAex_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2117,7 +2381,8 @@
     "rarity": "SR",
     "name": "Wigglytuff ex",
     "image": "cPK_20_001950_00_PUKURINex_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2125,7 +2390,8 @@
     "rarity": "SR",
     "name": "Erika",
     "image": "cTR_20_000110_00_ERIKA_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2133,7 +2399,8 @@
     "rarity": "SR",
     "name": "Misty",
     "image": "cTR_20_000120_00_KASUMI_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2141,7 +2408,8 @@
     "rarity": "SR",
     "name": "Blaine",
     "image": "cTR_20_000130_00_KATSURA_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2149,7 +2417,8 @@
     "rarity": "SR",
     "name": "Koga",
     "image": "cTR_20_000140_00_KYOU_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2157,7 +2426,8 @@
     "rarity": "SR",
     "name": "Giovanni",
     "image": "cTR_20_000150_00_SAKAKI_SR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2165,7 +2435,8 @@
     "rarity": "SR",
     "name": "Brock",
     "image": "cTR_20_000160_00_TAKESHI_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2173,7 +2444,8 @@
     "rarity": "SR",
     "name": "Sabrina",
     "image": "cTR_20_000170_00_NATSUME_SR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2181,7 +2453,8 @@
     "rarity": "SR",
     "name": "Lt. Surge",
     "image": "cTR_20_000180_00_MATISSE_SR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2189,7 +2462,8 @@
     "rarity": "SAR",
     "name": "Moltres ex",
     "image": "cPK_20_000470_01_FIREex_SAR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2197,7 +2471,8 @@
     "rarity": "SAR",
     "name": "Articuno ex",
     "image": "cPK_20_000840_01_FREEZERex_SAR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2205,7 +2480,8 @@
     "rarity": "SAR",
     "name": "Zapdos ex",
     "image": "cPK_20_001040_01_THUNDERex_SAR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2213,7 +2489,8 @@
     "rarity": "SAR",
     "name": "Gengar ex",
     "image": "cPK_20_001230_01_GANGARex_SAR.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2221,7 +2498,8 @@
     "rarity": "SAR",
     "name": "Machamp ex",
     "image": "cPK_20_001460_01_KAIRIKYex_SAR.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2229,7 +2507,8 @@
     "rarity": "SAR",
     "name": "Wigglytuff ex",
     "image": "cPK_20_001950_01_PUKURINex_SAR.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2237,7 +2516,8 @@
     "rarity": "IM",
     "name": "Charizard ex",
     "image": "cPK_20_000360_01_LIZARDONex_IM.webp",
-    "packs": ["Charizard"]
+    "packs": ["Charizard"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2245,7 +2525,8 @@
     "rarity": "IM",
     "name": "Pikachu ex",
     "image": "cPK_20_000960_01_PIKACHUex_IM.webp",
-    "packs": ["Pikachu"]
+    "packs": ["Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2253,14 +2534,16 @@
     "rarity": "IM",
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_01_MEWTWOex_IM.webp",
-    "packs": ["Mewtwo"]
+    "packs": ["Mewtwo"],
+    "parallel": false
   },
   {
     "set": "A1",
     "number": 283,
     "rarity": "IM",
     "name": "Mew",
-    "image": "cPK_20_002140_00_MEW_IM.webp"
+    "image": "cPK_20_002140_00_MEW_IM.webp",
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2268,7 +2551,8 @@
     "rarity": "UR",
     "name": "Charizard ex",
     "image": "cPK_20_000360_02_LIZARDONex_UR.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2276,7 +2560,8 @@
     "rarity": "UR",
     "name": "Pikachu ex",
     "image": "cPK_20_000960_02_PIKACHUex_UR.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1",
@@ -2284,7 +2569,8 @@
     "rarity": "UR",
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_02_MEWTWOex_UR.webp",
-    "packs": ["Charizard", "Mewtwo", "Pikachu"]
+    "packs": ["Charizard", "Mewtwo", "Pikachu"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2292,7 +2578,8 @@
     "rarity": "C",
     "name": "Exeggcute",
     "image": "cPK_10_002150_00_TAMATAMA_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2300,7 +2587,8 @@
     "rarity": "U",
     "name": "Exeggutor",
     "image": "cPK_10_002160_00_NASSY_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2308,7 +2596,8 @@
     "rarity": "RR",
     "name": "Celebi ex",
     "image": "cPK_10_002170_00_CELEBIex_RR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2316,7 +2605,8 @@
     "rarity": "C",
     "name": "Snivy",
     "image": "cPK_10_002180_00_TSUTARJA_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2324,7 +2614,8 @@
     "rarity": "U",
     "name": "Servine",
     "image": "cPK_10_002190_00_JANOVY_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2332,7 +2623,8 @@
     "rarity": "R",
     "name": "Serperior",
     "image": "cPK_10_002200_00_JALORDA_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2340,7 +2632,8 @@
     "rarity": "C",
     "name": "Morelull",
     "image": "cPK_10_002210_00_NEMASYU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2348,7 +2641,8 @@
     "rarity": "U",
     "name": "Shiinotic",
     "image": "cPK_10_002220_00_MASHADE_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2356,7 +2650,8 @@
     "rarity": "U",
     "name": "Dhelmise",
     "image": "cPK_10_002230_00_DADARIN_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2364,7 +2659,8 @@
     "rarity": "C",
     "name": "Ponyta",
     "image": "cPK_10_002240_00_PONYTA_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2372,7 +2668,8 @@
     "rarity": "U",
     "name": "Rapidash",
     "image": "cPK_10_002250_00_GALLOP_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2380,7 +2677,8 @@
     "rarity": "U",
     "name": "Magmar",
     "image": "cPK_10_002260_00_BOOBER_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2388,7 +2686,8 @@
     "rarity": "C",
     "name": "Larvesta",
     "image": "cPK_10_002270_00_MERLARVA_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2396,7 +2695,8 @@
     "rarity": "R",
     "name": "Volcarona",
     "image": "cPK_10_002280_00_ULGAMOTH_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2404,7 +2704,8 @@
     "rarity": "C",
     "name": "Salandit",
     "image": "cPK_10_002290_00_YATOUMORI_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2412,7 +2713,8 @@
     "rarity": "C",
     "name": "Salazzle",
     "image": "cPK_10_002300_00_ENNEWT_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2420,7 +2722,8 @@
     "rarity": "C",
     "name": "Magikarp",
     "image": "cPK_10_002310_00_KOIKING_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2428,7 +2731,8 @@
     "rarity": "RR",
     "name": "Gyarados ex",
     "image": "cPK_10_002320_00_GYARADOSex_RR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2436,7 +2740,8 @@
     "rarity": "R",
     "name": "Vaporeon",
     "image": "cPK_10_002330_00_SHOWERS_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2444,7 +2749,8 @@
     "rarity": "C",
     "name": "Finneon",
     "image": "cPK_10_002340_00_KEIKOUO_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2452,7 +2758,8 @@
     "rarity": "U",
     "name": "Lumineon",
     "image": "cPK_10_002350_00_NEOLANT_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2460,7 +2767,8 @@
     "rarity": "C",
     "name": "Chewtle",
     "image": "cPK_10_002360_00_KAMUKAME_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2468,7 +2776,8 @@
     "rarity": "U",
     "name": "Drednaw",
     "image": "cPK_10_002370_00_KAJIRIGAME_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2476,7 +2785,8 @@
     "rarity": "C",
     "name": "Cramorant",
     "image": "cPK_10_002380_00_UU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2484,7 +2794,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_10_002390_00_PIKACHU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2492,7 +2803,8 @@
     "rarity": "R",
     "name": "Raichu",
     "image": "cPK_10_002400_00_RAICHU_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2500,7 +2812,8 @@
     "rarity": "U",
     "name": "Electabuzz",
     "image": "cPK_10_002410_00_ELEBOO_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2508,7 +2821,8 @@
     "rarity": "C",
     "name": "Joltik",
     "image": "cPK_10_002420_00_BACHURU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2516,7 +2830,8 @@
     "rarity": "U",
     "name": "Galvantula",
     "image": "cPK_10_002430_00_DENTULA_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2524,7 +2839,8 @@
     "rarity": "C",
     "name": "Dedenne",
     "image": "cPK_10_002440_00_DEDENNE_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2532,7 +2848,8 @@
     "rarity": "R",
     "name": "Mew",
     "image": "cPK_10_002140_00_MEW_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2540,7 +2857,8 @@
     "rarity": "RR",
     "name": "Mew ex",
     "image": "cPK_10_002450_00_MEWex_RR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2548,7 +2866,8 @@
     "rarity": "U",
     "name": "Sigilyph",
     "image": "cPK_10_002460_00_SYMBOLER_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2556,7 +2875,8 @@
     "rarity": "C",
     "name": "Elgyem",
     "image": "cPK_10_002470_00_LIGRAY_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2564,15 +2884,17 @@
     "rarity": "U",
     "name": "Beheeyem",
     "image": "cPK_10_002500_00_OHBEM_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
     "number": 36,
     "rarity": "C",
-    "name": "Flabébé",
+    "name": "Flab\u00e9b\u00e9",
     "image": "cPK_10_002510_00_FLABEBE_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2580,7 +2902,8 @@
     "rarity": "C",
     "name": "Floette",
     "image": "cPK_10_002520_00_FLOETTE_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2588,7 +2911,8 @@
     "rarity": "U",
     "name": "Florges",
     "image": "cPK_10_002480_00_FLORGES_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2596,7 +2920,8 @@
     "rarity": "C",
     "name": "Swirlix",
     "image": "cPK_10_002490_00_PEROPPAFU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2604,7 +2929,8 @@
     "rarity": "C",
     "name": "Slurpuff",
     "image": "cPK_10_002530_00_PEROREAM_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2612,7 +2938,8 @@
     "rarity": "C",
     "name": "Mankey",
     "image": "cPK_10_002540_00_MANKEY_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2620,7 +2947,8 @@
     "rarity": "C",
     "name": "Primeape",
     "image": "cPK_10_002550_00_OKORIZARU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2628,7 +2956,8 @@
     "rarity": "C",
     "name": "Geodude",
     "image": "cPK_10_002560_00_ISITSUBUTE_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2636,7 +2965,8 @@
     "rarity": "U",
     "name": "Graveler",
     "image": "cPK_10_002570_00_GOLONE_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2644,7 +2974,8 @@
     "rarity": "R",
     "name": "Golem",
     "image": "cPK_10_002580_00_GOLONYA_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2652,7 +2983,8 @@
     "rarity": "RR",
     "name": "Aerodactyl ex",
     "image": "cPK_10_002590_00_PTERAex_RR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2660,7 +2992,8 @@
     "rarity": "R",
     "name": "Marshadow",
     "image": "cPK_10_002600_00_MARSHADOW_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2668,7 +3001,8 @@
     "rarity": "U",
     "name": "Stonjourner",
     "image": "cPK_10_002610_00_ISHIHENGIN_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2676,7 +3010,8 @@
     "rarity": "C",
     "name": "Koffing",
     "image": "cPK_10_002620_00_DOGARS_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2684,7 +3019,8 @@
     "rarity": "U",
     "name": "Weezing",
     "image": "cPK_10_002630_00_MATADOGAS_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2692,7 +3028,8 @@
     "rarity": "C",
     "name": "Purrloin",
     "image": "cPK_10_002640_00_CHORONEKO_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2700,7 +3037,8 @@
     "rarity": "C",
     "name": "Liepard",
     "image": "cPK_10_002650_00_LEPARDAS_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2708,7 +3046,8 @@
     "rarity": "C",
     "name": "Venipede",
     "image": "cPK_10_002660_00_FUSHIDE_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2716,7 +3055,8 @@
     "rarity": "C",
     "name": "Whirlipede",
     "image": "cPK_10_002670_00_WHEEGA_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2724,7 +3064,8 @@
     "rarity": "U",
     "name": "Scolipede",
     "image": "cPK_10_002680_00_PENDROR_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2732,7 +3073,8 @@
     "rarity": "U",
     "name": "Druddigon",
     "image": "cPK_10_002690_00_CRIMGAN_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2740,7 +3082,8 @@
     "rarity": "C",
     "name": "Pidgey",
     "image": "cPK_10_002700_00_POPPO_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2748,7 +3091,8 @@
     "rarity": "C",
     "name": "Pidgeotto",
     "image": "cPK_10_002710_00_PIGEON_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2756,7 +3100,8 @@
     "rarity": "RR",
     "name": "Pidgeot ex",
     "image": "cPK_10_002720_00_PIGEOTex_RR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2764,7 +3109,8 @@
     "rarity": "R",
     "name": "Tauros",
     "image": "cPK_10_002730_00_KENTAUROS_R.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2772,7 +3118,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_002740_00_EIEVUI_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2780,7 +3127,8 @@
     "rarity": "C",
     "name": "Chatot",
     "image": "cPK_10_002750_00_PERAP_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2788,15 +3136,17 @@
     "rarity": "C",
     "name": "Old Amber",
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
     "number": 64,
     "rarity": "U",
-    "name": "Pokémon Flute",
+    "name": "Pok\u00e9mon Flute",
     "image": "cTR_10_000200_00_POKEMONNOFUE_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2804,7 +3154,8 @@
     "rarity": "U",
     "name": "Mythical Slab",
     "image": "cTR_10_000190_00_MABOROSHINOSEKIBAN_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2812,7 +3163,8 @@
     "rarity": "U",
     "name": "Budding Expeditioner",
     "image": "cTR_10_000220_00_KAKEDASHICHOSAIN_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2820,7 +3172,8 @@
     "rarity": "U",
     "name": "Blue",
     "image": "cTR_10_000210_00_GREEN_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2828,7 +3181,8 @@
     "rarity": "U",
     "name": "Leaf",
     "image": "cTR_10_000230_00_LEAF_U.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2836,7 +3190,8 @@
     "rarity": "AR",
     "name": "Exeggutor",
     "image": "cPK_20_002160_00_NASSY_AR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2844,7 +3199,8 @@
     "rarity": "AR",
     "name": "Serperior",
     "image": "cPK_20_002200_00_JALORDA_AR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2852,7 +3208,8 @@
     "rarity": "AR",
     "name": "Salandit",
     "image": "cPK_20_002290_00_YATOUMORI_AR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2860,7 +3217,8 @@
     "rarity": "AR",
     "name": "Vaporeon",
     "image": "cPK_20_002330_00_SHOWERS_AR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2868,7 +3226,8 @@
     "rarity": "AR",
     "name": "Dedenne",
     "image": "cPK_20_002440_00_DEDENNE_AR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2876,7 +3235,8 @@
     "rarity": "AR",
     "name": "Marshadow",
     "image": "cPK_20_002600_00_MARSHADOW_AR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2884,7 +3244,8 @@
     "rarity": "SR",
     "name": "Celebi ex",
     "image": "cPK_20_002170_00_CELEBIex_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2892,7 +3253,8 @@
     "rarity": "SR",
     "name": "Gyarados ex",
     "image": "cPK_20_002320_00_GYARADOSex_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2900,7 +3262,8 @@
     "rarity": "SR",
     "name": "Mew ex",
     "image": "cPK_20_002450_00_MEWex_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2908,7 +3271,8 @@
     "rarity": "SR",
     "name": "Aerodactyl ex",
     "image": "cPK_20_002590_00_PTERAex_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2916,7 +3280,8 @@
     "rarity": "SR",
     "name": "Pidgeot ex",
     "image": "cPK_20_002720_00_PIGEOTex_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2924,7 +3289,8 @@
     "rarity": "SR",
     "name": "Budding Expeditioner",
     "image": "cTR_20_000220_00_KAKEDASHICHOSAIN_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2932,7 +3298,8 @@
     "rarity": "SR",
     "name": "Blue",
     "image": "cTR_20_000210_00_GREEN_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2940,7 +3307,8 @@
     "rarity": "SR",
     "name": "Leaf",
     "image": "cTR_20_000230_00_LEAF_SR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2948,7 +3316,8 @@
     "rarity": "SAR",
     "name": "Mew ex",
     "image": "cPK_20_002450_01_MEWex_SAR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2956,7 +3325,8 @@
     "rarity": "SAR",
     "name": "Aerodactyl ex",
     "image": "cPK_20_002590_01_PTERAex_SAR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2964,7 +3334,8 @@
     "rarity": "IM",
     "name": "Celebi ex",
     "image": "cPK_20_002170_01_CELEBIex_IM.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A1a",
@@ -2972,7 +3343,8 @@
     "rarity": "UR",
     "name": "Mew ex",
     "image": "cPK_20_002450_02_MEWex_UR.webp",
-    "packs": ["Mew"]
+    "packs": ["Mew"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -2980,7 +3352,8 @@
     "rarity": "C",
     "name": "Oddish",
     "image": "cPK_10_002820_00_NAZONOKUSA_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -2988,7 +3361,8 @@
     "rarity": "C",
     "name": "Gloom",
     "image": "cPK_10_002830_00_KUSAIHANA_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -2996,7 +3370,8 @@
     "rarity": "U",
     "name": "Bellossom",
     "image": "cPK_10_002840_00_KIREIHANA_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3004,7 +3379,8 @@
     "rarity": "C",
     "name": "Tangela",
     "image": "cPK_10_002850_00_MONJARA_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3012,7 +3388,8 @@
     "rarity": "U",
     "name": "Tangrowth",
     "image": "cPK_10_002860_00_MOJUMBO_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3020,7 +3397,8 @@
     "rarity": "C",
     "name": "Yanma",
     "image": "cPK_10_002870_00_YANYANMA_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3028,7 +3406,8 @@
     "rarity": "RR",
     "name": "Yanmega ex",
     "image": "cPK_10_002880_00_MEGAYANMAex_RR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3036,7 +3415,8 @@
     "rarity": "C",
     "name": "Roselia",
     "image": "cPK_10_002890_00_ROSELIA_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3044,7 +3424,8 @@
     "rarity": "U",
     "name": "Roserade",
     "image": "cPK_10_002900_00_ROSERADE_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3052,7 +3433,8 @@
     "rarity": "C",
     "name": "Turtwig",
     "image": "cPK_10_002910_00_NAETLE_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3060,7 +3442,8 @@
     "rarity": "U",
     "name": "Grotle",
     "image": "cPK_10_002920_00_HAYASHIGAME_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3068,7 +3451,8 @@
     "rarity": "R",
     "name": "Torterra",
     "image": "cPK_10_002930_00_DODAITOSE_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3076,7 +3460,8 @@
     "rarity": "C",
     "name": "Kricketot",
     "image": "cPK_10_002940_00_KOROBOHSHI_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3084,7 +3469,8 @@
     "rarity": "C",
     "name": "Kricketune",
     "image": "cPK_10_002950_00_KOROTOCK_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3092,7 +3478,8 @@
     "rarity": "C",
     "name": "Burmy",
     "image": "cPK_10_002960_00_MINOMUCCHI_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3100,7 +3487,8 @@
     "rarity": "C",
     "name": "Wormadam",
     "image": "cPK_10_002970_00_MINOMADAMKUSAKINOMINO_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3108,7 +3496,8 @@
     "rarity": "C",
     "name": "Combee",
     "image": "cPK_10_002980_00_MITSUHONEY_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3116,7 +3505,8 @@
     "rarity": "U",
     "name": "Vespiquen",
     "image": "cPK_10_002990_00_BEEQUEN_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3124,7 +3514,8 @@
     "rarity": "U",
     "name": "Carnivine",
     "image": "cPK_10_003000_00_MUSKIPPA_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3132,7 +3523,8 @@
     "rarity": "R",
     "name": "Leafeon",
     "image": "cPK_10_003010_00_LEAFIA_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3140,7 +3532,8 @@
     "rarity": "C",
     "name": "Mow Rotom",
     "image": "cPK_10_003020_00_CUT ROTOM_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3148,7 +3541,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_10_003030_00_SHAYMIN_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3156,7 +3550,8 @@
     "rarity": "C",
     "name": "Magmar",
     "image": "cPK_10_003040_00_BOOBER_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3164,7 +3559,8 @@
     "rarity": "R",
     "name": "Magmortar",
     "image": "cPK_10_003050_00_BOOBURN_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3172,7 +3568,8 @@
     "rarity": "C",
     "name": "Slugma",
     "image": "cPK_10_003060_00_MAGMAG_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3180,7 +3577,8 @@
     "rarity": "U",
     "name": "Magcargo",
     "image": "cPK_10_003070_00_MAGCARGOT_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3188,7 +3586,8 @@
     "rarity": "C",
     "name": "Chimchar",
     "image": "cPK_10_003080_00_HIKOZARU_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3196,7 +3595,8 @@
     "rarity": "U",
     "name": "Monferno",
     "image": "cPK_10_003090_00_MOUKAZARU_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3204,7 +3604,8 @@
     "rarity": "RR",
     "name": "Infernape ex",
     "image": "cPK_10_003100_00_GOUKAZARUex_RR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3212,7 +3613,8 @@
     "rarity": "C",
     "name": "Heat Rotom",
     "image": "cPK_10_003110_00_HEAT ROTOM_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3220,7 +3622,8 @@
     "rarity": "C",
     "name": "Swinub",
     "image": "cPK_10_003120_00_URIMOO_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3228,7 +3631,8 @@
     "rarity": "U",
     "name": "Piloswine",
     "image": "cPK_10_003130_00_INOMOO_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3236,7 +3640,8 @@
     "rarity": "R",
     "name": "Mamoswine",
     "image": "cPK_10_003140_00_MAMMOO_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3244,7 +3649,8 @@
     "rarity": "U",
     "name": "Regice",
     "image": "cPK_10_003150_00_REGICE_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3252,7 +3658,8 @@
     "rarity": "C",
     "name": "Piplup",
     "image": "cPK_10_003160_00_POCHAMA_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3260,7 +3667,8 @@
     "rarity": "U",
     "name": "Prinplup",
     "image": "cPK_10_003170_00_POTTAISHI_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3268,7 +3676,8 @@
     "rarity": "R",
     "name": "Empoleon",
     "image": "cPK_10_003180_00_EMPERTE_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3276,7 +3685,8 @@
     "rarity": "C",
     "name": "Buizel",
     "image": "cPK_10_003190_00_BUOYSEL_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3284,7 +3694,8 @@
     "rarity": "U",
     "name": "Floatzel",
     "image": "cPK_10_003200_00_FLOAZEL_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3292,7 +3703,8 @@
     "rarity": "C",
     "name": "Shellos",
     "image": "cPK_10_003210_00_KARANAKUSHI_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3300,7 +3712,8 @@
     "rarity": "U",
     "name": "Gastrodon",
     "image": "cPK_10_003220_00_TRITODON_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3308,7 +3721,8 @@
     "rarity": "C",
     "name": "Finneon",
     "image": "cPK_10_003230_00_KEIKOUO_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3316,7 +3730,8 @@
     "rarity": "U",
     "name": "Lumineon",
     "image": "cPK_10_003240_00_NEOLANT_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3324,7 +3739,8 @@
     "rarity": "C",
     "name": "Snover",
     "image": "cPK_10_003250_00_YUKIKABURI_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3332,7 +3748,8 @@
     "rarity": "U",
     "name": "Abomasnow",
     "image": "cPK_10_003260_00_YUKINOOH_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3340,7 +3757,8 @@
     "rarity": "R",
     "name": "Glaceon",
     "image": "cPK_10_003270_00_GLACIA_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3348,7 +3766,8 @@
     "rarity": "C",
     "name": "Wash Rotom",
     "image": "cPK_10_003280_00_WASH ROTOM_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3356,7 +3775,8 @@
     "rarity": "C",
     "name": "Frost Rotom",
     "image": "cPK_10_003290_00_FROST ROTOM_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3364,7 +3784,8 @@
     "rarity": "RR",
     "name": "Palkia ex",
     "image": "cPK_10_003300_00_PALKIAex_RR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3372,7 +3793,8 @@
     "rarity": "U",
     "name": "Manaphy",
     "image": "cPK_10_003310_00_MANAPHY_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3380,7 +3802,8 @@
     "rarity": "C",
     "name": "Magnemite",
     "image": "cPK_10_003320_00_COIL_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3388,7 +3811,8 @@
     "rarity": "U",
     "name": "Magneton",
     "image": "cPK_10_003330_00_RARECOIL_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3396,7 +3820,8 @@
     "rarity": "R",
     "name": "Magnezone",
     "image": "cPK_10_003340_00_JIBACOIL_R.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3404,7 +3829,8 @@
     "rarity": "C",
     "name": "Voltorb",
     "image": "cPK_10_003350_00_BIRIRIDAMA_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3412,7 +3838,8 @@
     "rarity": "U",
     "name": "Electrode",
     "image": "cPK_10_003360_00_MARUMINE_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3420,7 +3847,8 @@
     "rarity": "C",
     "name": "Electabuzz",
     "image": "cPK_10_003370_00_ELEBOO_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3428,7 +3856,8 @@
     "rarity": "R",
     "name": "Electivire",
     "image": "cPK_10_003380_00_ELEKIBLE_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3436,7 +3865,8 @@
     "rarity": "C",
     "name": "Shinx",
     "image": "cPK_10_003390_00_KOLINK_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3444,7 +3874,8 @@
     "rarity": "U",
     "name": "Luxio",
     "image": "cPK_10_003400_00_LUXIO_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3452,7 +3883,8 @@
     "rarity": "R",
     "name": "Luxray",
     "image": "cPK_10_003410_00_RENTORAR_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3460,7 +3892,8 @@
     "rarity": "RR",
     "name": "Pachirisu ex",
     "image": "cPK_10_003420_00_PACHIRISUex_RR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3468,7 +3901,8 @@
     "rarity": "C",
     "name": "Rotom",
     "image": "cPK_10_003430_00_ROTOM_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3476,7 +3910,8 @@
     "rarity": "C",
     "name": "Togepi",
     "image": "cPK_10_003440_00_TOGEPY_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3484,7 +3919,8 @@
     "rarity": "U",
     "name": "Togetic",
     "image": "cPK_10_003450_00_TOGECHICK_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3492,7 +3928,8 @@
     "rarity": "R",
     "name": "Togekiss",
     "image": "cPK_10_003460_00_TOGEKISS_R.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3500,7 +3937,8 @@
     "rarity": "C",
     "name": "Misdreavus",
     "image": "cPK_10_003470_00_MUMA_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3508,7 +3946,8 @@
     "rarity": "RR",
     "name": "Mismagius ex",
     "image": "cPK_10_003480_00_MUMARGIex_RR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3516,7 +3955,8 @@
     "rarity": "C",
     "name": "Ralts",
     "image": "cPK_10_003490_00_RALTS_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3524,7 +3964,8 @@
     "rarity": "C",
     "name": "Kirlia",
     "image": "cPK_10_003500_00_KIRLIA_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3532,7 +3973,8 @@
     "rarity": "C",
     "name": "Duskull",
     "image": "cPK_10_003510_00_YOMAWARU_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3540,7 +3982,8 @@
     "rarity": "U",
     "name": "Dusclops",
     "image": "cPK_10_003520_00_SAMAYOURU_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3548,7 +3991,8 @@
     "rarity": "R",
     "name": "Dusknoir",
     "image": "cPK_10_003530_00_YONOIR_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3556,7 +4000,8 @@
     "rarity": "C",
     "name": "Drifloon",
     "image": "cPK_10_003540_00_FUWANTE_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3564,7 +4009,8 @@
     "rarity": "U",
     "name": "Drifblim",
     "image": "cPK_10_003550_00_FUWARIDE_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3572,7 +4018,8 @@
     "rarity": "U",
     "name": "Uxie",
     "image": "cPK_10_003560_00_YUXIE_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3580,7 +4027,8 @@
     "rarity": "R",
     "name": "Mesprit",
     "image": "cPK_10_003570_00_EMRIT_R.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3588,7 +4036,8 @@
     "rarity": "U",
     "name": "Azelf",
     "image": "cPK_10_003580_00_AGNOME_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3596,7 +4045,8 @@
     "rarity": "R",
     "name": "Giratina",
     "image": "cPK_10_003590_00_ORIGINGIRATINA_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3604,7 +4054,8 @@
     "rarity": "R",
     "name": "Cresselia",
     "image": "cPK_10_003600_00_CRESSELIA_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3612,7 +4063,8 @@
     "rarity": "C",
     "name": "Rhyhorn",
     "image": "cPK_10_003610_00_SIHORN_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3620,7 +4072,8 @@
     "rarity": "U",
     "name": "Rhydon",
     "image": "cPK_10_003620_00_SIDON_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3628,7 +4081,8 @@
     "rarity": "R",
     "name": "Rhyperior",
     "image": "cPK_10_003630_00_DOSIDON_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3636,7 +4090,8 @@
     "rarity": "C",
     "name": "Gligar",
     "image": "cPK_10_003640_00_GLIGER_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3644,7 +4099,8 @@
     "rarity": "U",
     "name": "Gliscor",
     "image": "cPK_10_003650_00_GLION_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3652,7 +4108,8 @@
     "rarity": "C",
     "name": "Hitmontop",
     "image": "cPK_10_003660_00_KAPOERER_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3660,7 +4117,8 @@
     "rarity": "C",
     "name": "Nosepass",
     "image": "cPK_10_003670_00_NOSEPASS_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3668,7 +4126,8 @@
     "rarity": "U",
     "name": "Regirock",
     "image": "cPK_10_003680_00_REGIROCK_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3676,7 +4135,8 @@
     "rarity": "U",
     "name": "Cranidos",
     "image": "cPK_10_003690_00_ZUGAIDOS_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3684,7 +4144,8 @@
     "rarity": "R",
     "name": "Rampardos",
     "image": "cPK_10_003700_00_RAMPALD_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3692,7 +4153,8 @@
     "rarity": "C",
     "name": "Wormadam",
     "image": "cPK_10_003710_00_MINOMADAMSUNACHINOMINO_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3700,7 +4162,8 @@
     "rarity": "C",
     "name": "Riolu",
     "image": "cPK_10_003720_00_RIOLU_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3708,7 +4171,8 @@
     "rarity": "R",
     "name": "Lucario",
     "image": "cPK_10_003730_00_LUCARIO_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3716,7 +4180,8 @@
     "rarity": "C",
     "name": "Hippopotas",
     "image": "cPK_10_003740_00_HIPPOPOTAS_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3724,7 +4189,8 @@
     "rarity": "U",
     "name": "Hippowdon",
     "image": "cPK_10_003750_00_KABALDON_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3732,7 +4198,8 @@
     "rarity": "RR",
     "name": "Gallade ex",
     "image": "cPK_10_003760_00_ERUREIDOex_RR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3740,7 +4207,8 @@
     "rarity": "C",
     "name": "Murkrow",
     "image": "cPK_10_003770_00_YAMIKARASU_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3748,7 +4216,8 @@
     "rarity": "U",
     "name": "Honchkrow",
     "image": "cPK_10_003780_00_DONGKARASU_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3756,7 +4225,8 @@
     "rarity": "C",
     "name": "Sneasel",
     "image": "cPK_10_003790_00_NYULA_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3764,7 +4234,8 @@
     "rarity": "RR",
     "name": "Weavile ex",
     "image": "cPK_10_003800_00_MANYULAex_RR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3772,7 +4243,8 @@
     "rarity": "C",
     "name": "Poochyena",
     "image": "cPK_10_003810_00_POCHIENA_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3780,7 +4252,8 @@
     "rarity": "U",
     "name": "Mightyena",
     "image": "cPK_10_003820_00_GRAENA_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3788,7 +4261,8 @@
     "rarity": "C",
     "name": "Stunky",
     "image": "cPK_10_003830_00_SKUNPUU_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3796,7 +4270,8 @@
     "rarity": "U",
     "name": "Skuntank",
     "image": "cPK_10_003840_00_SKUTANK_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3804,7 +4279,8 @@
     "rarity": "U",
     "name": "Spiritomb",
     "image": "cPK_10_003850_00_MIKARUGE_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3812,7 +4288,8 @@
     "rarity": "C",
     "name": "Skorupi",
     "image": "cPK_10_003860_00_SCORUPI_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3820,7 +4297,8 @@
     "rarity": "U",
     "name": "Drapion",
     "image": "cPK_10_003870_00_DORAPION_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3828,7 +4306,8 @@
     "rarity": "C",
     "name": "Croagunk",
     "image": "cPK_10_003880_00_GUREGGRU_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3836,7 +4315,8 @@
     "rarity": "U",
     "name": "Toxicroak",
     "image": "cPK_10_003890_00_DOKUROG_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3844,7 +4324,8 @@
     "rarity": "R",
     "name": "Darkrai",
     "image": "cPK_10_003900_00_DARKRAI_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3852,7 +4333,8 @@
     "rarity": "RR",
     "name": "Darkrai ex",
     "image": "cPK_10_003910_00_DARKRAIex_RR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3860,7 +4342,8 @@
     "rarity": "U",
     "name": "Skarmory",
     "image": "cPK_10_003920_00_AIRMD_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3868,7 +4351,8 @@
     "rarity": "U",
     "name": "Registeel",
     "image": "cPK_10_003930_00_REGISTEEL_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3876,7 +4360,8 @@
     "rarity": "U",
     "name": "Shieldon",
     "image": "cPK_10_003940_00_TATETOPS_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3884,7 +4369,8 @@
     "rarity": "R",
     "name": "Bastiodon",
     "image": "cPK_10_003950_00_TORIDEPS_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3892,7 +4378,8 @@
     "rarity": "C",
     "name": "Wormadam",
     "image": "cPK_10_003960_00_MINOMADAMGOMINOMINO_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3900,7 +4387,8 @@
     "rarity": "C",
     "name": "Bronzor",
     "image": "cPK_10_003970_00_DOHMIRROR_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3908,7 +4396,8 @@
     "rarity": "U",
     "name": "Bronzong",
     "image": "cPK_10_003980_00_DOHTAKUN_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3916,7 +4405,8 @@
     "rarity": "U",
     "name": "Probopass",
     "image": "cPK_10_003990_00_DAINOSE_U.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3924,7 +4414,8 @@
     "rarity": "RR",
     "name": "Dialga ex",
     "image": "cPK_10_004000_00_DIALGAex_RR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3932,7 +4423,8 @@
     "rarity": "R",
     "name": "Heatran",
     "image": "cPK_10_004010_00_HEATRAN_R.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3940,7 +4432,8 @@
     "rarity": "C",
     "name": "Gible",
     "image": "cPK_10_004020_00_FUKAMARU_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3948,7 +4441,8 @@
     "rarity": "U",
     "name": "Gabite",
     "image": "cPK_10_004030_00_GABITE_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3956,7 +4450,8 @@
     "rarity": "R",
     "name": "Garchomp",
     "image": "cPK_10_004040_00_GABURIAS_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3964,7 +4459,8 @@
     "rarity": "C",
     "name": "Lickitung",
     "image": "cPK_10_004050_00_BERORINGA_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3972,7 +4468,8 @@
     "rarity": "RR",
     "name": "Lickilicky ex",
     "image": "cPK_10_004060_00_BEROBELTex_RR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3980,7 +4477,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_004070_00_EIEVUI_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3988,7 +4486,8 @@
     "rarity": "C",
     "name": "Porygon",
     "image": "cPK_10_004080_00_PORYGON_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -3996,7 +4495,8 @@
     "rarity": "U",
     "name": "Porygon2",
     "image": "cPK_10_004090_00_PORYGON2_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4004,7 +4504,8 @@
     "rarity": "R",
     "name": "Porygon-Z",
     "image": "cPK_10_004100_00_PORYGON-Z_R.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4012,7 +4513,8 @@
     "rarity": "C",
     "name": "Aipom",
     "image": "cPK_10_004110_00_EIPAM_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4020,7 +4522,8 @@
     "rarity": "C",
     "name": "Ambipom",
     "image": "cPK_10_004120_00_ETEBOTH_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4028,7 +4531,8 @@
     "rarity": "C",
     "name": "Starly",
     "image": "cPK_10_004130_00_MUKKURU_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4036,7 +4540,8 @@
     "rarity": "C",
     "name": "Staravia",
     "image": "cPK_10_004140_00_MUKUBIRD_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4044,7 +4549,8 @@
     "rarity": "U",
     "name": "Staraptor",
     "image": "cPK_10_004150_00_MUKUHAWK_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4052,7 +4558,8 @@
     "rarity": "C",
     "name": "Bidoof",
     "image": "cPK_10_004160_00_BIPPA_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4060,7 +4567,8 @@
     "rarity": "C",
     "name": "Bibarel",
     "image": "cPK_10_004170_00_BEADARU_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4068,7 +4576,8 @@
     "rarity": "C",
     "name": "Buneary",
     "image": "cPK_10_004180_00_MIMIROL_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4076,7 +4585,8 @@
     "rarity": "C",
     "name": "Lopunny",
     "image": "cPK_10_004190_00_MIMILOP_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4084,7 +4594,8 @@
     "rarity": "C",
     "name": "Glameow",
     "image": "cPK_10_004200_00_NYARMAR_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4092,7 +4603,8 @@
     "rarity": "U",
     "name": "Purugly",
     "image": "cPK_10_004210_00_BUNYATTO_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4100,7 +4612,8 @@
     "rarity": "C",
     "name": "Chatot",
     "image": "cPK_10_004220_00_PERAP_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4108,7 +4621,8 @@
     "rarity": "C",
     "name": "Fan Rotom",
     "image": "cPK_10_004230_00_SPIN ROTOM_C.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4116,7 +4630,8 @@
     "rarity": "R",
     "name": "Regigigas",
     "image": "cPK_10_004240_00_REGIGIGAS_R.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4124,7 +4639,8 @@
     "rarity": "C",
     "name": "Skull Fossil",
     "image": "cTR_10_000260_00_ZUGAINOKASEKI_C.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4132,15 +4648,17 @@
     "rarity": "C",
     "name": "Armor Fossil",
     "image": "cTR_10_000270_00_TATENOKASEKI_C.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
     "number": 146,
     "rarity": "U",
-    "name": "Pokémon Communication",
+    "name": "Pok\u00e9mon Communication",
     "image": "cTR_10_000280_00_POKEMONTSUUSHIN_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4148,7 +4666,8 @@
     "rarity": "U",
     "name": "Giant Cape",
     "image": "cTR_10_000290_00_OOKINAMANTO_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4156,7 +4675,8 @@
     "rarity": "U",
     "name": "Rocky Helmet",
     "image": "cTR_10_000300_00_GOTSUGOTSUMETTO_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4164,7 +4684,8 @@
     "rarity": "U",
     "name": "Lum Berry",
     "image": "cTR_10_000310_00_RAMUNOMI_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4172,7 +4693,8 @@
     "rarity": "U",
     "name": "Cyrus",
     "image": "cTR_10_000320_00_AKAGI_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4180,7 +4702,8 @@
     "rarity": "U",
     "name": "Team Galactic Grunt",
     "image": "cTR_10_000330_00_GINGADANNOSHITAPPA_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4188,7 +4711,8 @@
     "rarity": "U",
     "name": "Cynthia",
     "image": "cTR_10_000340_00_SHIRONA_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4196,7 +4720,8 @@
     "rarity": "U",
     "name": "Volkner",
     "image": "cTR_10_000350_00_DENZI_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4204,7 +4729,8 @@
     "rarity": "U",
     "name": "Dawn",
     "image": "cTR_10_000360_00_HIKARI_U.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4212,7 +4738,8 @@
     "rarity": "U",
     "name": "Mars",
     "image": "cTR_10_000370_00_MARS_U.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4220,7 +4747,8 @@
     "rarity": "AR",
     "name": "Tangrowth",
     "image": "cPK_20_002860_00_MOJUMBO_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4228,7 +4756,8 @@
     "rarity": "AR",
     "name": "Combee",
     "image": "cPK_20_002980_00_MITSUHONEY_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4236,7 +4765,8 @@
     "rarity": "AR",
     "name": "Carnivine",
     "image": "cPK_20_003000_00_MUSKIPPA_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4244,7 +4774,8 @@
     "rarity": "AR",
     "name": "Shaymin",
     "image": "cPK_20_003030_00_SHAYMIN_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4252,7 +4783,8 @@
     "rarity": "AR",
     "name": "Mamoswine",
     "image": "cPK_20_003140_00_MAMMOO_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4260,7 +4792,8 @@
     "rarity": "AR",
     "name": "Gastrodon",
     "image": "cPK_20_003220_00_TRITODON_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4268,7 +4801,8 @@
     "rarity": "AR",
     "name": "Manaphy",
     "image": "cPK_20_003310_00_MANAPHY_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4276,7 +4810,8 @@
     "rarity": "AR",
     "name": "Shinx",
     "image": "cPK_20_003390_00_KOLINK_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4284,7 +4819,8 @@
     "rarity": "AR",
     "name": "Rotom",
     "image": "cPK_20_003430_00_ROTOM_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4292,7 +4828,8 @@
     "rarity": "AR",
     "name": "Drifloon",
     "image": "cPK_20_003540_00_FUWANTE_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4300,7 +4837,8 @@
     "rarity": "AR",
     "name": "Mesprit",
     "image": "cPK_20_003570_00_EMRIT_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4308,7 +4846,8 @@
     "rarity": "AR",
     "name": "Giratina",
     "image": "cPK_20_003590_00_ORIGINGIRATINA_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4316,7 +4855,8 @@
     "rarity": "AR",
     "name": "Cresselia",
     "image": "cPK_20_003600_00_CRESSELIA_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4324,7 +4864,8 @@
     "rarity": "AR",
     "name": "Rhyperior",
     "image": "cPK_20_003630_00_DOSIDON_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4332,7 +4873,8 @@
     "rarity": "AR",
     "name": "Lucario",
     "image": "cPK_20_003730_00_LUCARIO_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4340,7 +4882,8 @@
     "rarity": "AR",
     "name": "Hippopotas",
     "image": "cPK_20_003740_00_HIPPOPOTAS_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4348,7 +4891,8 @@
     "rarity": "AR",
     "name": "Spiritomb",
     "image": "cPK_20_003850_00_MIKARUGE_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4356,7 +4900,8 @@
     "rarity": "AR",
     "name": "Croagunk",
     "image": "cPK_20_003880_00_GUREGGRU_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4364,7 +4909,8 @@
     "rarity": "AR",
     "name": "Heatran",
     "image": "cPK_20_004010_00_HEATRAN_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4372,7 +4918,8 @@
     "rarity": "AR",
     "name": "Garchomp",
     "image": "cPK_20_004040_00_GABURIAS_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4380,7 +4927,8 @@
     "rarity": "AR",
     "name": "Staraptor",
     "image": "cPK_20_004150_00_MUKUHAWK_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4388,7 +4936,8 @@
     "rarity": "AR",
     "name": "Bidoof",
     "image": "cPK_20_004160_00_BIPPA_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4396,7 +4945,8 @@
     "rarity": "AR",
     "name": "Glameow",
     "image": "cPK_20_004200_00_NYARMAR_AR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4404,7 +4954,8 @@
     "rarity": "AR",
     "name": "Regigigas",
     "image": "cPK_20_004240_00_REGIGIGAS_AR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4412,7 +4963,8 @@
     "rarity": "SR",
     "name": "Yanmega ex",
     "image": "cPK_20_002880_00_MEGAYANMAex_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4420,7 +4972,8 @@
     "rarity": "SR",
     "name": "Infernape ex",
     "image": "cPK_20_003100_00_GOUKAZARUex_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4428,7 +4981,8 @@
     "rarity": "SR",
     "name": "Palkia ex",
     "image": "cPK_20_003300_00_PALKIAex_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4436,7 +4990,8 @@
     "rarity": "SR",
     "name": "Pachirisu ex",
     "image": "cPK_20_003420_00_PACHIRISUex_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4444,7 +4999,8 @@
     "rarity": "SR",
     "name": "Mismagius ex",
     "image": "cPK_20_003480_00_MUMARGIex_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4452,7 +5008,8 @@
     "rarity": "SR",
     "name": "Gallade ex",
     "image": "cPK_20_003760_00_ERUREIDOex_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4460,7 +5017,8 @@
     "rarity": "SR",
     "name": "Weavile ex",
     "image": "cPK_20_003800_00_MANYULAex_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4468,7 +5026,8 @@
     "rarity": "SR",
     "name": "Darkrai ex",
     "image": "cPK_20_003910_00_DARKRAIex_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4476,7 +5035,8 @@
     "rarity": "SR",
     "name": "Dialga ex",
     "image": "cPK_20_004000_00_DIALGAex_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4484,7 +5044,8 @@
     "rarity": "SR",
     "name": "Lickilicky ex",
     "image": "cPK_20_004060_00_BEROBELTex_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4492,7 +5053,8 @@
     "rarity": "SR",
     "name": "Cyrus",
     "image": "cTR_20_000320_00_AKAGI_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4500,7 +5062,8 @@
     "rarity": "SR",
     "name": "Team Galactic Grunt",
     "image": "cTR_20_000330_00_GINGADANNOSHITAPPA_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4508,7 +5071,8 @@
     "rarity": "SR",
     "name": "Cynthia",
     "image": "cTR_20_000340_00_SHIRONA_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4516,7 +5080,8 @@
     "rarity": "SR",
     "name": "Volkner",
     "image": "cTR_20_000350_00_DENZI_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4524,7 +5089,8 @@
     "rarity": "SR",
     "name": "Dawn",
     "image": "cTR_20_000360_00_HIKARI_SR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4532,7 +5098,8 @@
     "rarity": "SR",
     "name": "Mars",
     "image": "cTR_20_000370_00_MARS_SR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4540,7 +5107,8 @@
     "rarity": "SAR",
     "name": "Yanmega ex",
     "image": "cPK_20_002880_01_MEGAYANMAex_SAR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4548,7 +5116,8 @@
     "rarity": "SAR",
     "name": "Infernape ex",
     "image": "cPK_20_003100_01_GOUKAZARUex_SAR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4556,7 +5125,8 @@
     "rarity": "SAR",
     "name": "Pachirisu ex",
     "image": "cPK_20_003420_01_PACHIRISUex_SAR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4564,7 +5134,8 @@
     "rarity": "SAR",
     "name": "Mismagius ex",
     "image": "cPK_20_003480_01_MUMARGIex_SAR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4572,7 +5143,8 @@
     "rarity": "SAR",
     "name": "Gallade ex",
     "image": "cPK_20_003760_01_ERUREIDOex_SAR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4580,7 +5152,8 @@
     "rarity": "SAR",
     "name": "Weavile ex",
     "image": "cPK_20_003800_01_MANYULAex_SAR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4588,7 +5161,8 @@
     "rarity": "SAR",
     "name": "Darkrai ex",
     "image": "cPK_20_003910_01_DARKRAIex_SAR.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4596,7 +5170,8 @@
     "rarity": "SAR",
     "name": "Lickilicky ex",
     "image": "cPK_20_004060_01_BEROBELTex_SAR.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4604,7 +5179,8 @@
     "rarity": "IM",
     "name": "Palkia ex",
     "image": "cPK_20_003300_01_PALKIAex_IM.webp",
-    "packs": ["Palkia"]
+    "packs": ["Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4612,7 +5188,8 @@
     "rarity": "IM",
     "name": "Dialga ex",
     "image": "cPK_20_004000_01_DIALGAex_IM.webp",
-    "packs": ["Dialga"]
+    "packs": ["Dialga"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4620,7 +5197,8 @@
     "rarity": "UR",
     "name": "Palkia ex",
     "image": "cPK_20_003300_02_PALKIAex_UR.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2",
@@ -4628,7 +5206,8 @@
     "rarity": "UR",
     "name": "Dialga ex",
     "image": "cPK_20_004000_02_DIALGAex_UR.webp",
-    "packs": ["Dialga", "Palkia"]
+    "packs": ["Dialga", "Palkia"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4636,7 +5215,8 @@
     "rarity": "U",
     "name": "Heracross",
     "image": "cPK_10_004250_00_HERACROS_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4644,7 +5224,8 @@
     "rarity": "C",
     "name": "Burmy",
     "image": "cPK_10_004260_00_MINOMUCCHI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4652,7 +5233,8 @@
     "rarity": "U",
     "name": "Mothim",
     "image": "cPK_10_004270_00_GAMALE_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4660,7 +5242,8 @@
     "rarity": "C",
     "name": "Combee",
     "image": "cPK_10_004280_00_MITSUHONEY_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4668,7 +5251,8 @@
     "rarity": "U",
     "name": "Vespiquen",
     "image": "cPK_10_004290_00_BEEQUEN_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4676,7 +5260,8 @@
     "rarity": "C",
     "name": "Cherubi",
     "image": "cPK_10_004300_00_CHERINBO_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4684,7 +5269,8 @@
     "rarity": "U",
     "name": "Cherrim",
     "image": "cPK_10_004310_00_CHERRIM_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4692,7 +5278,8 @@
     "rarity": "U",
     "name": "Cherrim",
     "image": "cPK_10_004320_00_CHERRIM_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4700,7 +5287,8 @@
     "rarity": "R",
     "name": "Carnivine",
     "image": "cPK_10_004330_00_MUSKIPPA_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4708,7 +5296,8 @@
     "rarity": "RR",
     "name": "Leafeon ex",
     "image": "cPK_10_004340_00_LEAFIAex_RR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4716,7 +5305,8 @@
     "rarity": "C",
     "name": "Houndour",
     "image": "cPK_10_004350_00_DELVIL_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4724,7 +5314,8 @@
     "rarity": "U",
     "name": "Houndoom",
     "image": "cPK_10_004360_00_HELLGAR_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4732,7 +5323,8 @@
     "rarity": "R",
     "name": "Heatran",
     "image": "cPK_10_004370_00_HEATRAN_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4740,7 +5332,8 @@
     "rarity": "C",
     "name": "Marill",
     "image": "cPK_10_004380_00_MARIL_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4748,7 +5341,8 @@
     "rarity": "C",
     "name": "Azumarill",
     "image": "cPK_10_004390_00_MARILLI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4756,7 +5350,8 @@
     "rarity": "C",
     "name": "Barboach",
     "image": "cPK_10_004400_00_DOJOACH_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4764,7 +5359,8 @@
     "rarity": "U",
     "name": "Whiscash",
     "image": "cPK_10_004410_00_NAMAZUN_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4772,7 +5368,8 @@
     "rarity": "C",
     "name": "Snorunt",
     "image": "cPK_10_004420_00_YUKIWARASHI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4780,7 +5377,8 @@
     "rarity": "U",
     "name": "Froslass",
     "image": "cPK_10_004430_00_YUKIMENOKO_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4788,7 +5386,8 @@
     "rarity": "C",
     "name": "Snover",
     "image": "cPK_10_004440_00_YUKIKABURI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4796,7 +5395,8 @@
     "rarity": "R",
     "name": "Abomasnow",
     "image": "cPK_10_004450_00_YUKINOOH_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4804,7 +5404,8 @@
     "rarity": "RR",
     "name": "Glaceon ex",
     "image": "cPK_10_004460_00_GLACIAex_RR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4812,7 +5413,8 @@
     "rarity": "R",
     "name": "Palkia",
     "image": "cPK_10_004470_00_ORIGINPALKIA_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4820,7 +5422,8 @@
     "rarity": "U",
     "name": "Phione",
     "image": "cPK_10_004480_00_PHIONE_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4828,7 +5431,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_10_004490_00_PIKACHU_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4836,7 +5440,8 @@
     "rarity": "R",
     "name": "Raichu",
     "image": "cPK_10_004500_00_RAICHU_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4844,7 +5449,8 @@
     "rarity": "C",
     "name": "Electrike",
     "image": "cPK_10_004510_00_RAKURAI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4852,7 +5458,8 @@
     "rarity": "U",
     "name": "Manectric",
     "image": "cPK_10_004520_00_LIVOLT_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4860,7 +5467,8 @@
     "rarity": "C",
     "name": "Clefairy",
     "image": "cPK_10_004530_00_PIPPI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4868,7 +5476,8 @@
     "rarity": "U",
     "name": "Clefable",
     "image": "cPK_10_004540_00_PIXY_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4876,7 +5485,8 @@
     "rarity": "C",
     "name": "Gastly",
     "image": "cPK_10_004550_00_GHOS_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4884,7 +5494,8 @@
     "rarity": "C",
     "name": "Haunter",
     "image": "cPK_10_004560_00_GHOST_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4892,7 +5503,8 @@
     "rarity": "U",
     "name": "Gengar",
     "image": "cPK_10_004570_00_GANGAR_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4900,7 +5512,8 @@
     "rarity": "U",
     "name": "Unown",
     "image": "cPK_10_004580_00_UNKNOWN_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4908,7 +5521,8 @@
     "rarity": "R",
     "name": "Rotom",
     "image": "cPK_10_004590_00_ROTOM_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4916,7 +5530,8 @@
     "rarity": "U",
     "name": "Sudowoodo",
     "image": "cPK_10_004600_00_USOKKIE_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4924,7 +5539,8 @@
     "rarity": "C",
     "name": "Phanpy",
     "image": "cPK_10_004610_00_GOMAZOU_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4932,7 +5548,8 @@
     "rarity": "U",
     "name": "Donphan",
     "image": "cPK_10_004620_00_DONFAN_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4940,7 +5557,8 @@
     "rarity": "C",
     "name": "Larvitar",
     "image": "cPK_10_004630_00_YOGIRAS_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4948,7 +5566,8 @@
     "rarity": "U",
     "name": "Pupitar",
     "image": "cPK_10_004640_00_SANAGIRAS_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4956,7 +5575,8 @@
     "rarity": "R",
     "name": "Tyranitar",
     "image": "cPK_10_004650_00_BANGIRAS_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4964,7 +5584,8 @@
     "rarity": "C",
     "name": "Nosepass",
     "image": "cPK_10_004660_00_NOSEPASS_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4972,7 +5593,8 @@
     "rarity": "C",
     "name": "Meditite",
     "image": "cPK_10_004670_00_ASANAN_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4980,7 +5602,8 @@
     "rarity": "U",
     "name": "Medicham",
     "image": "cPK_10_004680_00_CHAREM_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4988,7 +5611,8 @@
     "rarity": "C",
     "name": "Gible",
     "image": "cPK_10_004690_00_FUKAMARU_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -4996,7 +5620,8 @@
     "rarity": "C",
     "name": "Gabite",
     "image": "cPK_10_004700_00_GABITE_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5004,7 +5629,8 @@
     "rarity": "RR",
     "name": "Garchomp ex",
     "image": "cPK_10_004710_00_GABURIASex_RR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5012,7 +5638,8 @@
     "rarity": "C",
     "name": "Zubat",
     "image": "cPK_10_004720_00_ZUBAT_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5020,7 +5647,8 @@
     "rarity": "C",
     "name": "Golbat",
     "image": "cPK_10_004730_00_GOLBAT_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5028,7 +5656,8 @@
     "rarity": "R",
     "name": "Crobat",
     "image": "cPK_10_004740_00_CROBAT_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5036,7 +5665,8 @@
     "rarity": "C",
     "name": "Croagunk",
     "image": "cPK_10_004750_00_GUREGGRU_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5044,7 +5674,8 @@
     "rarity": "U",
     "name": "Toxicroak",
     "image": "cPK_10_004760_00_DOKUROG_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5052,7 +5683,8 @@
     "rarity": "C",
     "name": "Magnemite",
     "image": "cPK_10_004770_00_COIL_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5060,7 +5692,8 @@
     "rarity": "C",
     "name": "Magneton",
     "image": "cPK_10_004780_00_RARECOIL_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5068,7 +5701,8 @@
     "rarity": "R",
     "name": "Magnezone",
     "image": "cPK_10_004790_00_JIBACOIL_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5076,7 +5710,8 @@
     "rarity": "C",
     "name": "Mawile",
     "image": "cPK_10_004800_00_KUCHEAT_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5084,7 +5719,8 @@
     "rarity": "RR",
     "name": "Probopass ex",
     "image": "cPK_10_004810_00_DAINOSEex_RR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5092,7 +5728,8 @@
     "rarity": "C",
     "name": "Bronzor",
     "image": "cPK_10_004820_00_DOHMIRROR_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5100,7 +5737,8 @@
     "rarity": "U",
     "name": "Bronzong",
     "image": "cPK_10_004830_00_DOHTAKUN_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5108,7 +5746,8 @@
     "rarity": "R",
     "name": "Dialga",
     "image": "cPK_10_004840_00_ORIGINDIALGA_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5116,7 +5755,8 @@
     "rarity": "R",
     "name": "Giratina",
     "image": "cPK_10_004850_00_GIRATINA_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5124,7 +5764,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_004860_00_EIEVUI_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5132,7 +5773,8 @@
     "rarity": "U",
     "name": "Snorlax",
     "image": "cPK_10_004870_00_KABIGON_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5140,7 +5782,8 @@
     "rarity": "C",
     "name": "Hoothoot",
     "image": "cPK_10_004880_00_HOHO_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5148,7 +5791,8 @@
     "rarity": "U",
     "name": "Noctowl",
     "image": "cPK_10_004890_00_YORUNOZUKU_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5156,7 +5800,8 @@
     "rarity": "C",
     "name": "Starly",
     "image": "cPK_10_004900_00_MUKKURU_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5164,7 +5809,8 @@
     "rarity": "C",
     "name": "Staravia",
     "image": "cPK_10_004910_00_MUKUBIRD_C.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5172,7 +5818,8 @@
     "rarity": "U",
     "name": "Staraptor",
     "image": "cPK_10_004920_00_MUKUHAWK_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5180,7 +5827,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_10_004930_00_SHAYMIN_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5188,7 +5836,8 @@
     "rarity": "R",
     "name": "Arceus",
     "image": "cPK_10_004940_00_ARCEUS_R.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5196,7 +5845,8 @@
     "rarity": "RR",
     "name": "Arceus ex",
     "image": "cPK_10_004950_00_ARCEUSex_RR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5204,7 +5854,8 @@
     "rarity": "U",
     "name": "Irida",
     "image": "cTR_10_000380_00_KAI_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5212,7 +5863,8 @@
     "rarity": "U",
     "name": "Celestic Town Elder",
     "image": "cTR_10_000390_00_KANNAGITOWNNOTYOUROU_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5220,7 +5872,8 @@
     "rarity": "U",
     "name": "Barry",
     "image": "cTR_10_000400_00_JUN_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5228,7 +5881,8 @@
     "rarity": "U",
     "name": "Adaman",
     "image": "cTR_10_000410_00_SEKI_U.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5236,7 +5890,8 @@
     "rarity": "AR",
     "name": "Houndoom",
     "image": "cPK_20_004360_00_HELLGAR_AR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5244,7 +5899,8 @@
     "rarity": "AR",
     "name": "Marill",
     "image": "cPK_20_004380_00_MARIL_AR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5252,7 +5908,8 @@
     "rarity": "AR",
     "name": "Unown",
     "image": "cPK_20_004580_00_UNKNOWN_AR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5260,7 +5917,8 @@
     "rarity": "AR",
     "name": "Sudowoodo",
     "image": "cPK_20_004600_00_USOKKIE_AR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5268,7 +5926,8 @@
     "rarity": "AR",
     "name": "Magnemite",
     "image": "cPK_20_004770_00_COIL_AR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5276,7 +5935,8 @@
     "rarity": "AR",
     "name": "Shaymin",
     "image": "cPK_20_004930_00_SHAYMIN_AR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5284,7 +5944,8 @@
     "rarity": "SR",
     "name": "Leafeon ex",
     "image": "cPK_20_004340_00_LEAFIAex_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5292,7 +5953,8 @@
     "rarity": "SR",
     "name": "Glaceon ex",
     "image": "cPK_20_004460_00_GLACIAex_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5300,7 +5962,8 @@
     "rarity": "SR",
     "name": "Garchomp ex",
     "image": "cPK_20_004710_00_GABURIASex_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5308,7 +5971,8 @@
     "rarity": "SR",
     "name": "Probopass ex",
     "image": "cPK_20_004810_00_DAINOSEex_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5316,7 +5980,8 @@
     "rarity": "SR",
     "name": "Arceus ex",
     "image": "cPK_20_004950_00_ARCEUSex_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5324,7 +5989,8 @@
     "rarity": "SR",
     "name": "Irida",
     "image": "cTR_20_000380_00_KAI_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5332,7 +5998,8 @@
     "rarity": "SR",
     "name": "Celestic Town Elder",
     "image": "cTR_20_000390_00_KANNAGITOWNNOTYOUROU_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5340,7 +6007,8 @@
     "rarity": "SR",
     "name": "Barry",
     "image": "cTR_20_000400_00_JUN_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5348,7 +6016,8 @@
     "rarity": "SR",
     "name": "Adaman",
     "image": "cTR_20_000410_00_SEKI_SR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5356,7 +6025,8 @@
     "rarity": "SAR",
     "name": "Leafeon ex",
     "image": "cPK_20_004340_01_LEAFIAex_SAR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5364,7 +6034,8 @@
     "rarity": "SAR",
     "name": "Glaceon ex",
     "image": "cPK_20_004460_01_GLACIAex_SAR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5372,7 +6043,8 @@
     "rarity": "SAR",
     "name": "Garchomp ex",
     "image": "cPK_20_004710_01_GABURIASex_SAR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5380,7 +6052,8 @@
     "rarity": "SAR",
     "name": "Probopass ex",
     "image": "cPK_20_004810_01_DAINOSEex_SAR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5388,7 +6061,8 @@
     "rarity": "IM",
     "name": "Arceus ex",
     "image": "cPK_20_004950_01_ARCEUSex_IM.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2a",
@@ -5396,7 +6070,8 @@
     "rarity": "UR",
     "name": "Arceus ex",
     "image": "cPK_20_004950_02_ARCEUSex_UR.webp",
-    "packs": ["Arceus"]
+    "packs": ["Arceus"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5404,7 +6079,8 @@
     "rarity": "C",
     "name": "Weedle",
     "image": "cPK_10_005210_00_BEEDLE_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5412,7 +6088,8 @@
     "rarity": "U",
     "name": "Kakuna",
     "image": "cPK_10_005220_00_COCOON_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5420,7 +6097,8 @@
     "rarity": "RR",
     "name": "Beedrill ex",
     "image": "cPK_10_005230_00_SPEARex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5428,7 +6106,8 @@
     "rarity": "C",
     "name": "Pinsir",
     "image": "cPK_10_005240_00_KAILIOS_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5436,7 +6115,8 @@
     "rarity": "C",
     "name": "Sprigatito",
     "image": "cPK_10_005080_00_NYAHOJA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5444,7 +6124,8 @@
     "rarity": "U",
     "name": "Floragato",
     "image": "cPK_10_005250_00_NYAROTE_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5452,7 +6133,8 @@
     "rarity": "R",
     "name": "Meowscarada",
     "image": "cPK_10_005260_00_MASQUERNYA_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5460,7 +6142,8 @@
     "rarity": "C",
     "name": "Charmander",
     "image": "cPK_10_005270_00_HITOKAGE_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5468,7 +6151,8 @@
     "rarity": "U",
     "name": "Charmeleon",
     "image": "cPK_10_005280_00_LIZARDO_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5476,7 +6160,8 @@
     "rarity": "RR",
     "name": "Charizard ex",
     "image": "cPK_10_005290_00_LIZARDONex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5484,7 +6169,8 @@
     "rarity": "C",
     "name": "Magmar",
     "image": "cPK_10_005300_00_BOOBER_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5492,7 +6178,8 @@
     "rarity": "R",
     "name": "Magmortar",
     "image": "cPK_10_005310_00_BOOBURN_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5500,7 +6187,8 @@
     "rarity": "U",
     "name": "Paldean Tauros",
     "image": "cPK_10_005320_00_PALDEAKENTAUROS_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5508,7 +6196,8 @@
     "rarity": "C",
     "name": "Tentacool",
     "image": "cPK_10_005330_00_MENOKURAGE_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5516,7 +6205,8 @@
     "rarity": "U",
     "name": "Tentacruel",
     "image": "cPK_10_005340_00_DOKUKURAGE_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5524,7 +6214,8 @@
     "rarity": "C",
     "name": "Buizel",
     "image": "cPK_10_005350_00_BUOYSEL_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5532,7 +6223,8 @@
     "rarity": "U",
     "name": "Floatzel",
     "image": "cPK_10_005360_00_FLOAZEL_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5540,7 +6232,8 @@
     "rarity": "C",
     "name": "Wiglett",
     "image": "cPK_10_005370_00_UMIDIGDA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5548,7 +6241,8 @@
     "rarity": "RR",
     "name": "Wugtrio ex",
     "image": "cPK_10_005380_00_UMITRIOex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5556,7 +6250,8 @@
     "rarity": "R",
     "name": "Dondozo",
     "image": "cPK_10_005390_00_HEYRUSHER_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5564,7 +6259,8 @@
     "rarity": "U",
     "name": "Tatsugiri",
     "image": "cPK_10_005400_00_SYARITATSU_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5572,7 +6268,8 @@
     "rarity": "RR",
     "name": "Pikachu ex",
     "image": "cPK_10_005410_00_PIKACHUex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5580,7 +6277,8 @@
     "rarity": "C",
     "name": "Voltorb",
     "image": "cPK_10_005420_00_BIRIRIDAMA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5588,7 +6286,8 @@
     "rarity": "U",
     "name": "Electrode",
     "image": "cPK_10_005430_00_MARUMINE_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5596,7 +6295,8 @@
     "rarity": "U",
     "name": "Pachirisu",
     "image": "cPK_10_005060_00_PACHIRISU_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5604,7 +6304,8 @@
     "rarity": "C",
     "name": "Pawmi",
     "image": "cPK_10_005440_00_PAMO_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5612,7 +6313,8 @@
     "rarity": "U",
     "name": "Pawmo",
     "image": "cPK_10_005450_00_PAMOT_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5620,7 +6322,8 @@
     "rarity": "R",
     "name": "Pawmot",
     "image": "cPK_10_005010_00_PARMOT_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5628,7 +6331,8 @@
     "rarity": "C",
     "name": "Abra",
     "image": "cPK_10_005460_00_CASEY_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5636,7 +6340,8 @@
     "rarity": "U",
     "name": "Kadabra",
     "image": "cPK_10_005470_00_YUNGERER_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5644,7 +6349,8 @@
     "rarity": "R",
     "name": "Alakazam",
     "image": "cPK_10_005480_00_FOODIN_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5652,7 +6358,8 @@
     "rarity": "C",
     "name": "Mr. Mime",
     "image": "cPK_10_005490_00_BARRIERD_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5660,7 +6367,8 @@
     "rarity": "C",
     "name": "Drifloon",
     "image": "cPK_10_005500_00_FUWANTE_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5668,7 +6376,8 @@
     "rarity": "U",
     "name": "Drifblim",
     "image": "cPK_10_005510_00_FUWARIDE_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5676,7 +6385,8 @@
     "rarity": "RR",
     "name": "Giratina ex",
     "image": "cPK_10_005520_00_GIRATINAex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5684,7 +6394,8 @@
     "rarity": "C",
     "name": "Gimmighoul",
     "image": "cPK_10_005530_00_COLLECUREI_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5692,7 +6403,8 @@
     "rarity": "C",
     "name": "Machop",
     "image": "cPK_10_005540_00_WANRIKY_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5700,7 +6412,8 @@
     "rarity": "C",
     "name": "Machoke",
     "image": "cPK_10_005550_00_GORIKY_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5708,7 +6421,8 @@
     "rarity": "R",
     "name": "Machamp",
     "image": "cPK_10_005020_00_KAIRIKY_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5716,7 +6430,8 @@
     "rarity": "C",
     "name": "Hitmonlee",
     "image": "cPK_10_005560_00_SAWAMULAR_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5724,7 +6439,8 @@
     "rarity": "C",
     "name": "Hitmonchan",
     "image": "cPK_10_005570_00_EBIWALAR_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5732,7 +6448,8 @@
     "rarity": "C",
     "name": "Riolu",
     "image": "cPK_10_005070_00_RIOLU_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5740,7 +6457,8 @@
     "rarity": "RR",
     "name": "Lucario ex",
     "image": "cPK_10_005580_00_LUCARIOex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5748,7 +6466,8 @@
     "rarity": "U",
     "name": "Flamigo",
     "image": "cPK_10_005590_00_KARAMINGO_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5756,7 +6475,8 @@
     "rarity": "C",
     "name": "Ekans",
     "image": "cPK_10_005600_00_ARBO_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5764,7 +6484,8 @@
     "rarity": "U",
     "name": "Arbok",
     "image": "cPK_10_005610_00_ARBOK_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5772,7 +6493,8 @@
     "rarity": "C",
     "name": "Paldean Wooper",
     "image": "cPK_10_005620_00_PALDEAUPAH_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5780,7 +6502,8 @@
     "rarity": "RR",
     "name": "Paldean Clodsire ex",
     "image": "cPK_10_005630_00_PALDEADOOHex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5788,7 +6511,8 @@
     "rarity": "U",
     "name": "Spiritomb",
     "image": "cPK_10_005640_00_MIKARUGE_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5796,7 +6520,8 @@
     "rarity": "C",
     "name": "Shroodle",
     "image": "cPK_10_005650_00_SHIRUSHREW_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5804,7 +6529,8 @@
     "rarity": "R",
     "name": "Grafaiai",
     "image": "cPK_10_005660_00_TAGGINGRU_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5812,7 +6538,8 @@
     "rarity": "C",
     "name": "Tinkatink",
     "image": "cPK_10_005670_00_KANUCHAN_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5820,7 +6547,8 @@
     "rarity": "U",
     "name": "Tinkatuff",
     "image": "cPK_10_005680_00_NAKANUCHAN_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5828,7 +6556,8 @@
     "rarity": "RR",
     "name": "Tinkaton ex",
     "image": "cPK_10_005690_00_DEKANUCHANex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5836,7 +6565,8 @@
     "rarity": "C",
     "name": "Varoom",
     "image": "cPK_10_005700_00_BURORON_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5844,7 +6574,8 @@
     "rarity": "U",
     "name": "Revavroom",
     "image": "cPK_10_005710_00_BUROROROOM_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5852,7 +6583,8 @@
     "rarity": "R",
     "name": "Gholdengo",
     "image": "cPK_10_005720_00_SURFUGO_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5860,7 +6592,8 @@
     "rarity": "C",
     "name": "Rattata",
     "image": "cPK_10_005730_00_KORATTA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5868,7 +6601,8 @@
     "rarity": "C",
     "name": "Raticate",
     "image": "cPK_10_005740_00_RATTA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5876,7 +6610,8 @@
     "rarity": "C",
     "name": "Jigglypuff",
     "image": "cPK_10_005750_00_PURIN_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5884,7 +6619,8 @@
     "rarity": "R",
     "name": "Wigglytuff",
     "image": "cPK_10_005760_00_PUKURIN_R.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5892,7 +6628,8 @@
     "rarity": "C",
     "name": "Lickitung",
     "image": "cPK_10_005770_00_BERORINGA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5900,7 +6637,8 @@
     "rarity": "C",
     "name": "Lickilicky",
     "image": "cPK_10_005780_00_BEROBELT_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5908,7 +6646,8 @@
     "rarity": "C",
     "name": "Bidoof",
     "image": "cPK_10_005040_00_BIPPA_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5916,7 +6655,8 @@
     "rarity": "RR",
     "name": "Bibarel ex",
     "image": "cPK_10_005790_00_BEADARUex_RR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5924,7 +6664,8 @@
     "rarity": "C",
     "name": "Buneary",
     "image": "cPK_10_005800_00_MIMIROL_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5932,7 +6673,8 @@
     "rarity": "C",
     "name": "Lopunny",
     "image": "cPK_10_005810_00_MIMILOP_C.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5940,7 +6682,8 @@
     "rarity": "U",
     "name": "Cyclizar",
     "image": "cPK_10_005090_00_MOTOTOKAGE_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5948,15 +6691,17 @@
     "rarity": "U",
     "name": "Iono",
     "image": "cTR_10_000420_00_NANJYAMO_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
     "number": 70,
     "rarity": "U",
-    "name": "Pokémon Center Lady",
+    "name": "Pok\u00e9mon Center Lady",
     "image": "cTR_10_000430_00_POKEMONCENTERNOONEESAN_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5964,7 +6709,8 @@
     "rarity": "U",
     "name": "Red",
     "image": "cTR_10_000440_00_RED_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5972,7 +6718,8 @@
     "rarity": "U",
     "name": "Team Rocket Grunt",
     "image": "cTR_10_000450_00_ROCKETDANNOSHITAPPA_U.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5980,7 +6727,8 @@
     "rarity": "AR",
     "name": "Meowscarada",
     "image": "cPK_20_005260_00_MASQUERNYA_AR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5988,7 +6736,8 @@
     "rarity": "AR",
     "name": "Buizel",
     "image": "cPK_20_005350_00_BUOYSEL_AR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -5996,7 +6745,8 @@
     "rarity": "AR",
     "name": "Tatsugiri",
     "image": "cPK_20_005400_00_SYARITATSU_AR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6004,7 +6754,8 @@
     "rarity": "AR",
     "name": "Grafaiai",
     "image": "cPK_20_005660_00_TAGGINGRU_AR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6012,7 +6763,8 @@
     "rarity": "AR",
     "name": "Gholdengo",
     "image": "cPK_20_005720_00_SURFUGO_AR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6020,7 +6772,8 @@
     "rarity": "AR",
     "name": "Wigglytuff",
     "image": "cPK_20_005760_00_PUKURIN_AR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6028,7 +6781,8 @@
     "rarity": "SR",
     "name": "Beedrill ex",
     "image": "cPK_20_005230_00_SPEARex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6036,7 +6790,8 @@
     "rarity": "SR",
     "name": "Charizard ex",
     "image": "cPK_20_005290_00_LIZARDONex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6044,7 +6799,8 @@
     "rarity": "SR",
     "name": "Wugtrio ex",
     "image": "cPK_20_005380_00_UMITRIOex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6052,7 +6808,8 @@
     "rarity": "SR",
     "name": "Pikachu ex",
     "image": "cPK_20_005410_00_PIKACHUex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6060,7 +6817,8 @@
     "rarity": "SR",
     "name": "Giratina ex",
     "image": "cPK_20_005520_00_GIRATINAex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6068,7 +6826,8 @@
     "rarity": "SR",
     "name": "Lucario ex",
     "image": "cPK_20_005580_00_LUCARIOex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6076,7 +6835,8 @@
     "rarity": "SR",
     "name": "Paldean Clodsire ex",
     "image": "cPK_20_005630_00_PALDEADOOHex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6084,7 +6844,8 @@
     "rarity": "SR",
     "name": "Tinkaton ex",
     "image": "cPK_20_005690_00_DEKANUCHANex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6092,7 +6853,8 @@
     "rarity": "SR",
     "name": "Bibarel ex",
     "image": "cPK_20_005790_00_BEADARUex_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6100,15 +6862,17 @@
     "rarity": "SR",
     "name": "Iono",
     "image": "cTR_20_000420_00_NANJYAMO_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
     "number": 89,
     "rarity": "SR",
-    "name": "Pokémon Center Lady",
+    "name": "Pok\u00e9mon Center Lady",
     "image": "cTR_20_000430_00_POKEMONCENTERNOONEESAN_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6116,7 +6880,8 @@
     "rarity": "SR",
     "name": "Red",
     "image": "cTR_20_000440_00_RED_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6124,7 +6889,8 @@
     "rarity": "SR",
     "name": "Team Rocket Grunt",
     "image": "cTR_20_000450_00_ROCKETDANNOSHITAPPA_SR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6132,7 +6898,8 @@
     "rarity": "SAR",
     "name": "Pikachu ex",
     "image": "cPK_20_005410_01_PIKACHUex_SAR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6140,7 +6907,8 @@
     "rarity": "SAR",
     "name": "Paldean Clodsire ex",
     "image": "cPK_20_005630_01_PALDEADOOHex_SAR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6148,7 +6916,8 @@
     "rarity": "SAR",
     "name": "Tinkaton ex",
     "image": "cPK_20_005690_01_DEKANUCHANex_SAR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6156,7 +6925,8 @@
     "rarity": "SAR",
     "name": "Bibarel ex",
     "image": "cPK_20_005790_01_BEADARUex_SAR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6164,7 +6934,8 @@
     "rarity": "IM",
     "name": "Giratina ex",
     "image": "cPK_20_005520_01_GIRATINAex_IM.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6172,7 +6943,8 @@
     "rarity": "S",
     "name": "Weedle",
     "image": "cPK_20_005210_00_BEEDLE_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6180,7 +6952,8 @@
     "rarity": "S",
     "name": "Kakuna",
     "image": "cPK_20_005220_00_COCOON_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6188,7 +6961,8 @@
     "rarity": "S",
     "name": "Charmander",
     "image": "cPK_20_005270_00_HITOKAGE_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6196,7 +6970,8 @@
     "rarity": "S",
     "name": "Charmeleon",
     "image": "cPK_20_005280_00_LIZARDO_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6204,7 +6979,8 @@
     "rarity": "S",
     "name": "Wiglett",
     "image": "cPK_20_005370_00_UMIDIGDA_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6212,7 +6988,8 @@
     "rarity": "S",
     "name": "Dondozo",
     "image": "cPK_20_005390_00_HEYRUSHER_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6220,7 +6997,8 @@
     "rarity": "S",
     "name": "Pachirisu",
     "image": "cPK_20_005060_00_PACHIRISU_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6228,7 +7006,8 @@
     "rarity": "S",
     "name": "Riolu",
     "image": "cPK_20_005070_00_RIOLU_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6236,7 +7015,8 @@
     "rarity": "S",
     "name": "Varoom",
     "image": "cPK_20_005700_00_BURORON_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6244,7 +7024,8 @@
     "rarity": "S",
     "name": "Revavroom",
     "image": "cPK_20_005710_00_BUROROROOM_S.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6252,7 +7033,8 @@
     "rarity": "SSR",
     "name": "Beedrill ex",
     "image": "cPK_20_005230_01_SPEARex_SSR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6260,7 +7042,8 @@
     "rarity": "SSR",
     "name": "Charizard ex",
     "image": "cPK_20_005290_01_LIZARDONex_SSR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6268,7 +7051,8 @@
     "rarity": "SSR",
     "name": "Wugtrio ex",
     "image": "cPK_20_005380_01_UMITRIOex_SSR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
@@ -6276,15 +7060,17 @@
     "rarity": "SSR",
     "name": "Lucario ex",
     "image": "cPK_20_005580_01_LUCARIOex_SSR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A2b",
     "number": 111,
     "rarity": "UR",
-    "name": "Poké Ball",
+    "name": "Pok\u00e9 Ball",
     "image": "cTR_20_000030_00_MONSTERBALL_UR.webp",
-    "packs": ["Shining"]
+    "packs": ["Shining"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6292,7 +7078,8 @@
     "rarity": "C",
     "name": "Exeggcute",
     "image": "cPK_10_005820_00_TAMATAMA_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6300,7 +7087,8 @@
     "rarity": "R",
     "name": "Alolan Exeggutor",
     "image": "cPK_10_005830_00_ALOLANASSY_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6308,7 +7096,8 @@
     "rarity": "C",
     "name": "Surskit",
     "image": "cPK_10_005840_00_AMETAMA_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6316,7 +7105,8 @@
     "rarity": "U",
     "name": "Masquerain",
     "image": "cPK_10_005850_00_AMEMOTH_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6324,7 +7114,8 @@
     "rarity": "C",
     "name": "Maractus",
     "image": "cPK_10_005860_00_MARACACCHI_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6332,7 +7123,8 @@
     "rarity": "C",
     "name": "Karrablast",
     "image": "cPK_10_005870_00_KABURUMO_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6340,7 +7132,8 @@
     "rarity": "C",
     "name": "Phantump",
     "image": "cPK_10_005880_00_BOKUREI_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6348,7 +7141,8 @@
     "rarity": "U",
     "name": "Trevenant",
     "image": "cPK_10_005890_00_OHROT_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6356,7 +7150,8 @@
     "rarity": "C",
     "name": "Rowlet",
     "image": "cPK_10_005900_00_MOKUROH_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6364,7 +7159,8 @@
     "rarity": "C",
     "name": "Rowlet",
     "image": "cPK_10_005910_00_MOKUROH_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6372,7 +7168,8 @@
     "rarity": "U",
     "name": "Dartrix",
     "image": "cPK_10_005920_00_FUKUTHROW_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6380,7 +7177,8 @@
     "rarity": "RR",
     "name": "Decidueye ex",
     "image": "cPK_10_005930_00_JUNAIPERex_RR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6388,7 +7186,8 @@
     "rarity": "C",
     "name": "Grubbin",
     "image": "cPK_10_005940_00_AGOJIMUSHI_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6396,7 +7195,8 @@
     "rarity": "C",
     "name": "Fomantis",
     "image": "cPK_10_005950_00_KARIKIRI_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6404,7 +7204,8 @@
     "rarity": "U",
     "name": "Lurantis",
     "image": "cPK_10_005960_00_LALANTES_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6412,7 +7213,8 @@
     "rarity": "C",
     "name": "Morelull",
     "image": "cPK_10_005970_00_NEMASYU_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6420,7 +7222,8 @@
     "rarity": "U",
     "name": "Shiinotic",
     "image": "cPK_10_005980_00_MASHADE_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6428,7 +7231,8 @@
     "rarity": "C",
     "name": "Bounsweet",
     "image": "cPK_10_005990_00_AMAKAJI_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6436,7 +7240,8 @@
     "rarity": "U",
     "name": "Steenee",
     "image": "cPK_10_006000_00_AMAMAIKO_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6444,7 +7249,8 @@
     "rarity": "R",
     "name": "Tsareena",
     "image": "cPK_10_006010_00_AMAJO_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6452,7 +7258,8 @@
     "rarity": "C",
     "name": "Wimpod",
     "image": "cPK_10_006020_00_KOSOKUMUSHI_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6460,7 +7267,8 @@
     "rarity": "R",
     "name": "Golisopod",
     "image": "cPK_10_006030_00_GUSOKUMUSHA_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6468,7 +7276,8 @@
     "rarity": "RR",
     "name": "Dhelmise ex",
     "image": "cPK_10_006040_00_DADARINex_RR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6476,7 +7285,8 @@
     "rarity": "R",
     "name": "Tapu Bulu",
     "image": "cPK_10_006050_00_KAPU-BULUL_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6484,7 +7294,8 @@
     "rarity": "C",
     "name": "Growlithe",
     "image": "cPK_10_006060_00_GARDIE_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6492,7 +7303,8 @@
     "rarity": "U",
     "name": "Arcanine",
     "image": "cPK_10_006070_00_WINDIE_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6500,7 +7312,8 @@
     "rarity": "U",
     "name": "Alolan Marowak",
     "image": "cPK_10_006080_00_ALOLAGARAGARA_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6508,7 +7321,8 @@
     "rarity": "C",
     "name": "Fletchinder",
     "image": "cPK_10_006090_00_HINOYAKOMA_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6516,7 +7330,8 @@
     "rarity": "R",
     "name": "Talonflame",
     "image": "cPK_10_006100_00_FIARROW_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6524,7 +7339,8 @@
     "rarity": "C",
     "name": "Litten",
     "image": "cPK_10_006110_00_NYABBY_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6532,7 +7348,8 @@
     "rarity": "C",
     "name": "Litten",
     "image": "cPK_10_006120_00_NYABBY_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6540,7 +7357,8 @@
     "rarity": "U",
     "name": "Torracat",
     "image": "cPK_10_006130_00_NYAHEAT_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6548,7 +7366,8 @@
     "rarity": "RR",
     "name": "Incineroar ex",
     "image": "cPK_10_006140_00_GAOGAENex_RR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6556,7 +7375,8 @@
     "rarity": "U",
     "name": "Oricorio",
     "image": "cPK_10_006150_00_ODORIDORIMERAMERASTYLE_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6564,7 +7384,8 @@
     "rarity": "C",
     "name": "Salandit",
     "image": "cPK_10_006160_00_YATOUMORI_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6572,7 +7393,8 @@
     "rarity": "C",
     "name": "Salazzle",
     "image": "cPK_10_006170_00_ENNEWT_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6580,7 +7402,8 @@
     "rarity": "R",
     "name": "Turtonator",
     "image": "cPK_10_006180_00_BAKUGAMES_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6588,7 +7411,8 @@
     "rarity": "C",
     "name": "Alolan Sandshrew",
     "image": "cPK_10_006190_00_ALOLASAND_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6596,7 +7420,8 @@
     "rarity": "U",
     "name": "Alolan Sandslash",
     "image": "cPK_10_006200_00_ALOLASANDPAN_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6604,7 +7429,8 @@
     "rarity": "C",
     "name": "Alolan Vulpix",
     "image": "cPK_10_006210_00_ALOLAROKON_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6612,7 +7438,8 @@
     "rarity": "R",
     "name": "Alolan Ninetales",
     "image": "cPK_10_006220_00_ALOLAKYUKON_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6620,7 +7447,8 @@
     "rarity": "C",
     "name": "Shellder",
     "image": "cPK_10_006230_00_SHELLDER_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6628,7 +7456,8 @@
     "rarity": "U",
     "name": "Cloyster",
     "image": "cPK_10_006240_00_PARSHEN_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6636,7 +7465,8 @@
     "rarity": "U",
     "name": "Lapras",
     "image": "cPK_10_006250_00_LAPLACE_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6644,7 +7474,8 @@
     "rarity": "C",
     "name": "Popplio",
     "image": "cPK_10_006260_00_ASHIMARI_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6652,7 +7483,8 @@
     "rarity": "C",
     "name": "Popplio",
     "image": "cPK_10_006270_00_ASHIMARI_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6660,7 +7492,8 @@
     "rarity": "U",
     "name": "Brionne",
     "image": "cPK_10_006280_00_OSYAMARI_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6668,7 +7501,8 @@
     "rarity": "R",
     "name": "Primarina",
     "image": "cPK_10_006290_00_ASHIRENE_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6676,7 +7510,8 @@
     "rarity": "RR",
     "name": "Crabominable ex",
     "image": "cPK_10_006300_00_KEKENKANIex_RR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6684,7 +7519,8 @@
     "rarity": "C",
     "name": "Wishiwashi",
     "image": "cPK_10_006310_00_YOWASHITANDOKUNOSUGATA_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6692,7 +7528,8 @@
     "rarity": "RR",
     "name": "Wishiwashi ex",
     "image": "cPK_10_006320_00_YOWASHIMURETASUGATA_RR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6700,7 +7537,8 @@
     "rarity": "C",
     "name": "Dewpider",
     "image": "cPK_10_006330_00_SHIZUKUMO_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6708,7 +7546,8 @@
     "rarity": "U",
     "name": "Araquanid",
     "image": "cPK_10_006340_00_ONISHIZUKUMO_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6716,7 +7555,8 @@
     "rarity": "C",
     "name": "Pyukumuku",
     "image": "cPK_10_006350_00_NAMAKOBUSHI_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6724,7 +7564,8 @@
     "rarity": "C",
     "name": "Bruxish",
     "image": "cPK_10_006360_00_HAGIGISHIRI_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6732,7 +7573,8 @@
     "rarity": "R",
     "name": "Tapu Fini",
     "image": "cPK_10_006370_00_KAPU-REHIRE_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6740,7 +7582,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_10_006380_00_PIKACHU_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6748,7 +7591,8 @@
     "rarity": "RR",
     "name": "Alolan Raichu ex",
     "image": "cPK_10_006390_00_ALOLARAICHUex_RR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6756,7 +7600,8 @@
     "rarity": "C",
     "name": "Alolan Geodude",
     "image": "cPK_10_006400_00_ALOLAISITSUBUTE_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6764,7 +7609,8 @@
     "rarity": "U",
     "name": "Alolan Graveler",
     "image": "cPK_10_006410_00_ALOLAGOLONE_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6772,7 +7618,8 @@
     "rarity": "R",
     "name": "Alolan Golem",
     "image": "cPK_10_006420_00_ALOLAGOLONYA_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6780,7 +7627,8 @@
     "rarity": "C",
     "name": "Helioptile",
     "image": "cPK_10_006430_00_ERIKITERU_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6788,7 +7636,8 @@
     "rarity": "C",
     "name": "Heliolisk",
     "image": "cPK_10_006440_00_ELEZARD_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6796,7 +7645,8 @@
     "rarity": "U",
     "name": "Charjabug",
     "image": "cPK_10_006450_00_DENDIMUSHI_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6804,7 +7654,8 @@
     "rarity": "R",
     "name": "Vikavolt",
     "image": "cPK_10_006460_00_KUWAGANNON_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6812,7 +7663,8 @@
     "rarity": "R",
     "name": "Oricorio",
     "image": "cPK_10_006470_00_ODORIDORIPACHIPACHISTYLE_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6820,7 +7672,8 @@
     "rarity": "C",
     "name": "Togedemaru",
     "image": "cPK_10_006480_00_TOGEDEMARU_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6828,7 +7681,8 @@
     "rarity": "R",
     "name": "Tapu Koko",
     "image": "cPK_10_006490_00_KAPU-KOKEKO_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6836,7 +7690,8 @@
     "rarity": "U",
     "name": "Mr. Mime",
     "image": "cPK_10_006500_00_BARRIERD_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6844,7 +7699,8 @@
     "rarity": "U",
     "name": "Sableye",
     "image": "cPK_10_006510_00_YAMIRAMI_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6852,7 +7708,8 @@
     "rarity": "C",
     "name": "Spoink",
     "image": "cPK_10_006520_00_BANEBOO_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6860,7 +7717,8 @@
     "rarity": "U",
     "name": "Grumpig",
     "image": "cPK_10_006530_00_BOOPIG_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6868,7 +7726,8 @@
     "rarity": "C",
     "name": "Lunatone",
     "image": "cPK_10_006540_00_LUNATONE_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6876,7 +7735,8 @@
     "rarity": "C",
     "name": "Shuppet",
     "image": "cPK_10_006550_00_KAGEBOUZU_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6884,7 +7744,8 @@
     "rarity": "C",
     "name": "Banette",
     "image": "cPK_10_006560_00_JUPPETA_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6892,7 +7753,8 @@
     "rarity": "U",
     "name": "Oricorio",
     "image": "cPK_10_006570_00_ODORIDORIFURAFURASTYLE_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6900,7 +7762,8 @@
     "rarity": "U",
     "name": "Oricorio",
     "image": "cPK_10_006580_00_ODORIDORIMAIMAISTYLE_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6908,7 +7771,8 @@
     "rarity": "C",
     "name": "Cutiefly",
     "image": "cPK_10_006590_00_ABULY_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6916,7 +7780,8 @@
     "rarity": "C",
     "name": "Ribombee",
     "image": "cPK_10_006600_00_ABURIBBON_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6924,7 +7789,8 @@
     "rarity": "R",
     "name": "Comfey",
     "image": "cPK_10_006610_00_CUWAWA_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6932,7 +7798,8 @@
     "rarity": "C",
     "name": "Sandygast",
     "image": "cPK_10_006620_00_SUNABA_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6940,7 +7807,8 @@
     "rarity": "R",
     "name": "Palossand",
     "image": "cPK_10_006630_00_SIRODETHNA_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6948,7 +7816,8 @@
     "rarity": "C",
     "name": "Mimikyu",
     "image": "cPK_10_006640_00_MIMIKKYU_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6956,7 +7825,8 @@
     "rarity": "R",
     "name": "Tapu Lele",
     "image": "cPK_10_006650_00_KAPU-TETEFU_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6964,7 +7834,8 @@
     "rarity": "C",
     "name": "Cosmog",
     "image": "cPK_10_006660_00_COSMOG_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6972,7 +7843,8 @@
     "rarity": "U",
     "name": "Cosmoem",
     "image": "cPK_10_006670_00_COSMOVUM_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6980,7 +7852,8 @@
     "rarity": "RR",
     "name": "Lunala ex",
     "image": "cPK_10_006680_00_LUNALAex_RR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6988,7 +7861,8 @@
     "rarity": "R",
     "name": "Necrozma",
     "image": "cPK_10_006690_00_NECROZMA_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -6996,7 +7870,8 @@
     "rarity": "C",
     "name": "Cubone",
     "image": "cPK_10_006700_00_KARAKARA_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7004,7 +7879,8 @@
     "rarity": "C",
     "name": "Makuhita",
     "image": "cPK_10_006710_00_MAKUNOSHITA_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7012,7 +7888,8 @@
     "rarity": "U",
     "name": "Hariyama",
     "image": "cPK_10_006720_00_HARITEYAMA_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7020,7 +7897,8 @@
     "rarity": "C",
     "name": "Solrock",
     "image": "cPK_10_006730_00_SOLROCK_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7028,7 +7906,8 @@
     "rarity": "C",
     "name": "Drilbur",
     "image": "cPK_10_006740_00_MOGUREW_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7036,7 +7915,8 @@
     "rarity": "C",
     "name": "Timburr",
     "image": "cPK_10_006750_00_DOKKORER_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7044,7 +7924,8 @@
     "rarity": "U",
     "name": "Gurdurr",
     "image": "cPK_10_006760_00_DOTEKKOTSU_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7052,7 +7933,8 @@
     "rarity": "R",
     "name": "Conkeldurr",
     "image": "cPK_10_006770_00_ROUBUSHIN_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7060,7 +7942,8 @@
     "rarity": "C",
     "name": "Crabrawler",
     "image": "cPK_10_006780_00_MAKENKANI_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7068,7 +7951,8 @@
     "rarity": "C",
     "name": "Rockruff",
     "image": "cPK_10_006790_00_IWANKO_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7076,7 +7960,8 @@
     "rarity": "C",
     "name": "Rockruff",
     "image": "cPK_10_006800_00_IWANKO_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7084,7 +7969,8 @@
     "rarity": "R",
     "name": "Lycanroc",
     "image": "cPK_10_006810_00_LUGARUGANMAHIRUNOSUGATA_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7092,7 +7978,8 @@
     "rarity": "R",
     "name": "Lycanroc",
     "image": "cPK_10_006820_00_LUGARUGANMAYONAKANOSUGATA_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7100,7 +7987,8 @@
     "rarity": "C",
     "name": "Mudbray",
     "image": "cPK_10_006830_00_DOROBANKO_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7108,7 +7996,8 @@
     "rarity": "U",
     "name": "Mudsdale",
     "image": "cPK_10_006840_00_BANBADORO_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7116,7 +8005,8 @@
     "rarity": "RR",
     "name": "Passimian ex",
     "image": "cPK_10_006850_00_NAGETUKESARUex_RR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7124,7 +8014,8 @@
     "rarity": "U",
     "name": "Minior",
     "image": "cPK_10_006860_00_METENOAKAIRONOCORE_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7132,7 +8023,8 @@
     "rarity": "C",
     "name": "Alolan Rattata",
     "image": "cPK_10_006870_00_ALOLAKORATTA_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7140,7 +8032,8 @@
     "rarity": "U",
     "name": "Alolan Raticate",
     "image": "cPK_10_006880_00_ALOLARATTA_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7148,7 +8041,8 @@
     "rarity": "C",
     "name": "Alolan Meowth",
     "image": "cPK_10_006890_00_ALOLANYARTH_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7156,7 +8050,8 @@
     "rarity": "R",
     "name": "Alolan Persian",
     "image": "cPK_10_006900_00_ALOLAPERSIAN_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7164,7 +8059,8 @@
     "rarity": "C",
     "name": "Alolan Grimer",
     "image": "cPK_10_006910_00_ALOLABETBETER_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7172,7 +8068,8 @@
     "rarity": "RR",
     "name": "Alolan Muk ex",
     "image": "cPK_10_006920_00_ALOLABETBETONex_RR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7180,7 +8077,8 @@
     "rarity": "R",
     "name": "Absol",
     "image": "cPK_10_006930_00_ABSOL_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7188,7 +8086,8 @@
     "rarity": "C",
     "name": "Trubbish",
     "image": "cPK_10_006940_00_YABUKURON_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7196,7 +8095,8 @@
     "rarity": "U",
     "name": "Garbodor",
     "image": "cPK_10_006950_00_DUSTDAS_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7204,7 +8104,8 @@
     "rarity": "C",
     "name": "Mareanie",
     "image": "cPK_10_006960_00_HIDOIDE_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7212,7 +8113,8 @@
     "rarity": "C",
     "name": "Toxapex",
     "image": "cPK_10_006970_00_DOHIDOIDE_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7220,7 +8122,8 @@
     "rarity": "C",
     "name": "Alolan Diglett",
     "image": "cPK_10_006980_00_ALOLADIGDA_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7228,7 +8131,8 @@
     "rarity": "C",
     "name": "Alolan Dugtrio",
     "image": "cPK_10_006990_00_ALOLADUGTRIO_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7236,7 +8140,8 @@
     "rarity": "U",
     "name": "Excadrill",
     "image": "cPK_10_007000_00_DORYUZU_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7244,7 +8149,8 @@
     "rarity": "U",
     "name": "Escavalier",
     "image": "cPK_10_007010_00_CHEVARGO_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7252,7 +8158,8 @@
     "rarity": "R",
     "name": "Klefki",
     "image": "cPK_10_007020_00_CLEFFY_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7260,7 +8167,8 @@
     "rarity": "RR",
     "name": "Solgaleo ex",
     "image": "cPK_10_007030_00_SOLGALEOex_RR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7268,7 +8176,8 @@
     "rarity": "R",
     "name": "Magearna",
     "image": "cPK_10_007040_00_MAGEARNA_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7276,7 +8185,8 @@
     "rarity": "R",
     "name": "Drampa",
     "image": "cPK_10_007050_00_JIJILONG_R.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7284,7 +8194,8 @@
     "rarity": "C",
     "name": "Jangmo-o",
     "image": "cPK_10_007060_00_JYARAKO_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7292,7 +8203,8 @@
     "rarity": "U",
     "name": "Hakamo-o",
     "image": "cPK_10_007070_00_JYARANGO_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7300,7 +8212,8 @@
     "rarity": "R",
     "name": "Kommo-o",
     "image": "cPK_10_007080_00_JYARARANGA_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7308,7 +8221,8 @@
     "rarity": "U",
     "name": "Tauros",
     "image": "cPK_10_007090_00_KENTAUROS_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7316,7 +8230,8 @@
     "rarity": "C",
     "name": "Skitty",
     "image": "cPK_10_007100_00_ENECO_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7324,7 +8239,8 @@
     "rarity": "U",
     "name": "Delcatty",
     "image": "cPK_10_007110_00_ENEKORORO_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7332,7 +8248,8 @@
     "rarity": "C",
     "name": "Fletchling",
     "image": "cPK_10_007120_00_YAYAKOMA_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7340,7 +8257,8 @@
     "rarity": "U",
     "name": "Hawlucha",
     "image": "cPK_10_007130_00_LUCHABULL_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7348,7 +8266,8 @@
     "rarity": "C",
     "name": "Pikipek",
     "image": "cPK_10_007140_00_TSUTSUKERA_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7356,7 +8275,8 @@
     "rarity": "C",
     "name": "Trumbeak",
     "image": "cPK_10_007150_00_KERARAPPA_C.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7364,7 +8284,8 @@
     "rarity": "U",
     "name": "Toucannon",
     "image": "cPK_10_007160_00_DODEKABASHI_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7372,7 +8293,8 @@
     "rarity": "C",
     "name": "Yungoos",
     "image": "cPK_10_007170_00_YOUNGOOSE_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7380,7 +8302,8 @@
     "rarity": "C",
     "name": "Gumshoos",
     "image": "cPK_10_007180_00_DEKAGOOSE_C.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7388,7 +8311,8 @@
     "rarity": "C",
     "name": "Stufful",
     "image": "cPK_10_007190_00_NUIKOGUMA_C.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7396,7 +8320,8 @@
     "rarity": "R",
     "name": "Bewear",
     "image": "cPK_10_007200_00_KITERUGUMA_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7404,7 +8329,8 @@
     "rarity": "R",
     "name": "Oranguru",
     "image": "cPK_10_007210_00_YAREYUUTAN_R.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7412,7 +8338,8 @@
     "rarity": "U",
     "name": "Komala",
     "image": "cPK_10_007220_00_NEKKOARA_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7420,7 +8347,8 @@
     "rarity": "U",
     "name": "Big Malasada",
     "image": "cTR_10_000460_00_OOKIIMARASADA_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7428,7 +8356,8 @@
     "rarity": "U",
     "name": "Fishing Net",
     "image": "cTR_10_000470_00_OSAKANANETTO_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7436,7 +8365,8 @@
     "rarity": "U",
     "name": "Rare Candy",
     "image": "cTR_10_000480_00_FUSHIGINAAME_U.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7444,7 +8374,8 @@
     "rarity": "U",
     "name": "Rotom Dex",
     "image": "cTR_10_000490_00_ROTOMUZUKAN_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7452,7 +8383,8 @@
     "rarity": "U",
     "name": "Poison Barb",
     "image": "cTR_10_000500_00_DOKUBARI_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7460,7 +8392,8 @@
     "rarity": "U",
     "name": "Leaf Cape",
     "image": "cTR_10_000510_00_LEAFMANTO_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7468,7 +8401,8 @@
     "rarity": "U",
     "name": "Acerola",
     "image": "cTR_10_000520_00_ACEROLA_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7476,7 +8410,8 @@
     "rarity": "U",
     "name": "Ilima",
     "image": "cTR_10_000530_00_ILIMA_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7484,7 +8419,8 @@
     "rarity": "U",
     "name": "Kiawe",
     "image": "cTR_10_000540_00_KAKI_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7492,7 +8428,8 @@
     "rarity": "U",
     "name": "Guzma",
     "image": "cTR_10_000550_00_GUZUMA_U.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7500,7 +8437,8 @@
     "rarity": "U",
     "name": "Lana",
     "image": "cTR_10_000560_00_SUIREN_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7508,7 +8446,8 @@
     "rarity": "U",
     "name": "Sophocles",
     "image": "cTR_10_000570_00_MAMANE_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7516,7 +8455,8 @@
     "rarity": "U",
     "name": "Mallow",
     "image": "cTR_10_000580_00_MAO_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7524,7 +8464,8 @@
     "rarity": "U",
     "name": "Lillie",
     "image": "cTR_10_000590_00_LILIE_U.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7532,7 +8473,8 @@
     "rarity": "AR",
     "name": "Alolan Exeggutor",
     "image": "cPK_20_005830_00_ALOLANASSY_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7540,7 +8482,8 @@
     "rarity": "AR",
     "name": "Morelull",
     "image": "cPK_20_005970_00_NEMASYU_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7548,7 +8491,8 @@
     "rarity": "AR",
     "name": "Tsareena",
     "image": "cPK_20_006010_00_AMAJO_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7556,7 +8500,8 @@
     "rarity": "AR",
     "name": "Tapu Bulu",
     "image": "cPK_20_006050_00_KAPU-BULUL_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7564,7 +8509,8 @@
     "rarity": "AR",
     "name": "Alolan Marowak",
     "image": "cPK_20_006080_00_ALOLAGARAGARA_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7572,7 +8518,8 @@
     "rarity": "AR",
     "name": "Turtonator",
     "image": "cPK_20_006180_00_BAKUGAMES_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7580,7 +8527,8 @@
     "rarity": "AR",
     "name": "Alolan Vulpix",
     "image": "cPK_20_006210_00_ALOLAROKON_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7588,7 +8536,8 @@
     "rarity": "AR",
     "name": "Pyukumuku",
     "image": "cPK_20_006350_00_NAMAKOBUSHI_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7596,7 +8545,8 @@
     "rarity": "AR",
     "name": "Tapu Fini",
     "image": "cPK_20_006370_00_KAPU-REHIRE_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7604,7 +8554,8 @@
     "rarity": "AR",
     "name": "Oricorio",
     "image": "cPK_20_006470_00_ODORIDORIPACHIPACHISTYLE_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7612,7 +8563,8 @@
     "rarity": "AR",
     "name": "Tapu Koko",
     "image": "cPK_20_006490_00_KAPU-KOKEKO_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7620,7 +8572,8 @@
     "rarity": "AR",
     "name": "Cutiefly",
     "image": "cPK_20_006590_00_ABULY_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7628,7 +8581,8 @@
     "rarity": "AR",
     "name": "Comfey",
     "image": "cPK_20_006610_00_CUWAWA_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7636,7 +8590,8 @@
     "rarity": "AR",
     "name": "Sandygast",
     "image": "cPK_20_006620_00_SUNABA_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7644,7 +8599,8 @@
     "rarity": "AR",
     "name": "Tapu Lele",
     "image": "cPK_20_006650_00_KAPU-TETEFU_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7652,7 +8608,8 @@
     "rarity": "AR",
     "name": "Cosmog",
     "image": "cPK_20_006660_00_COSMOG_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7660,7 +8617,8 @@
     "rarity": "AR",
     "name": "Rockruff",
     "image": "cPK_20_006790_00_IWANKO_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7668,7 +8626,8 @@
     "rarity": "AR",
     "name": "Mudsdale",
     "image": "cPK_20_006840_00_BANBADORO_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7676,7 +8635,8 @@
     "rarity": "AR",
     "name": "Minior",
     "image": "cPK_20_006860_00_METENOAKAIRONOCORE_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7684,7 +8644,8 @@
     "rarity": "AR",
     "name": "Magearna",
     "image": "cPK_20_007040_00_MAGEARNA_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7692,7 +8653,8 @@
     "rarity": "AR",
     "name": "Drampa",
     "image": "cPK_20_007050_00_JIJILONG_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7700,7 +8662,8 @@
     "rarity": "AR",
     "name": "Pikipek",
     "image": "cPK_20_007140_00_TSUTSUKERA_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7708,7 +8671,8 @@
     "rarity": "AR",
     "name": "Bewear",
     "image": "cPK_20_007200_00_KITERUGUMA_AR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7716,7 +8680,8 @@
     "rarity": "AR",
     "name": "Komala",
     "image": "cPK_20_007220_00_NEKKOARA_AR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7724,7 +8689,8 @@
     "rarity": "SR",
     "name": "Decidueye ex",
     "image": "cPK_20_005930_00_JUNAIPERex_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7732,7 +8698,8 @@
     "rarity": "SR",
     "name": "Dhelmise ex",
     "image": "cPK_20_006040_00_DADARINex_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7740,7 +8707,8 @@
     "rarity": "SR",
     "name": "Incineroar ex",
     "image": "cPK_20_006140_00_GAOGAENex_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7748,7 +8716,8 @@
     "rarity": "SR",
     "name": "Crabominable ex",
     "image": "cPK_20_006300_00_KEKENKANIex_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7756,7 +8725,8 @@
     "rarity": "SR",
     "name": "Wishiwashi ex",
     "image": "cPK_20_006320_00_YOWASHIMURETASUGATA_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7764,7 +8734,8 @@
     "rarity": "SR",
     "name": "Alolan Raichu ex",
     "image": "cPK_20_006390_00_ALOLARAICHUex_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7772,7 +8743,8 @@
     "rarity": "SR",
     "name": "Lunala ex",
     "image": "cPK_20_006680_00_LUNALAex_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7780,7 +8752,8 @@
     "rarity": "SR",
     "name": "Passimian ex",
     "image": "cPK_20_006850_00_NAGETUKESARUex_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7788,7 +8761,8 @@
     "rarity": "SR",
     "name": "Alolan Muk ex",
     "image": "cPK_20_006920_00_ALOLABETBETONex_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7796,7 +8770,8 @@
     "rarity": "SR",
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_00_SOLGALEOex_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7804,7 +8779,8 @@
     "rarity": "SR",
     "name": "Acerola",
     "image": "cTR_20_000520_00_ACEROLA_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7812,7 +8788,8 @@
     "rarity": "SR",
     "name": "Ilima",
     "image": "cTR_20_000530_00_ILIMA_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7820,7 +8797,8 @@
     "rarity": "SR",
     "name": "Kiawe",
     "image": "cTR_20_000540_00_KAKI_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7828,7 +8806,8 @@
     "rarity": "SR",
     "name": "Guzma",
     "image": "cTR_20_000550_00_GUZUMA_SR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7836,7 +8815,8 @@
     "rarity": "SR",
     "name": "Lana",
     "image": "cTR_20_000560_00_SUIREN_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7844,7 +8824,8 @@
     "rarity": "SR",
     "name": "Sophocles",
     "image": "cTR_20_000570_00_MAMANE_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7852,7 +8833,8 @@
     "rarity": "SR",
     "name": "Mallow",
     "image": "cTR_20_000580_00_MAO_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7860,7 +8842,8 @@
     "rarity": "SR",
     "name": "Lillie",
     "image": "cTR_20_000590_00_LILIE_SR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7868,7 +8851,8 @@
     "rarity": "SAR",
     "name": "Decidueye ex",
     "image": "cPK_20_005930_01_JUNAIPERex_SAR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7876,7 +8860,8 @@
     "rarity": "SAR",
     "name": "Dhelmise ex",
     "image": "cPK_20_006040_01_DADARINex_SAR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7884,7 +8869,8 @@
     "rarity": "SAR",
     "name": "Incineroar ex",
     "image": "cPK_20_006140_01_GAOGAENex_SAR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7892,7 +8878,8 @@
     "rarity": "SAR",
     "name": "Crabominable ex",
     "image": "cPK_20_006300_01_KEKENKANIex_SAR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7900,7 +8887,8 @@
     "rarity": "SAR",
     "name": "Wishiwashi ex",
     "image": "cPK_20_006320_01_YOWASHIMURETASUGATA_SAR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7908,7 +8896,8 @@
     "rarity": "SAR",
     "name": "Alolan Raichu ex",
     "image": "cPK_20_006390_01_ALOLARAICHUex_SAR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7916,7 +8905,8 @@
     "rarity": "SAR",
     "name": "Lunala ex",
     "image": "cPK_20_006680_01_LUNALAex_SAR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7924,7 +8914,8 @@
     "rarity": "SAR",
     "name": "Passimian ex",
     "image": "cPK_20_006850_01_NAGETUKESARUex_SAR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7932,7 +8923,8 @@
     "rarity": "SAR",
     "name": "Alolan Muk ex",
     "image": "cPK_20_006920_01_ALOLABETBETONex_SAR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7940,7 +8932,8 @@
     "rarity": "SAR",
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_01_SOLGALEOex_SAR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7948,7 +8941,8 @@
     "rarity": "IM",
     "name": "Guzma",
     "image": "cTR_20_000550_01_GUZUMA_IM.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7956,7 +8950,8 @@
     "rarity": "IM",
     "name": "Lillie",
     "image": "cTR_20_000590_01_LILIE_IM.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7964,7 +8959,8 @@
     "rarity": "S",
     "name": "Bulbasaur",
     "image": "cPK_20_000010_01_FUSHIGIDANE_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7972,7 +8968,8 @@
     "rarity": "S",
     "name": "Ivysaur",
     "image": "cPK_20_000020_00_FUSHIGISOU_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7980,7 +8977,8 @@
     "rarity": "S",
     "name": "Venusaur",
     "image": "cPK_20_000030_00_FUSHIGIBANA_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7988,7 +8986,8 @@
     "rarity": "S",
     "name": "Exeggcute",
     "image": "cPK_20_005820_00_TAMATAMA_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -7996,7 +8995,8 @@
     "rarity": "S",
     "name": "Exeggutor",
     "image": "cPK_20_002160_01_NASSY_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8004,7 +9004,8 @@
     "rarity": "S",
     "name": "Squirtle",
     "image": "cPK_20_000530_01_ZENIGAME_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8012,7 +9013,8 @@
     "rarity": "S",
     "name": "Wartortle",
     "image": "cPK_20_000540_00_KAMEIL_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8020,7 +9022,8 @@
     "rarity": "S",
     "name": "Blastoise",
     "image": "cPK_20_000550_00_KAMEX_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8028,7 +9031,8 @@
     "rarity": "S",
     "name": "Staryu",
     "image": "cPK_20_000740_00_HITODEMAN_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8036,7 +9040,8 @@
     "rarity": "S",
     "name": "Starmie",
     "image": "cPK_20_000750_00_STARMIE_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8044,7 +9049,8 @@
     "rarity": "S",
     "name": "Gastly",
     "image": "cPK_20_004550_00_GHOS_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8052,7 +9058,8 @@
     "rarity": "S",
     "name": "Haunter",
     "image": "cPK_20_001210_00_GHOST_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8060,7 +9067,8 @@
     "rarity": "S",
     "name": "Gengar",
     "image": "cPK_20_001220_00_GANGAR_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8068,7 +9076,8 @@
     "rarity": "S",
     "name": "Machop",
     "image": "cPK_20_001430_00_WANRIKY_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8076,7 +9085,8 @@
     "rarity": "S",
     "name": "Machoke",
     "image": "cPK_20_001440_00_GORIKY_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8084,7 +9094,8 @@
     "rarity": "S",
     "name": "Machamp",
     "image": "cPK_20_005020_00_KAIRIKY_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8092,7 +9103,8 @@
     "rarity": "S",
     "name": "Cubone",
     "image": "cPK_20_001510_01_KARAKARA_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8100,7 +9112,8 @@
     "rarity": "S",
     "name": "Marowak",
     "image": "cPK_20_001520_00_GARAGARA_S.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8108,7 +9121,8 @@
     "rarity": "S",
     "name": "Jigglypuff",
     "image": "cPK_20_005750_00_PURIN_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8116,7 +9130,8 @@
     "rarity": "S",
     "name": "Wigglytuff",
     "image": "cPK_20_005760_01_PUKURIN_S.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8124,7 +9139,8 @@
     "rarity": "SSR",
     "name": "Venusaur ex",
     "image": "cPK_20_000040_01_FUSHIGIBANAex_SSR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8132,7 +9148,8 @@
     "rarity": "SSR",
     "name": "Exeggutor ex",
     "image": "cPK_20_000230_01_NASSYex_SSR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8140,7 +9157,8 @@
     "rarity": "SSR",
     "name": "Blastoise ex",
     "image": "cPK_20_000560_01_KAMEXex_SSR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8148,7 +9166,8 @@
     "rarity": "SSR",
     "name": "Starmie ex",
     "image": "cPK_20_000760_01_STARMIEex_SSR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8156,7 +9175,8 @@
     "rarity": "SSR",
     "name": "Gengar ex",
     "image": "cPK_20_001230_02_GANGARex_SSR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8164,7 +9184,8 @@
     "rarity": "SSR",
     "name": "Machamp ex",
     "image": "cPK_20_001460_02_KAIRIKYex_SSR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8172,7 +9193,8 @@
     "rarity": "SSR",
     "name": "Marowak ex",
     "image": "cPK_20_001530_01_GARAGARAex_SSR.webp",
-    "packs": ["Lunala"]
+    "packs": ["Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8180,7 +9202,8 @@
     "rarity": "SSR",
     "name": "Wigglytuff ex",
     "image": "cPK_20_001950_02_PUKURINex_SSR.webp",
-    "packs": ["Solgaleo"]
+    "packs": ["Solgaleo"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8188,7 +9211,8 @@
     "rarity": "UR",
     "name": "Lunala ex",
     "image": "cPK_20_006680_02_LUNALAex_UR.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3",
@@ -8196,7 +9220,8 @@
     "rarity": "UR",
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_02_SOLGALEOex_UR.webp",
-    "packs": ["Solgaleo", "Lunala"]
+    "packs": ["Solgaleo", "Lunala"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8204,7 +9229,8 @@
     "rarity": "C",
     "name": "Petilil",
     "image": "cPK_10_007430_00_CHURINE_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8212,7 +9238,8 @@
     "rarity": "C",
     "name": "Lilligant",
     "image": "cPK_10_007440_00_DREDEAR_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8220,7 +9247,8 @@
     "rarity": "C",
     "name": "Rowlet",
     "image": "cPK_10_007450_00_MOKUROH_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8228,7 +9256,8 @@
     "rarity": "U",
     "name": "Dartrix",
     "image": "cPK_10_007460_00_FUKUTHROW_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8236,7 +9265,8 @@
     "rarity": "R",
     "name": "Decidueye",
     "image": "cPK_10_007470_00_JUNAIPER_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8244,7 +9274,8 @@
     "rarity": "RR",
     "name": "Buzzwole ex",
     "image": "cPK_10_007480_00_MASSIVOONex_RR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8252,7 +9283,8 @@
     "rarity": "U",
     "name": "Pheromosa",
     "image": "cPK_10_007490_00_PHEROACHE_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8260,7 +9292,8 @@
     "rarity": "C",
     "name": "Kartana",
     "image": "cPK_10_007250_00_KAMITURUGI_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8268,7 +9301,8 @@
     "rarity": "U",
     "name": "Blacephalon",
     "image": "cPK_10_007260_00_ZUGADOON_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8276,7 +9310,8 @@
     "rarity": "C",
     "name": "Mantine",
     "image": "cPK_10_007500_00_MANTAIN_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8284,7 +9319,8 @@
     "rarity": "C",
     "name": "Carvanha",
     "image": "cPK_10_007510_00_KIBANHA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8292,7 +9328,8 @@
     "rarity": "U",
     "name": "Sharpedo",
     "image": "cPK_10_007520_00_SAMEHADER_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8300,7 +9337,8 @@
     "rarity": "C",
     "name": "Shinx",
     "image": "cPK_10_007530_00_KOLINK_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8308,7 +9346,8 @@
     "rarity": "C",
     "name": "Luxio",
     "image": "cPK_10_007540_00_LUXIO_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8316,7 +9355,8 @@
     "rarity": "R",
     "name": "Luxray",
     "image": "cPK_10_007550_00_RENTORAR_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8324,7 +9364,8 @@
     "rarity": "C",
     "name": "Blitzle",
     "image": "cPK_10_007560_00_SHIMAMA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8332,7 +9373,8 @@
     "rarity": "C",
     "name": "Zebstrika",
     "image": "cPK_10_007570_00_ZEBRAIKA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8340,7 +9382,8 @@
     "rarity": "C",
     "name": "Emolga",
     "image": "cPK_10_007580_00_EMOLGA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8348,7 +9391,8 @@
     "rarity": "RR",
     "name": "Tapu Koko ex",
     "image": "cPK_10_007420_00_KAPU-KOKEKOex_RR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8356,7 +9400,8 @@
     "rarity": "U",
     "name": "Xurkitree",
     "image": "cPK_10_007270_00_DENJYUMOKU_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8364,7 +9409,8 @@
     "rarity": "R",
     "name": "Zeraora",
     "image": "cPK_10_007410_00_ZERAORA_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8372,7 +9418,8 @@
     "rarity": "C",
     "name": "Clefairy",
     "image": "cPK_10_007590_00_PIPPI_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8380,7 +9427,8 @@
     "rarity": "U",
     "name": "Clefable",
     "image": "cPK_10_007600_00_PIXY_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8388,7 +9436,8 @@
     "rarity": "C",
     "name": "Phantump",
     "image": "cPK_10_007610_00_BOKUREI_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8396,7 +9445,8 @@
     "rarity": "C",
     "name": "Trevenant",
     "image": "cPK_10_007620_00_OHROT_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8404,7 +9454,8 @@
     "rarity": "C",
     "name": "Morelull",
     "image": "cPK_10_007630_00_NEMASYU_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8412,7 +9463,8 @@
     "rarity": "R",
     "name": "Shiinotic",
     "image": "cPK_10_007640_00_MASHADE_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8420,7 +9472,8 @@
     "rarity": "C",
     "name": "Meditite",
     "image": "cPK_10_007650_00_ASANAN_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8428,7 +9481,8 @@
     "rarity": "U",
     "name": "Medicham",
     "image": "cPK_10_007660_00_CHAREM_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8436,7 +9490,8 @@
     "rarity": "C",
     "name": "Baltoy",
     "image": "cPK_10_007670_00_YAJILON_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8444,7 +9499,8 @@
     "rarity": "U",
     "name": "Claydol",
     "image": "cPK_10_007680_00_NENDOLL_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8452,7 +9508,8 @@
     "rarity": "C",
     "name": "Rockruff",
     "image": "cPK_10_007690_00_IWANKO_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8460,7 +9517,8 @@
     "rarity": "RR",
     "name": "Lycanroc ex",
     "image": "cPK_10_007700_00_LUGARUGANTASOGARENOSUGATA_RR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8468,7 +9526,8 @@
     "rarity": "C",
     "name": "Passimian",
     "image": "cPK_10_007710_00_NAGETUKESARU_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8476,7 +9535,8 @@
     "rarity": "C",
     "name": "Sandygast",
     "image": "cPK_10_007720_00_SUNABA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8484,7 +9544,8 @@
     "rarity": "U",
     "name": "Palossand",
     "image": "cPK_10_007730_00_SIRODETHNA_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8492,7 +9553,8 @@
     "rarity": "C",
     "name": "Alolan Meowth",
     "image": "cPK_10_007740_00_ALOLANYARTH_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8500,7 +9562,8 @@
     "rarity": "U",
     "name": "Alolan Persian",
     "image": "cPK_10_007750_00_ALOLAPERSIAN_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8508,7 +9571,8 @@
     "rarity": "C",
     "name": "Sandile",
     "image": "cPK_10_007760_00_MEGUROCO_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8516,7 +9580,8 @@
     "rarity": "C",
     "name": "Krokorok",
     "image": "cPK_10_007770_00_WARUVILE_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8524,7 +9589,8 @@
     "rarity": "U",
     "name": "Krookodile",
     "image": "cPK_10_007780_00_WARUVIAL_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8532,7 +9598,8 @@
     "rarity": "R",
     "name": "Nihilego",
     "image": "cPK_10_007790_00_UTUROID_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8540,7 +9607,8 @@
     "rarity": "RR",
     "name": "Guzzlord ex",
     "image": "cPK_10_007800_00_AKUZIKINGex_RR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8548,7 +9616,8 @@
     "rarity": "C",
     "name": "Poipole",
     "image": "cPK_10_007370_00_BEVENOM_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8556,7 +9625,8 @@
     "rarity": "R",
     "name": "Naganadel",
     "image": "cPK_10_007810_00_AGOYON_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8564,7 +9634,8 @@
     "rarity": "C",
     "name": "Alolan Diglett",
     "image": "cPK_10_007820_00_ALOLADIGDA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8572,7 +9643,8 @@
     "rarity": "RR",
     "name": "Alolan Dugtrio ex",
     "image": "cPK_10_007830_00_ALOLADUGTRIOex_RR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8580,7 +9652,8 @@
     "rarity": "C",
     "name": "Aron",
     "image": "cPK_10_007840_00_COKODORA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8588,7 +9661,8 @@
     "rarity": "C",
     "name": "Lairon",
     "image": "cPK_10_007850_00_KODORA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8596,7 +9670,8 @@
     "rarity": "U",
     "name": "Aggron",
     "image": "cPK_10_007860_00_BOSSGODORA_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8604,7 +9679,8 @@
     "rarity": "C",
     "name": "Ferroseed",
     "image": "cPK_10_007870_00_TESSEED_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8612,7 +9688,8 @@
     "rarity": "U",
     "name": "Ferrothorn",
     "image": "cPK_10_007880_00_NUTREY_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8620,7 +9697,8 @@
     "rarity": "U",
     "name": "Stakataka",
     "image": "cPK_10_007300_00_TUNDETUNDE_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8628,7 +9706,8 @@
     "rarity": "C",
     "name": "Lillipup",
     "image": "cPK_10_007890_00_YORTERRIE_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8636,7 +9715,8 @@
     "rarity": "C",
     "name": "Herdier",
     "image": "cPK_10_007900_00_HERDERRIE_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8644,7 +9724,8 @@
     "rarity": "U",
     "name": "Stoutland",
     "image": "cPK_10_007910_00_MOOLAND_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8652,7 +9733,8 @@
     "rarity": "C",
     "name": "Stufful",
     "image": "cPK_10_007380_00_NUIKOGUMA_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8660,7 +9742,8 @@
     "rarity": "U",
     "name": "Bewear",
     "image": "cPK_10_007920_00_KITERUGUMA_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8668,7 +9751,8 @@
     "rarity": "C",
     "name": "Oranguru",
     "image": "cPK_10_007930_00_YAREYUUTAN_C.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8676,7 +9760,8 @@
     "rarity": "U",
     "name": "Type: Null",
     "image": "cPK_10_007940_00_TYPENULL_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8684,7 +9769,8 @@
     "rarity": "R",
     "name": "Silvally",
     "image": "cPK_10_007950_00_SILVADY_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8692,7 +9778,8 @@
     "rarity": "R",
     "name": "Celesteela",
     "image": "cPK_10_007960_00_TEKKAGUYA_R.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8700,7 +9787,8 @@
     "rarity": "U",
     "name": "Beast Wall",
     "image": "cTR_10_000600_00_BISUTOWORU_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8708,7 +9796,8 @@
     "rarity": "U",
     "name": "Repel",
     "image": "cTR_10_000610_00_MUSHIYOKESUPUREI_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8716,7 +9805,8 @@
     "rarity": "U",
     "name": "Electrical Cord",
     "image": "cTR_10_000620_00_EREKIKORD_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8724,7 +9814,8 @@
     "rarity": "U",
     "name": "Beastite",
     "image": "cTR_10_000630_00_BISUTONAITO_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8732,7 +9823,8 @@
     "rarity": "U",
     "name": "Gladion",
     "image": "cTR_10_000640_00_GLAZIO_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8740,7 +9832,8 @@
     "rarity": "U",
     "name": "Looker",
     "image": "cTR_10_000650_00_HANDSOME_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8748,7 +9841,8 @@
     "rarity": "U",
     "name": "Lusamine",
     "image": "cTR_10_000660_00_LUSAMINE_U.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8756,7 +9850,8 @@
     "rarity": "AR",
     "name": "Rowlet",
     "image": "cPK_20_007450_00_MOKUROH_AR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8764,7 +9859,8 @@
     "rarity": "AR",
     "name": "Pheromosa",
     "image": "cPK_20_007490_00_PHEROACHE_AR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8772,7 +9868,8 @@
     "rarity": "AR",
     "name": "Blacephalon",
     "image": "cPK_20_007260_00_ZUGADOON_AR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8780,7 +9877,8 @@
     "rarity": "AR",
     "name": "Alolan Meowth",
     "image": "cPK_20_007740_00_ALOLANYARTH_AR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8788,7 +9886,8 @@
     "rarity": "AR",
     "name": "Silvally",
     "image": "cPK_20_007950_00_SILVADY_AR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8796,7 +9895,8 @@
     "rarity": "AR",
     "name": "Celesteela",
     "image": "cPK_20_007960_00_TEKKAGUYA_AR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8804,7 +9904,8 @@
     "rarity": "SR",
     "name": "Buzzwole ex",
     "image": "cPK_20_007480_00_MASSIVOONex_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8812,7 +9913,8 @@
     "rarity": "SR",
     "name": "Tapu Koko ex",
     "image": "cPK_20_007420_00_KAPU-KOKEKOex_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8820,7 +9922,8 @@
     "rarity": "SR",
     "name": "Lycanroc ex",
     "image": "cPK_20_007700_00_LUGARUGANex_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8828,7 +9931,8 @@
     "rarity": "SR",
     "name": "Guzzlord ex",
     "image": "cPK_20_007800_00_AKUZIKINGex_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8836,7 +9940,8 @@
     "rarity": "SR",
     "name": "Alolan Dugtrio ex",
     "image": "cPK_20_007830_00_ALOLADUGTRIOex_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8844,7 +9949,8 @@
     "rarity": "SR",
     "name": "Gladion",
     "image": "cTR_20_000640_00_GLAZIO_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8852,7 +9958,8 @@
     "rarity": "SR",
     "name": "Looker",
     "image": "cTR_20_000650_00_HANDSOME_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8860,7 +9967,8 @@
     "rarity": "SR",
     "name": "Lusamine",
     "image": "cTR_20_000660_00_LUSAMINE_SR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8868,7 +9976,8 @@
     "rarity": "SAR",
     "name": "Tapu Koko ex",
     "image": "cPK_20_007420_01_KAPU-KOKEKOex_SAR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8876,7 +9985,8 @@
     "rarity": "SAR",
     "name": "Lycanroc ex",
     "image": "cPK_20_007700_01_LUGARUGANex_SAR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8884,7 +9994,8 @@
     "rarity": "SAR",
     "name": "Guzzlord ex",
     "image": "cPK_20_007800_01_AKUZIKINGex_SAR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8892,7 +10003,8 @@
     "rarity": "SAR",
     "name": "Alolan Dugtrio ex",
     "image": "cPK_20_007830_01_ALOLADUGTRIOex_SAR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8900,7 +10012,8 @@
     "rarity": "IM",
     "name": "Buzzwole ex",
     "image": "cPK_20_007480_01_MASSIVOONex_IM.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8908,7 +10021,8 @@
     "rarity": "S",
     "name": "Growlithe",
     "image": "cPK_20_000390_00_GARDIE_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8916,7 +10030,8 @@
     "rarity": "S",
     "name": "Arcanine",
     "image": "cPK_20_000400_00_WINDIE_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8924,7 +10039,8 @@
     "rarity": "S",
     "name": "Froakie",
     "image": "cPK_20_000870_00_KEROMATSU_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8932,7 +10048,8 @@
     "rarity": "S",
     "name": "Frogadier",
     "image": "cPK_20_000880_00_GEKOGASHIRA_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8940,7 +10057,8 @@
     "rarity": "S",
     "name": "Greninja",
     "image": "cPK_20_000890_00_GEKKOUGA_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8948,7 +10066,8 @@
     "rarity": "S",
     "name": "Jynx",
     "image": "cPK_20_001270_00_ROUGELA_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8956,7 +10075,8 @@
     "rarity": "S",
     "name": "Pidgey",
     "image": "cPK_20_001860_00_POPPO_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8964,7 +10084,8 @@
     "rarity": "S",
     "name": "Pidgeotto",
     "image": "cPK_20_001870_00_PIGEON_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8972,7 +10093,8 @@
     "rarity": "S",
     "name": "Pidgeot",
     "image": "cPK_20_001880_01_PIGEOT_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8980,7 +10102,8 @@
     "rarity": "S",
     "name": "Aerodactyl",
     "image": "cPK_20_002080_00_PTERA_S.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8988,7 +10111,8 @@
     "rarity": "SSR",
     "name": "Celebi ex",
     "image": "cPK_20_002170_02_CELEBIex_SSR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -8996,7 +10120,8 @@
     "rarity": "SSR",
     "name": "Arcanine ex",
     "image": "cPK_20_000410_01_WINDIEex_SSR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -9004,7 +10129,8 @@
     "rarity": "SSR",
     "name": "Aerodactyl ex",
     "image": "cPK_20_002590_02_PTERAex_SSR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -9012,7 +10138,8 @@
     "rarity": "SSR",
     "name": "Pidgeot ex",
     "image": "cPK_20_002720_01_PIGEOTex_SSR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3a",
@@ -9020,7 +10147,8 @@
     "rarity": "UR",
     "name": "Nihilego",
     "image": "cPK_20_007790_00_UTUROID_UR.webp",
-    "packs": ["Extradimensional"]
+    "packs": ["Extradimensional"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9028,7 +10156,8 @@
     "rarity": "U",
     "name": "Tropius",
     "image": "cPK_10_007970_00_TROPIUS_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9036,7 +10165,8 @@
     "rarity": "R",
     "name": "Leafeon",
     "image": "cPK_10_007980_00_LEAFIA_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9044,7 +10174,8 @@
     "rarity": "C",
     "name": "Bounsweet",
     "image": "cPK_10_007990_00_AMAKAJI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9052,7 +10183,8 @@
     "rarity": "C",
     "name": "Steenee",
     "image": "cPK_10_008000_00_AMAMAIKO_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9060,7 +10192,8 @@
     "rarity": "U",
     "name": "Tsareena",
     "image": "cPK_10_008010_00_AMAJO_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9068,7 +10201,8 @@
     "rarity": "C",
     "name": "Applin",
     "image": "cPK_10_008020_00_KAJICCHU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9076,7 +10210,8 @@
     "rarity": "U",
     "name": "Appletun",
     "image": "cPK_10_008030_00_TARUPPLE_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9084,7 +10219,8 @@
     "rarity": "R",
     "name": "Flareon",
     "image": "cPK_10_008040_00_BOOSTER_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9092,7 +10228,8 @@
     "rarity": "RR",
     "name": "Flareon ex",
     "image": "cPK_10_008050_00_BOOSTERex_RR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9100,7 +10237,8 @@
     "rarity": "C",
     "name": "Torkoal",
     "image": "cPK_10_008060_00_COTOISE_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9108,7 +10246,8 @@
     "rarity": "C",
     "name": "Litten",
     "image": "cPK_10_008070_00_NYABBY_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9116,7 +10255,8 @@
     "rarity": "C",
     "name": "Torracat",
     "image": "cPK_10_008080_00_NYAHEAT_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9124,7 +10264,8 @@
     "rarity": "U",
     "name": "Incineroar",
     "image": "cPK_10_008090_00_GAOGAEN_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9132,7 +10273,8 @@
     "rarity": "C",
     "name": "Salandit",
     "image": "cPK_10_008100_00_YATOUMORI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9140,7 +10282,8 @@
     "rarity": "U",
     "name": "Salazzle",
     "image": "cPK_10_008110_00_ENNEWT_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9148,7 +10291,8 @@
     "rarity": "R",
     "name": "Vaporeon",
     "image": "cPK_10_008120_00_SHOWERS_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9156,7 +10300,8 @@
     "rarity": "R",
     "name": "Glaceon",
     "image": "cPK_10_008130_00_GLACIA_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9164,7 +10309,8 @@
     "rarity": "C",
     "name": "Vanillite",
     "image": "cPK_10_007320_00_VANIPETI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9172,7 +10318,8 @@
     "rarity": "C",
     "name": "Vanillish",
     "image": "cPK_10_008140_00_VANIRICH_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9180,7 +10327,8 @@
     "rarity": "U",
     "name": "Vanilluxe",
     "image": "cPK_10_008150_00_BAIVANILLA_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9188,7 +10336,8 @@
     "rarity": "C",
     "name": "Alomomola",
     "image": "cPK_10_008160_00_MAMANBOU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9196,7 +10345,8 @@
     "rarity": "C",
     "name": "Popplio",
     "image": "cPK_10_008170_00_ASHIMARI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9204,7 +10354,8 @@
     "rarity": "C",
     "name": "Brionne",
     "image": "cPK_10_008180_00_OSYAMARI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9212,7 +10363,8 @@
     "rarity": "RR",
     "name": "Primarina ex",
     "image": "cPK_10_008190_00_ASHIRENEex_RR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9220,7 +10372,8 @@
     "rarity": "R",
     "name": "Jolteon",
     "image": "cPK_10_007330_00_THUNDERS_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9228,7 +10381,8 @@
     "rarity": "C",
     "name": "Joltik",
     "image": "cPK_10_008200_00_BACHURU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9236,7 +10390,8 @@
     "rarity": "U",
     "name": "Galvantula",
     "image": "cPK_10_008210_00_DENTULA_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9244,7 +10399,8 @@
     "rarity": "R",
     "name": "Espeon",
     "image": "cPK_10_008220_00_EIFIE_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9252,7 +10408,8 @@
     "rarity": "C",
     "name": "Woobat",
     "image": "cPK_10_008230_00_KOROMORI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9260,7 +10417,8 @@
     "rarity": "U",
     "name": "Swoobat",
     "image": "cPK_10_008240_00_KOKOROMORI_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9268,7 +10426,8 @@
     "rarity": "C",
     "name": "Swirlix",
     "image": "cPK_10_008250_00_PEROPPAFU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9276,7 +10435,8 @@
     "rarity": "U",
     "name": "Slurpuff",
     "image": "cPK_10_008260_00_PEROREAM_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9284,7 +10444,8 @@
     "rarity": "R",
     "name": "Sylveon",
     "image": "cPK_10_008270_00_NYMPHIA_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9292,7 +10453,8 @@
     "rarity": "RR",
     "name": "Sylveon ex",
     "image": "cPK_10_008280_00_NYMPHIAex_RR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9300,7 +10462,8 @@
     "rarity": "U",
     "name": "Mimikyu",
     "image": "cPK_10_008290_00_MIMIKKYU_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9308,7 +10471,8 @@
     "rarity": "C",
     "name": "Milcery",
     "image": "cPK_10_008300_00_MAHOMIL_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9316,7 +10480,8 @@
     "rarity": "U",
     "name": "Alcremie",
     "image": "cPK_10_007340_00_MAWHIP_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9324,7 +10489,8 @@
     "rarity": "C",
     "name": "Barboach",
     "image": "cPK_10_008310_00_DOJOACH_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9332,7 +10498,8 @@
     "rarity": "U",
     "name": "Whiscash",
     "image": "cPK_10_008320_00_NAMAZUN_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9340,7 +10507,8 @@
     "rarity": "C",
     "name": "Mienfoo",
     "image": "cPK_10_008330_00_KOJOFU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9348,7 +10516,8 @@
     "rarity": "U",
     "name": "Mienshao",
     "image": "cPK_10_008340_00_KOJONDO_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9356,7 +10525,8 @@
     "rarity": "C",
     "name": "Carbink",
     "image": "cPK_10_008350_00_MELECIE_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9364,7 +10534,8 @@
     "rarity": "R",
     "name": "Umbreon",
     "image": "cPK_10_008360_00_BRACKY_R.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9372,7 +10543,8 @@
     "rarity": "C",
     "name": "Sableye",
     "image": "cPK_10_008370_00_YAMIRAMI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9380,7 +10552,8 @@
     "rarity": "C",
     "name": "Purrloin",
     "image": "cPK_10_008380_00_CHORONEKO_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9388,7 +10561,8 @@
     "rarity": "U",
     "name": "Liepard",
     "image": "cPK_10_008390_00_LEPARDAS_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9396,7 +10570,8 @@
     "rarity": "C",
     "name": "Mawile",
     "image": "cPK_10_008400_00_KUCHEAT_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9404,7 +10579,8 @@
     "rarity": "C",
     "name": "Togedemaru",
     "image": "cPK_10_007390_00_TOGEDEMARU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9412,7 +10588,8 @@
     "rarity": "C",
     "name": "Meltan",
     "image": "cPK_10_008410_00_MELTAN_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9420,7 +10597,8 @@
     "rarity": "U",
     "name": "Melmetal",
     "image": "cPK_10_008420_00_MELMETAL_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9428,7 +10606,8 @@
     "rarity": "C",
     "name": "Dratini",
     "image": "cPK_10_008430_00_MINIRYU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9436,7 +10615,8 @@
     "rarity": "C",
     "name": "Dragonair",
     "image": "cPK_10_008440_00_HAKURYU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9444,7 +10624,8 @@
     "rarity": "RR",
     "name": "Dragonite ex",
     "image": "cPK_10_008450_00_KAIRYUex_RR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9452,7 +10633,8 @@
     "rarity": "U",
     "name": "Drampa",
     "image": "cPK_10_008460_00_JIJILONG_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9460,7 +10642,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_008470_00_EIEVUI_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9468,7 +10651,8 @@
     "rarity": "RR",
     "name": "Eevee ex",
     "image": "cPK_10_008480_00_EIEVUIex_RR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9476,7 +10660,8 @@
     "rarity": "RR",
     "name": "Snorlax ex",
     "image": "cPK_10_008490_00_KABIGONex_RR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9484,7 +10669,8 @@
     "rarity": "C",
     "name": "Aipom",
     "image": "cPK_10_008500_00_EIPAM_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9492,7 +10678,8 @@
     "rarity": "U",
     "name": "Ambipom",
     "image": "cPK_10_008510_00_ETEBOTH_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9500,7 +10687,8 @@
     "rarity": "C",
     "name": "Chatot",
     "image": "cPK_10_008520_00_PERAP_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9508,7 +10696,8 @@
     "rarity": "C",
     "name": "Audino",
     "image": "cPK_10_008530_00_TABUNNE_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9516,7 +10705,8 @@
     "rarity": "C",
     "name": "Minccino",
     "image": "cPK_10_008540_00_CHILLARMY_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9524,7 +10714,8 @@
     "rarity": "U",
     "name": "Cinccino",
     "image": "cPK_10_008550_00_CHILLACCINO_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9532,7 +10723,8 @@
     "rarity": "C",
     "name": "Skwovet",
     "image": "cPK_10_008560_00_HOSHIGARISU_C.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9540,7 +10732,8 @@
     "rarity": "U",
     "name": "Greedent",
     "image": "cPK_10_007400_00_YOKUBARISU_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9548,7 +10741,8 @@
     "rarity": "U",
     "name": "Eevee Bag",
     "image": "cTR_10_000670_00_IIBUINOBAKKU_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9556,7 +10750,8 @@
     "rarity": "U",
     "name": "Leftovers",
     "image": "cTR_10_000680_00_TABENOKOSHI_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9564,7 +10759,8 @@
     "rarity": "U",
     "name": "Hau",
     "image": "cTR_10_000690_00_HAU_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9572,7 +10768,8 @@
     "rarity": "U",
     "name": "Penny",
     "image": "cTR_10_000700_00_BOTAN_U.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9580,7 +10777,8 @@
     "rarity": "AR",
     "name": "Leafeon",
     "image": "cPK_20_007980_00_LEAFIA_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9588,7 +10786,8 @@
     "rarity": "AR",
     "name": "Flareon",
     "image": "cPK_20_008040_00_BOOSTER_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9596,7 +10795,8 @@
     "rarity": "AR",
     "name": "Vaporeon",
     "image": "cPK_20_008120_00_SHOWERS_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9604,7 +10804,8 @@
     "rarity": "AR",
     "name": "Glaceon",
     "image": "cPK_20_008130_00_GLACIA_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9612,7 +10813,8 @@
     "rarity": "AR",
     "name": "Jolteon",
     "image": "cPK_20_007330_00_THUNDERS_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9620,7 +10822,8 @@
     "rarity": "AR",
     "name": "Espeon",
     "image": "cPK_20_008220_00_EIFIE_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9628,7 +10831,8 @@
     "rarity": "AR",
     "name": "Sylveon",
     "image": "cPK_20_008270_00_NYMPHIA_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9636,7 +10840,8 @@
     "rarity": "AR",
     "name": "Umbreon",
     "image": "cPK_20_008360_00_BRACKY_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9644,7 +10849,8 @@
     "rarity": "AR",
     "name": "Eevee",
     "image": "cPK_20_008470_00_EIEVUI_AR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9652,7 +10858,8 @@
     "rarity": "SR",
     "name": "Flareon ex",
     "image": "cPK_20_008050_00_BOOSTERex_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9660,7 +10867,8 @@
     "rarity": "SR",
     "name": "Primarina ex",
     "image": "cPK_20_008190_00_ASHIRENEex_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9668,7 +10876,8 @@
     "rarity": "SR",
     "name": "Sylveon ex",
     "image": "cPK_20_008280_00_NYMPHIAex_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9676,7 +10885,8 @@
     "rarity": "SR",
     "name": "Dragonite ex",
     "image": "cPK_20_008450_00_KAIRYUex_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9684,7 +10894,8 @@
     "rarity": "SR",
     "name": "Eevee ex",
     "image": "cPK_20_008480_00_EIEVUIex_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9692,7 +10903,8 @@
     "rarity": "SR",
     "name": "Snorlax ex",
     "image": "cPK_20_008490_00_KABIGONex_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9700,7 +10912,8 @@
     "rarity": "SR",
     "name": "Hau",
     "image": "cTR_20_000690_00_HAU_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9708,7 +10921,8 @@
     "rarity": "SR",
     "name": "Penny",
     "image": "cTR_20_000700_00_BOTAN_SR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9716,7 +10930,8 @@
     "rarity": "SAR",
     "name": "Flareon ex",
     "image": "cPK_20_008050_01_BOOSTERex_SAR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9724,7 +10939,8 @@
     "rarity": "SAR",
     "name": "Primarina ex",
     "image": "cPK_20_008190_01_ASHIRENEex_SAR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9732,7 +10948,8 @@
     "rarity": "SAR",
     "name": "Sylveon ex",
     "image": "cPK_20_008280_01_NYMPHIAex_SAR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9740,7 +10957,8 @@
     "rarity": "SAR",
     "name": "Dragonite ex",
     "image": "cPK_20_008450_01_KAIRYUex_SAR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9748,7 +10966,8 @@
     "rarity": "SAR",
     "name": "Snorlax ex",
     "image": "cPK_20_008490_01_KABIGONex_SAR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9756,7 +10975,8 @@
     "rarity": "IM",
     "name": "Eevee ex",
     "image": "cPK_20_008480_01_EIEVUIex_IM.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9764,7 +10984,8 @@
     "rarity": "S",
     "name": "Pinsir",
     "image": "cPK_20_005240_00_KAILIOS_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9772,7 +10993,8 @@
     "rarity": "S",
     "name": "Lapras",
     "image": "cPK_20_000790_01_LAPLACE_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9780,7 +11002,8 @@
     "rarity": "S",
     "name": "Voltorb",
     "image": "cPK_20_003350_00_BIRIRIDAMA_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9788,7 +11011,8 @@
     "rarity": "S",
     "name": "Electrode",
     "image": "cPK_20_003360_00_MARUMINE_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9796,7 +11020,8 @@
     "rarity": "S",
     "name": "Ralts",
     "image": "cPK_20_003490_00_RALTS_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9804,7 +11029,8 @@
     "rarity": "S",
     "name": "Kirlia",
     "image": "cPK_20_003500_00_KIRLIA_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9812,7 +11038,8 @@
     "rarity": "S",
     "name": "Gardevoir",
     "image": "cPK_20_001320_00_SIRNIGHT_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9820,7 +11047,8 @@
     "rarity": "S",
     "name": "Ekans",
     "image": "cPK_20_001640_00_ARBO_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9828,15 +11056,17 @@
     "rarity": "S",
     "name": "Arbok",
     "image": "cPK_20_001650_00_ARBOK_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
     "number": 102,
     "rarity": "S",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_20_001980_00_KAMONEGI_S.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9844,7 +11074,8 @@
     "rarity": "SSR",
     "name": "Moltres ex",
     "image": "cPK_20_000470_02_FIREex_SSR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9852,7 +11083,8 @@
     "rarity": "SSR",
     "name": "Articuno ex",
     "image": "cPK_20_000840_02_FREEZERex_SSR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9860,7 +11092,8 @@
     "rarity": "SSR",
     "name": "Zapdos ex",
     "image": "cPK_20_001040_02_THUNDERex_SSR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9868,7 +11101,8 @@
     "rarity": "SSR",
     "name": "Gallade ex",
     "image": "cPK_20_003760_02_ERUREIDOex_SSR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A3b",
@@ -9876,7 +11110,8 @@
     "rarity": "UR",
     "name": "Eevee Bag",
     "image": "cTR_20_000670_00_IIBUINOBAKKU_UR.webp",
-    "packs": ["Eevee"]
+    "packs": ["Eevee"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9884,7 +11119,8 @@
     "rarity": "C",
     "name": "Oddish",
     "image": "cPK_10_008570_00_NAZONOKUSA_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9892,7 +11128,8 @@
     "rarity": "U",
     "name": "Gloom",
     "image": "cPK_10_008580_00_KUSAIHANA_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9900,7 +11137,8 @@
     "rarity": "R",
     "name": "Bellossom",
     "image": "cPK_10_008590_00_KIREIHANA_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9908,7 +11146,8 @@
     "rarity": "C",
     "name": "Tangela",
     "image": "cPK_10_008600_00_MONJARA_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9916,7 +11155,8 @@
     "rarity": "R",
     "name": "Tangrowth",
     "image": "cPK_10_008610_00_MOJUMBO_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9924,7 +11164,8 @@
     "rarity": "C",
     "name": "Scyther",
     "image": "cPK_10_008620_00_STRIKE_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9932,7 +11173,8 @@
     "rarity": "C",
     "name": "Pinsir",
     "image": "cPK_10_008630_00_KAILIOS_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9940,7 +11182,8 @@
     "rarity": "C",
     "name": "Chikorita",
     "image": "cPK_10_008640_00_CHICORITA_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9948,7 +11191,8 @@
     "rarity": "U",
     "name": "Bayleef",
     "image": "cPK_10_008650_00_BAYLEAF_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9956,7 +11200,8 @@
     "rarity": "R",
     "name": "Meganium",
     "image": "cPK_10_008660_00_MEGANIUM_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9964,7 +11209,8 @@
     "rarity": "C",
     "name": "Ledyba",
     "image": "cPK_10_008670_00_REDIBA_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9972,7 +11218,8 @@
     "rarity": "C",
     "name": "Ledian",
     "image": "cPK_10_008680_00_REDIAN_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9980,7 +11227,8 @@
     "rarity": "C",
     "name": "Hoppip",
     "image": "cPK_10_008690_00_HANECCO_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9988,7 +11236,8 @@
     "rarity": "U",
     "name": "Skiploom",
     "image": "cPK_10_008700_00_POPOCCO_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -9996,7 +11245,8 @@
     "rarity": "R",
     "name": "Jumpluff",
     "image": "cPK_10_008710_00_WATACCO_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10004,7 +11254,8 @@
     "rarity": "C",
     "name": "Sunkern",
     "image": "cPK_10_008720_00_HIMANUTS_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10012,7 +11263,8 @@
     "rarity": "U",
     "name": "Sunflora",
     "image": "cPK_10_008730_00_KIMAWARI_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10020,7 +11272,8 @@
     "rarity": "C",
     "name": "Yanma",
     "image": "cPK_10_008740_00_YANYANMA_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10028,7 +11281,8 @@
     "rarity": "U",
     "name": "Yanmega",
     "image": "cPK_10_008750_00_MEGAYANMA_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10036,7 +11290,8 @@
     "rarity": "C",
     "name": "Pineco",
     "image": "cPK_10_008760_00_KUNUGIDAMA_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10044,7 +11299,8 @@
     "rarity": "RR",
     "name": "Shuckle ex",
     "image": "cPK_10_008770_00_TSUBOTSUBOex_RR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10052,7 +11308,8 @@
     "rarity": "R",
     "name": "Heracross",
     "image": "cPK_10_008780_00_HERACROS_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10060,7 +11317,8 @@
     "rarity": "C",
     "name": "Cherubi",
     "image": "cPK_10_008790_00_CHERINBO_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10068,7 +11326,8 @@
     "rarity": "U",
     "name": "Cherrim",
     "image": "cPK_10_008800_00_CHERRIM_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10076,7 +11335,8 @@
     "rarity": "C",
     "name": "Vulpix",
     "image": "cPK_10_008810_00_ROKON_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10084,7 +11344,8 @@
     "rarity": "R",
     "name": "Ninetales",
     "image": "cPK_10_008820_00_KYUKON_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10092,7 +11353,8 @@
     "rarity": "C",
     "name": "Cyndaquil",
     "image": "cPK_10_008830_00_HINOARASHI_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10100,7 +11362,8 @@
     "rarity": "U",
     "name": "Quilava",
     "image": "cPK_10_008840_00_MAGMARASHI_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10108,7 +11371,8 @@
     "rarity": "R",
     "name": "Typhlosion",
     "image": "cPK_10_008850_00_BAKPHOON_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10116,7 +11380,8 @@
     "rarity": "C",
     "name": "Slugma",
     "image": "cPK_10_008860_00_MAGMAG_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10124,7 +11389,8 @@
     "rarity": "U",
     "name": "Magcargo",
     "image": "cPK_10_008870_00_MAGCARGOT_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10132,7 +11398,8 @@
     "rarity": "R",
     "name": "Magby",
     "image": "cPK_10_008880_00_BUBY_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10140,7 +11407,8 @@
     "rarity": "R",
     "name": "Entei",
     "image": "cPK_10_008890_00_ENTEI_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10148,7 +11416,8 @@
     "rarity": "RR",
     "name": "Ho-Oh ex",
     "image": "cPK_10_008900_00_HOUOUex_RR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10156,7 +11425,8 @@
     "rarity": "C",
     "name": "Darumaka",
     "image": "cPK_10_008910_00_DARUMAKKA_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10164,7 +11434,8 @@
     "rarity": "U",
     "name": "Darmanitan",
     "image": "cPK_10_008920_00_HIHIDARUMA_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10172,7 +11443,8 @@
     "rarity": "C",
     "name": "Heatmor",
     "image": "cPK_10_008930_00_KUITARAN_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10180,7 +11452,8 @@
     "rarity": "C",
     "name": "Poliwag",
     "image": "cPK_10_008940_00_NYOROMO_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10188,7 +11461,8 @@
     "rarity": "U",
     "name": "Poliwhirl",
     "image": "cPK_10_008950_00_NYOROZO_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10196,7 +11470,8 @@
     "rarity": "R",
     "name": "Politoed",
     "image": "cPK_10_008960_00_NYOROTONO_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10204,7 +11479,8 @@
     "rarity": "C",
     "name": "Horsea",
     "image": "cPK_10_008970_00_TATTU_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10212,7 +11488,8 @@
     "rarity": "U",
     "name": "Seadra",
     "image": "cPK_10_008980_00_SEADRA_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10220,7 +11497,8 @@
     "rarity": "RR",
     "name": "Kingdra ex",
     "image": "cPK_10_008990_00_KINGDRAex_RR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10228,7 +11506,8 @@
     "rarity": "C",
     "name": "Magikarp",
     "image": "cPK_10_009000_00_KOIKING_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10236,7 +11515,8 @@
     "rarity": "R",
     "name": "Gyarados",
     "image": "cPK_10_009010_00_GYARADOS_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10244,7 +11524,8 @@
     "rarity": "C",
     "name": "Totodile",
     "image": "cPK_10_009020_00_WANINOKO_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10252,7 +11533,8 @@
     "rarity": "U",
     "name": "Croconaw",
     "image": "cPK_10_009030_00_ALLIGATES_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10260,7 +11542,8 @@
     "rarity": "R",
     "name": "Feraligatr",
     "image": "cPK_10_009040_00_ORDILE_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10268,7 +11551,8 @@
     "rarity": "C",
     "name": "Marill",
     "image": "cPK_10_009050_00_MARIL_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10276,7 +11560,8 @@
     "rarity": "U",
     "name": "Azumarill",
     "image": "cPK_10_009060_00_MARILLI_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10284,7 +11569,8 @@
     "rarity": "C",
     "name": "Wooper",
     "image": "cPK_10_009070_00_UPAH_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10292,7 +11578,8 @@
     "rarity": "U",
     "name": "Quagsire",
     "image": "cPK_10_009080_00_NUOH_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10300,7 +11587,8 @@
     "rarity": "U",
     "name": "Qwilfish",
     "image": "cPK_10_009090_00_HARYSEN_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10308,7 +11596,8 @@
     "rarity": "C",
     "name": "Corsola",
     "image": "cPK_10_009100_00_SUNNYGO_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10316,7 +11605,8 @@
     "rarity": "C",
     "name": "Remoraid",
     "image": "cPK_10_009110_00_TEPPOUO_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10324,7 +11614,8 @@
     "rarity": "R",
     "name": "Octillery",
     "image": "cPK_10_009120_00_OKUTANK_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10332,7 +11623,8 @@
     "rarity": "U",
     "name": "Delibird",
     "image": "cPK_10_009130_00_DELIBIRD_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10340,7 +11632,8 @@
     "rarity": "U",
     "name": "Mantine",
     "image": "cPK_10_009140_00_MANTAIN_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10348,7 +11641,8 @@
     "rarity": "R",
     "name": "Suicune",
     "image": "cPK_10_009150_00_SUICUNE_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10356,7 +11650,8 @@
     "rarity": "C",
     "name": "Corphish",
     "image": "cPK_10_009160_00_HEIGANI_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10364,7 +11659,8 @@
     "rarity": "R",
     "name": "Crawdaunt",
     "image": "cPK_10_009170_00_SHIZARIGER_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10372,7 +11668,8 @@
     "rarity": "C",
     "name": "Ducklett",
     "image": "cPK_10_009180_00_KOARUHIE_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10380,7 +11677,8 @@
     "rarity": "U",
     "name": "Swanna",
     "image": "cPK_10_009190_00_SWANNA_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10388,7 +11686,8 @@
     "rarity": "C",
     "name": "Chinchou",
     "image": "cPK_10_009200_00_CHONCHIE_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10396,7 +11695,8 @@
     "rarity": "RR",
     "name": "Lanturn ex",
     "image": "cPK_10_009210_00_LANTERNex_RR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10404,7 +11704,8 @@
     "rarity": "R",
     "name": "Pichu",
     "image": "cPK_10_009220_00_PICHU_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10412,7 +11713,8 @@
     "rarity": "C",
     "name": "Mareep",
     "image": "cPK_10_009230_00_MERRIEP_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10420,7 +11722,8 @@
     "rarity": "U",
     "name": "Flaaffy",
     "image": "cPK_10_009240_00_MOKOKO_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10428,7 +11731,8 @@
     "rarity": "R",
     "name": "Ampharos",
     "image": "cPK_10_009250_00_DENRYU_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10436,7 +11740,8 @@
     "rarity": "R",
     "name": "Elekid",
     "image": "cPK_10_009260_00_ELEKID_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10444,7 +11749,8 @@
     "rarity": "R",
     "name": "Raikou",
     "image": "cPK_10_009270_00_RAIKOU_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10452,7 +11758,8 @@
     "rarity": "C",
     "name": "Emolga",
     "image": "cPK_10_009280_00_EMOLGA_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10460,7 +11767,8 @@
     "rarity": "C",
     "name": "Slowpoke",
     "image": "cPK_10_009290_00_YADON_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10468,7 +11776,8 @@
     "rarity": "U",
     "name": "Slowking",
     "image": "cPK_10_009300_00_YADOKING_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10476,7 +11785,8 @@
     "rarity": "R",
     "name": "Smoochum",
     "image": "cPK_10_009310_00_MUCHUL_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10484,7 +11794,8 @@
     "rarity": "C",
     "name": "Jynx",
     "image": "cPK_10_009320_00_ROUGELA_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10492,7 +11803,8 @@
     "rarity": "R",
     "name": "Cleffa",
     "image": "cPK_10_009330_00_PY_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10500,7 +11812,8 @@
     "rarity": "C",
     "name": "Togepi",
     "image": "cPK_10_009340_00_TOGEPY_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10508,7 +11821,8 @@
     "rarity": "U",
     "name": "Togetic",
     "image": "cPK_10_009350_00_TOGECHICK_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10516,7 +11830,8 @@
     "rarity": "R",
     "name": "Togekiss",
     "image": "cPK_10_009360_00_TOGEKISS_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10524,7 +11839,8 @@
     "rarity": "C",
     "name": "Natu",
     "image": "cPK_10_009370_00_NATY_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10532,7 +11848,8 @@
     "rarity": "R",
     "name": "Xatu",
     "image": "cPK_10_009380_00_NATIO_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10540,7 +11857,8 @@
     "rarity": "RR",
     "name": "Espeon ex",
     "image": "cPK_10_009390_00_EIFIEex_RR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10548,7 +11866,8 @@
     "rarity": "R",
     "name": "Unown",
     "image": "cPK_10_009400_00_UNKNOWN_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10556,7 +11875,8 @@
     "rarity": "R",
     "name": "Unown",
     "image": "cPK_10_009410_00_UNKNOWN_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10564,7 +11884,8 @@
     "rarity": "C",
     "name": "Wobbuffet",
     "image": "cPK_10_009420_00_SONANS_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10572,7 +11893,8 @@
     "rarity": "C",
     "name": "Girafarig",
     "image": "cPK_10_009430_00_KIRINRIKI_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10580,7 +11902,8 @@
     "rarity": "C",
     "name": "Snubbull",
     "image": "cPK_10_009440_00_BULU_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10588,7 +11911,8 @@
     "rarity": "U",
     "name": "Granbull",
     "image": "cPK_10_009450_00_GRANBULU_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10596,7 +11920,8 @@
     "rarity": "C",
     "name": "Munna",
     "image": "cPK_10_009460_00_MUNNA_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10604,7 +11929,8 @@
     "rarity": "U",
     "name": "Musharna",
     "image": "cPK_10_009470_00_MUSHARNA_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10612,7 +11938,8 @@
     "rarity": "C",
     "name": "Onix",
     "image": "cPK_10_009480_00_IWARK_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10620,7 +11947,8 @@
     "rarity": "C",
     "name": "Sudowoodo",
     "image": "cPK_10_009490_00_USOKKIE_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10628,7 +11956,8 @@
     "rarity": "C",
     "name": "Gligar",
     "image": "cPK_10_009500_00_GLIGER_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10636,7 +11965,8 @@
     "rarity": "U",
     "name": "Gliscor",
     "image": "cPK_10_009510_00_GLION_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10644,7 +11974,8 @@
     "rarity": "C",
     "name": "Swinub",
     "image": "cPK_10_009520_00_URIMOO_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10652,7 +11983,8 @@
     "rarity": "U",
     "name": "Piloswine",
     "image": "cPK_10_009530_00_INOMOO_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10660,7 +11992,8 @@
     "rarity": "R",
     "name": "Mamoswine",
     "image": "cPK_10_009540_00_MAMMOO_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10668,7 +12001,8 @@
     "rarity": "C",
     "name": "Phanpy",
     "image": "cPK_10_009550_00_GOMAZOU_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10676,7 +12010,8 @@
     "rarity": "RR",
     "name": "Donphan ex",
     "image": "cPK_10_009560_00_DONFANex_RR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10684,7 +12019,8 @@
     "rarity": "R",
     "name": "Tyrogue",
     "image": "cPK_10_009570_00_BALKIE_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10692,7 +12028,8 @@
     "rarity": "C",
     "name": "Hitmontop",
     "image": "cPK_10_009580_00_KAPOERER_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10700,7 +12037,8 @@
     "rarity": "C",
     "name": "Larvitar",
     "image": "cPK_10_009590_00_YOGIRAS_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10708,7 +12046,8 @@
     "rarity": "U",
     "name": "Pupitar",
     "image": "cPK_10_009600_00_SANAGIRAS_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10716,7 +12055,8 @@
     "rarity": "C",
     "name": "Binacle",
     "image": "cPK_10_009610_00_KAMETETE_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10724,7 +12064,8 @@
     "rarity": "U",
     "name": "Barbaracle",
     "image": "cPK_10_009620_00_GAMENODES_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10732,7 +12073,8 @@
     "rarity": "C",
     "name": "Zubat",
     "image": "cPK_10_009630_00_ZUBAT_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10740,7 +12082,8 @@
     "rarity": "U",
     "name": "Golbat",
     "image": "cPK_10_009640_00_GOLBAT_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10748,7 +12091,8 @@
     "rarity": "RR",
     "name": "Crobat ex",
     "image": "cPK_10_009650_00_CROBATex_RR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10756,7 +12100,8 @@
     "rarity": "C",
     "name": "Spinarak",
     "image": "cPK_10_009660_00_ITOMARU_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10764,7 +12109,8 @@
     "rarity": "U",
     "name": "Ariados",
     "image": "cPK_10_009670_00_ARIADOS_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10772,7 +12118,8 @@
     "rarity": "RR",
     "name": "Umbreon ex",
     "image": "cPK_10_009680_00_BRACKYex_RR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10780,7 +12127,8 @@
     "rarity": "C",
     "name": "Murkrow",
     "image": "cPK_10_009690_00_YAMIKARASU_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10788,7 +12136,8 @@
     "rarity": "U",
     "name": "Honchkrow",
     "image": "cPK_10_009700_00_DONGKARASU_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10796,7 +12145,8 @@
     "rarity": "C",
     "name": "Sneasel",
     "image": "cPK_10_009710_00_NYULA_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10804,7 +12154,8 @@
     "rarity": "U",
     "name": "Weavile",
     "image": "cPK_10_009720_00_MANYULA_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10812,7 +12163,8 @@
     "rarity": "C",
     "name": "Houndour",
     "image": "cPK_10_009730_00_DELVIL_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10820,7 +12172,8 @@
     "rarity": "U",
     "name": "Houndoom",
     "image": "cPK_10_009740_00_HELLGAR_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10828,7 +12181,8 @@
     "rarity": "R",
     "name": "Tyranitar",
     "image": "cPK_10_009750_00_BANGIRAS_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10836,7 +12190,8 @@
     "rarity": "U",
     "name": "Absol",
     "image": "cPK_10_009760_00_ABSOL_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10844,7 +12199,8 @@
     "rarity": "U",
     "name": "Forretress",
     "image": "cPK_10_009770_00_FORETOS_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10852,7 +12208,8 @@
     "rarity": "R",
     "name": "Steelix",
     "image": "cPK_10_009780_00_HAGANEIL_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10860,7 +12217,8 @@
     "rarity": "R",
     "name": "Scizor",
     "image": "cPK_10_009790_00_HASSAM_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10868,7 +12226,8 @@
     "rarity": "RR",
     "name": "Skarmory ex",
     "image": "cPK_10_009800_00_AIRMDex_RR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10876,7 +12235,8 @@
     "rarity": "C",
     "name": "Mawile",
     "image": "cPK_10_009810_00_KUCHEAT_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10884,7 +12244,8 @@
     "rarity": "C",
     "name": "Klink",
     "image": "cPK_10_009820_00_GIARU_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10892,7 +12253,8 @@
     "rarity": "U",
     "name": "Klang",
     "image": "cPK_10_009830_00_GIGIARU_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10900,7 +12262,8 @@
     "rarity": "R",
     "name": "Klinklang",
     "image": "cPK_10_009840_00_GIGIGIARU_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10908,7 +12271,8 @@
     "rarity": "C",
     "name": "Spearow",
     "image": "cPK_10_009850_00_ONISUZUME_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10916,7 +12280,8 @@
     "rarity": "C",
     "name": "Fearow",
     "image": "cPK_10_009860_00_ONIDRILL_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10924,7 +12289,8 @@
     "rarity": "C",
     "name": "Chansey",
     "image": "cPK_10_009870_00_LUCKY_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10932,7 +12298,8 @@
     "rarity": "R",
     "name": "Blissey",
     "image": "cPK_10_009880_00_HAPPINAS_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10940,7 +12307,8 @@
     "rarity": "R",
     "name": "Kangaskhan",
     "image": "cPK_10_009890_00_GARURA_R.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10948,7 +12316,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_009900_00_EIEVUI_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10956,7 +12325,8 @@
     "rarity": "C",
     "name": "Porygon",
     "image": "cPK_10_009910_00_PORYGON_C.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10964,7 +12334,8 @@
     "rarity": "U",
     "name": "Porygon2",
     "image": "cPK_10_009920_00_PORYGON2_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10972,7 +12343,8 @@
     "rarity": "R",
     "name": "Porygon-Z",
     "image": "cPK_10_009930_00_PORYGON-Z_R.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10980,7 +12352,8 @@
     "rarity": "C",
     "name": "Sentret",
     "image": "cPK_10_009940_00_OTACHI_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10988,7 +12361,8 @@
     "rarity": "C",
     "name": "Furret",
     "image": "cPK_10_009950_00_OOTACHI_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -10996,7 +12370,8 @@
     "rarity": "C",
     "name": "Hoothoot",
     "image": "cPK_10_009960_00_HOHO_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11004,7 +12379,8 @@
     "rarity": "C",
     "name": "Noctowl",
     "image": "cPK_10_009970_00_YORUNOZUKU_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11012,7 +12388,8 @@
     "rarity": "C",
     "name": "Aipom",
     "image": "cPK_10_009980_00_EIPAM_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11020,7 +12397,8 @@
     "rarity": "C",
     "name": "Ambipom",
     "image": "cPK_10_009990_00_ETEBOTH_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11028,7 +12406,8 @@
     "rarity": "C",
     "name": "Dunsparce",
     "image": "cPK_10_010000_00_NOKOCCHI_C.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11036,7 +12415,8 @@
     "rarity": "C",
     "name": "Teddiursa",
     "image": "cPK_10_010010_00_HIMEGUMA_C.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11044,7 +12424,8 @@
     "rarity": "U",
     "name": "Ursaring",
     "image": "cPK_10_010020_00_RINGUMA_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11052,7 +12433,8 @@
     "rarity": "U",
     "name": "Stantler",
     "image": "cPK_10_010030_00_ODOSHISHI_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11060,7 +12442,8 @@
     "rarity": "U",
     "name": "Smeargle",
     "image": "cPK_10_010040_00_DOBLE_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11068,7 +12451,8 @@
     "rarity": "RR",
     "name": "Lugia ex",
     "image": "cPK_10_010050_00_LUGIAex_RR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11076,7 +12460,8 @@
     "rarity": "U",
     "name": "Bouffalant",
     "image": "cPK_10_010060_00_BUFFRON_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11084,7 +12469,8 @@
     "rarity": "U",
     "name": "Elemental Switch",
     "image": "cTR_10_000710_00_EREMENTARUTSUKEKAE_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11092,7 +12478,8 @@
     "rarity": "U",
     "name": "Squirt Bottle",
     "image": "cTR_10_000720_00_ZEHIGAMEJOURO_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11100,7 +12487,8 @@
     "rarity": "U",
     "name": "Steel Apron",
     "image": "cTR_10_000730_00_GOUTETUNOMAEKAKE_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11108,7 +12496,8 @@
     "rarity": "U",
     "name": "Dark Pendant",
     "image": "cTR_10_000740_00_DARKPENDANTO_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11116,7 +12505,8 @@
     "rarity": "U",
     "name": "Rescue Scarf",
     "image": "cTR_10_000750_00_RESUKYUSUKAFU_U.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11124,7 +12514,8 @@
     "rarity": "U",
     "name": "Will",
     "image": "cTR_10_000760_00_ITSUKI_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11132,7 +12523,8 @@
     "rarity": "U",
     "name": "Lyra",
     "image": "cTR_10_000770_00_KOTONE_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11140,7 +12532,8 @@
     "rarity": "U",
     "name": "Silver",
     "image": "cTR_10_000780_00_SILVER_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11148,7 +12541,8 @@
     "rarity": "U",
     "name": "Fisher",
     "image": "cTR_10_000790_00_FISHER_U.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11156,7 +12550,8 @@
     "rarity": "U",
     "name": "Jasmine",
     "image": "cTR_10_000800_00_MIKAN_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11164,7 +12559,8 @@
     "rarity": "U",
     "name": "Hiker",
     "image": "cTR_10_000810_00_HIKER_U.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11172,7 +12568,8 @@
     "rarity": "AR",
     "name": "Chikorita",
     "image": "cPK_20_008640_00_CHICORITA_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11180,7 +12577,8 @@
     "rarity": "AR",
     "name": "Bellossom",
     "image": "cPK_20_008590_00_KIREIHANA_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11188,7 +12586,8 @@
     "rarity": "AR",
     "name": "Heracross",
     "image": "cPK_20_008780_00_HERACROS_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11196,7 +12595,8 @@
     "rarity": "AR",
     "name": "Cyndaquil",
     "image": "cPK_20_008830_00_HINOARASHI_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11204,7 +12604,8 @@
     "rarity": "AR",
     "name": "Magby",
     "image": "cPK_20_008880_00_BUBY_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11212,7 +12613,8 @@
     "rarity": "AR",
     "name": "Totodile",
     "image": "cPK_20_009020_00_WANINOKO_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11220,7 +12622,8 @@
     "rarity": "AR",
     "name": "Qwilfish",
     "image": "cPK_20_009090_00_HARYSEN_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11228,7 +12631,8 @@
     "rarity": "AR",
     "name": "Octillery",
     "image": "cPK_20_009120_00_OKUTANK_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11236,7 +12640,8 @@
     "rarity": "AR",
     "name": "Delibird",
     "image": "cPK_20_009130_00_DELIBIRD_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11244,7 +12649,8 @@
     "rarity": "AR",
     "name": "Pichu",
     "image": "cPK_20_009220_00_PICHU_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11252,7 +12658,8 @@
     "rarity": "AR",
     "name": "Ampharos",
     "image": "cPK_20_009250_00_DENRYU_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11260,7 +12667,8 @@
     "rarity": "AR",
     "name": "Togepi",
     "image": "cPK_20_009340_00_TOGEPY_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11268,7 +12676,8 @@
     "rarity": "AR",
     "name": "Xatu",
     "image": "cPK_20_009380_00_NATIO_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11276,7 +12685,8 @@
     "rarity": "AR",
     "name": "Wobbuffet",
     "image": "cPK_20_009420_00_SONANS_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11284,7 +12694,8 @@
     "rarity": "AR",
     "name": "Gligar",
     "image": "cPK_20_009500_00_GLIGER_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11292,7 +12703,8 @@
     "rarity": "AR",
     "name": "Spinarak",
     "image": "cPK_20_009660_00_ITOMARU_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11300,7 +12712,8 @@
     "rarity": "AR",
     "name": "Murkrow",
     "image": "cPK_20_009690_00_YAMIKARASU_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11308,7 +12721,8 @@
     "rarity": "AR",
     "name": "Tyranitar",
     "image": "cPK_20_009750_00_BANGIRAS_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11316,7 +12730,8 @@
     "rarity": "AR",
     "name": "Scizor",
     "image": "cPK_20_009790_00_HASSAM_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11324,7 +12739,8 @@
     "rarity": "AR",
     "name": "Sentret",
     "image": "cPK_20_009940_00_OTACHI_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11332,7 +12748,8 @@
     "rarity": "AR",
     "name": "Hoothoot",
     "image": "cPK_20_009960_00_HOHO_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11340,7 +12757,8 @@
     "rarity": "AR",
     "name": "Stantler",
     "image": "cPK_20_010030_00_ODOSHISHI_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11348,7 +12766,8 @@
     "rarity": "AR",
     "name": "Smeargle",
     "image": "cPK_20_010040_00_DOBLE_AR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11356,7 +12775,8 @@
     "rarity": "AR",
     "name": "Blissey",
     "image": "cPK_20_009880_00_HAPPINAS_AR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11364,7 +12784,8 @@
     "rarity": "SR",
     "name": "Shuckle ex",
     "image": "cPK_20_008770_00_TSUBOTSUBOex_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11372,7 +12793,8 @@
     "rarity": "SR",
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_00_HOUOUex_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11380,7 +12802,8 @@
     "rarity": "SR",
     "name": "Kingdra ex",
     "image": "cPK_20_008990_00_KINGDRAex_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11388,7 +12811,8 @@
     "rarity": "SR",
     "name": "Lanturn ex",
     "image": "cPK_20_009210_00_LANTERNex_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11396,7 +12820,8 @@
     "rarity": "SR",
     "name": "Espeon ex",
     "image": "cPK_20_009390_00_EIFIEex_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11404,7 +12829,8 @@
     "rarity": "SR",
     "name": "Donphan ex",
     "image": "cPK_20_009560_00_DONFANex_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11412,7 +12838,8 @@
     "rarity": "SR",
     "name": "Crobat ex",
     "image": "cPK_20_009650_00_CROBATex_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11420,7 +12847,8 @@
     "rarity": "SR",
     "name": "Umbreon ex",
     "image": "cPK_20_009680_00_BRACKYex_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11428,7 +12856,8 @@
     "rarity": "SR",
     "name": "Skarmory ex",
     "image": "cPK_20_009800_00_AIRMDex_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11436,7 +12865,8 @@
     "rarity": "SR",
     "name": "Lugia ex",
     "image": "cPK_20_010050_00_LUGIAex_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11444,7 +12874,8 @@
     "rarity": "SR",
     "name": "Will",
     "image": "cTR_20_000760_00_ITSUKI_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11452,7 +12883,8 @@
     "rarity": "SR",
     "name": "Lyra",
     "image": "cTR_20_000770_00_KOTONE_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11460,7 +12892,8 @@
     "rarity": "SR",
     "name": "Silver",
     "image": "cTR_20_000780_00_SILVER_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11468,7 +12901,8 @@
     "rarity": "SR",
     "name": "Fisher",
     "image": "cTR_20_000790_00_FISHER_SR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11476,7 +12910,8 @@
     "rarity": "SR",
     "name": "Jasmine",
     "image": "cTR_20_000800_00_MIKAN_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11484,7 +12919,8 @@
     "rarity": "SR",
     "name": "Hiker",
     "image": "cTR_20_000810_00_HIKER_SR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11492,7 +12928,8 @@
     "rarity": "SAR",
     "name": "Shuckle ex",
     "image": "cPK_20_008770_01_TSUBOTSUBOex_SAR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11500,7 +12937,8 @@
     "rarity": "SAR",
     "name": "Kingdra ex",
     "image": "cPK_20_008990_01_KINGDRAex_SAR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11508,7 +12946,8 @@
     "rarity": "SAR",
     "name": "Lanturn ex",
     "image": "cPK_20_009210_01_LANTERNex_SAR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11516,7 +12955,8 @@
     "rarity": "SAR",
     "name": "Espeon ex",
     "image": "cPK_20_009390_01_EIFIEex_SAR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11524,7 +12964,8 @@
     "rarity": "SAR",
     "name": "Donphan ex",
     "image": "cPK_20_009560_01_DONFANex_SAR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11532,7 +12973,8 @@
     "rarity": "SAR",
     "name": "Crobat ex",
     "image": "cPK_20_009650_01_CROBATex_SAR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11540,7 +12982,8 @@
     "rarity": "SAR",
     "name": "Umbreon ex",
     "image": "cPK_20_009680_01_BRACKYex_SAR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11548,7 +12991,8 @@
     "rarity": "SAR",
     "name": "Skarmory ex",
     "image": "cPK_20_009800_01_AIRMDex_SAR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11556,7 +13000,8 @@
     "rarity": "IM",
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_01_HOUOUex_IM.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11564,7 +13009,8 @@
     "rarity": "IM",
     "name": "Lugia ex",
     "image": "cPK_20_010050_01_LUGIAex_IM.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11572,7 +13018,8 @@
     "rarity": "S",
     "name": "Yanma",
     "image": "cPK_20_008740_00_YANYANMA_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11580,7 +13027,8 @@
     "rarity": "S",
     "name": "Flareon",
     "image": "cPK_20_008040_01_BOOSTER_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11588,7 +13036,8 @@
     "rarity": "S",
     "name": "Magikarp",
     "image": "cPK_20_002310_00_KOIKING_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11596,7 +13045,8 @@
     "rarity": "S",
     "name": "Gyarados",
     "image": "cPK_20_009010_00_GYARADOS_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11604,7 +13054,8 @@
     "rarity": "S",
     "name": "Vaporeon",
     "image": "cPK_20_000800_00_SHOWERS_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11612,7 +13063,8 @@
     "rarity": "S",
     "name": "Magnemite",
     "image": "cPK_20_000970_00_COIL_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11620,7 +13072,8 @@
     "rarity": "S",
     "name": "Magneton",
     "image": "cPK_20_000980_00_RARECOIL_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11628,7 +13081,8 @@
     "rarity": "S",
     "name": "Jolteon",
     "image": "cPK_20_007330_01_THUNDERS_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11636,7 +13090,8 @@
     "rarity": "S",
     "name": "Misdreavus",
     "image": "cPK_20_003470_00_MUMA_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11644,7 +13099,8 @@
     "rarity": "S",
     "name": "Mankey",
     "image": "cPK_20_002540_00_MANKEY_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11652,15 +13108,17 @@
     "rarity": "S",
     "name": "Primeape",
     "image": "cPK_20_001420_00_OKORIZARU_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
     "number": 223,
     "rarity": "S",
-    "name": "Nidoran♀",
+    "name": "Nidoran\u2640",
     "image": "cPK_20_001660_00_NIDORAN%E2%99%80_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11668,7 +13126,8 @@
     "rarity": "S",
     "name": "Nidorina",
     "image": "cPK_20_001670_00_NIDORINA_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11676,15 +13135,17 @@
     "rarity": "S",
     "name": "Nidoqueen",
     "image": "cPK_20_001680_01_NIDOQUEEN_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
     "number": 226,
     "rarity": "S",
-    "name": "Nidoran♂",
+    "name": "Nidoran\u2642",
     "image": "cPK_20_001690_00_NIDORAN%E2%99%82_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11692,7 +13153,8 @@
     "rarity": "S",
     "name": "Nidorino",
     "image": "cPK_20_001700_00_NIDORINO_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11700,7 +13162,8 @@
     "rarity": "S",
     "name": "Nidoking",
     "image": "cPK_20_001710_01_NIDOKING_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11708,7 +13171,8 @@
     "rarity": "S",
     "name": "Sneasel",
     "image": "cPK_20_009710_00_NYULA_S.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11716,7 +13180,8 @@
     "rarity": "S",
     "name": "Lickitung",
     "image": "cPK_20_004050_00_BERORINGA_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11724,7 +13189,8 @@
     "rarity": "S",
     "name": "Eevee",
     "image": "cPK_20_009900_00_EIEVUI_S.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11732,7 +13198,8 @@
     "rarity": "SSR",
     "name": "Yanmega ex",
     "image": "cPK_20_002880_02_MEGAYANMAex_SSR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11740,7 +13207,8 @@
     "rarity": "SSR",
     "name": "Leafeon ex",
     "image": "cPK_20_004340_02_LEAFIAex_SSR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11748,7 +13216,8 @@
     "rarity": "SSR",
     "name": "Gyarados ex",
     "image": "cPK_20_002320_01_GYARADOSex_SSR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11756,7 +13225,8 @@
     "rarity": "SSR",
     "name": "Glaceon ex",
     "image": "cPK_20_004460_02_GLACIAex_SSR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11764,7 +13234,8 @@
     "rarity": "SSR",
     "name": "Pachirisu ex",
     "image": "cPK_20_003420_02_PACHIRISUex_SSR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11772,7 +13243,8 @@
     "rarity": "SSR",
     "name": "Mismagius ex",
     "image": "cPK_20_003480_02_MUMARGIex_SSR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11780,7 +13252,8 @@
     "rarity": "SSR",
     "name": "Weavile ex",
     "image": "cPK_20_003800_02_MANYULAex_SSR.webp",
-    "packs": ["Lugia"]
+    "packs": ["Lugia"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11788,7 +13261,8 @@
     "rarity": "SSR",
     "name": "Lickilicky ex",
     "image": "cPK_20_004060_02_BEROBELTex_SSR.webp",
-    "packs": ["Ho-Oh"]
+    "packs": ["Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11796,7 +13270,8 @@
     "rarity": "UR",
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_02_HOUOUex_UR.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4",
@@ -11804,7 +13279,8 @@
     "rarity": "UR",
     "name": "Lugia ex",
     "image": "cPK_20_010050_02_LUGIAex_UR.webp",
-    "packs": ["Lugia", "Ho-Oh"]
+    "packs": ["Lugia", "Ho-Oh"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11812,7 +13288,8 @@
     "rarity": "C",
     "name": "Hoppip",
     "image": "cPK_10_010220_00_HANECCO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11820,7 +13297,8 @@
     "rarity": "U",
     "name": "Skiploom",
     "image": "cPK_10_010230_00_POPOCCO_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11828,7 +13306,8 @@
     "rarity": "RR",
     "name": "Jumpluff ex",
     "image": "cPK_10_010240_00_WATACCOex_RR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11836,7 +13315,8 @@
     "rarity": "C",
     "name": "Sunkern",
     "image": "cPK_10_010250_00_HIMANUTS_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11844,7 +13324,8 @@
     "rarity": "U",
     "name": "Sunflora",
     "image": "cPK_10_010260_00_KIMAWARI_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11852,7 +13333,8 @@
     "rarity": "R",
     "name": "Celebi",
     "image": "cPK_10_010270_00_CELEBI_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11860,7 +13342,8 @@
     "rarity": "C",
     "name": "Durant",
     "image": "cPK_10_010280_00_AIANT_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11868,7 +13351,8 @@
     "rarity": "C",
     "name": "Slugma",
     "image": "cPK_10_010290_00_MAGMAG_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11876,7 +13360,8 @@
     "rarity": "U",
     "name": "Magcargo",
     "image": "cPK_10_010300_00_MAGCARGOT_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11884,7 +13369,8 @@
     "rarity": "RR",
     "name": "Entei ex",
     "image": "cPK_10_010210_00_ENTEIex_RR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11892,7 +13378,8 @@
     "rarity": "C",
     "name": "Fletchinder",
     "image": "cPK_10_010310_00_HINOYAKOMA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11900,7 +13387,8 @@
     "rarity": "U",
     "name": "Talonflame",
     "image": "cPK_10_010320_00_FIARROW_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11908,7 +13396,8 @@
     "rarity": "C",
     "name": "Poliwag",
     "image": "cPK_10_010330_00_NYOROMO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11916,7 +13405,8 @@
     "rarity": "U",
     "name": "Poliwhirl",
     "image": "cPK_10_010340_00_NYOROZO_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11924,7 +13414,8 @@
     "rarity": "C",
     "name": "Tentacool",
     "image": "cPK_10_010350_00_MENOKURAGE_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11932,7 +13423,8 @@
     "rarity": "U",
     "name": "Tentacruel",
     "image": "cPK_10_010360_00_DOKUKURAGE_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11940,7 +13432,8 @@
     "rarity": "C",
     "name": "Slowpoke",
     "image": "cPK_10_010370_00_YADON_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11948,7 +13441,8 @@
     "rarity": "U",
     "name": "Slowking",
     "image": "cPK_10_010380_00_YADOKING_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11956,7 +13450,8 @@
     "rarity": "C",
     "name": "Jynx",
     "image": "cPK_10_010390_00_ROUGELA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11964,7 +13459,8 @@
     "rarity": "RR",
     "name": "Suicune ex",
     "image": "cPK_10_010400_00_SUICUNEex_RR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11972,7 +13468,8 @@
     "rarity": "C",
     "name": "Feebas",
     "image": "cPK_10_010410_00_HINBASS_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11980,7 +13477,8 @@
     "rarity": "R",
     "name": "Milotic",
     "image": "cPK_10_010120_00_MILOKAROSS_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11988,7 +13486,8 @@
     "rarity": "R",
     "name": "Mantyke",
     "image": "cPK_10_010420_00_TAMANTA_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -11996,7 +13495,8 @@
     "rarity": "C",
     "name": "Cryogonal",
     "image": "cPK_10_010430_00_FREEGEO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12004,7 +13504,8 @@
     "rarity": "RR",
     "name": "Raikou ex",
     "image": "cPK_10_010440_00_RAIKOUex_RR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12012,7 +13513,8 @@
     "rarity": "C",
     "name": "Tynamo",
     "image": "cPK_10_010450_00_SHIBISHIRASU_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12020,7 +13522,8 @@
     "rarity": "C",
     "name": "Eelektrik",
     "image": "cPK_10_010460_00_SHIBIBEEL_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12028,7 +13531,8 @@
     "rarity": "U",
     "name": "Eelektross",
     "image": "cPK_10_010470_00_SHIBIRUDON_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12036,7 +13540,8 @@
     "rarity": "C",
     "name": "Stunfisk",
     "image": "cPK_10_010480_00_MAGGYO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12044,7 +13549,8 @@
     "rarity": "C",
     "name": "Yamper",
     "image": "cPK_10_010490_00_WANPACHI_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12052,7 +13558,8 @@
     "rarity": "R",
     "name": "Boltund",
     "image": "cPK_10_010500_00_PULSEWAN_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12060,7 +13567,8 @@
     "rarity": "C",
     "name": "Misdreavus",
     "image": "cPK_10_010510_00_MUMA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12068,7 +13576,8 @@
     "rarity": "U",
     "name": "Mismagius",
     "image": "cPK_10_010520_00_MUMARGI_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12076,7 +13585,8 @@
     "rarity": "C",
     "name": "Galarian Corsola",
     "image": "cPK_10_010530_00_GALARSUNNYGO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12084,7 +13594,8 @@
     "rarity": "R",
     "name": "Galarian Cursola",
     "image": "cPK_10_010540_00_GALARSUNIGOON_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12092,7 +13603,8 @@
     "rarity": "R",
     "name": "Latias",
     "image": "cPK_10_010200_00_LATIAS_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12100,7 +13612,8 @@
     "rarity": "R",
     "name": "Latios",
     "image": "cPK_10_010550_00_LATIOS_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12108,7 +13621,8 @@
     "rarity": "C",
     "name": "Frillish",
     "image": "cPK_10_010560_00_PURURILL_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12116,7 +13630,8 @@
     "rarity": "U",
     "name": "Jellicent",
     "image": "cPK_10_010570_00_BURUNGEL_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12124,7 +13639,8 @@
     "rarity": "C",
     "name": "Diglett",
     "image": "cPK_10_010580_00_DIGDA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12132,7 +13648,8 @@
     "rarity": "U",
     "name": "Dugtrio",
     "image": "cPK_10_010590_00_DUGTRIO_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12140,7 +13657,8 @@
     "rarity": "RR",
     "name": "Poliwrath ex",
     "image": "cPK_10_010600_00_NYOROBONex_RR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12148,7 +13666,8 @@
     "rarity": "C",
     "name": "Phanpy",
     "image": "cPK_10_010190_00_GOMAZOU_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12156,7 +13675,8 @@
     "rarity": "U",
     "name": "Donphan",
     "image": "cPK_10_010610_00_DONFAN_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12164,7 +13684,8 @@
     "rarity": "C",
     "name": "Relicanth",
     "image": "cPK_10_010620_00_GLANTH_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12172,7 +13693,8 @@
     "rarity": "C",
     "name": "Dwebble",
     "image": "cPK_10_010630_00_ISHIZUMAI_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12180,7 +13702,8 @@
     "rarity": "U",
     "name": "Crustle",
     "image": "cPK_10_010640_00_IWAPALACE_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12188,7 +13711,8 @@
     "rarity": "C",
     "name": "Seviper",
     "image": "cPK_10_010650_00_HABUNAKE_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12196,7 +13720,8 @@
     "rarity": "C",
     "name": "Zorua",
     "image": "cPK_10_010130_00_ZORUA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12204,7 +13729,8 @@
     "rarity": "R",
     "name": "Zoroark",
     "image": "cPK_10_010140_00_ZOROARK_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12212,7 +13738,8 @@
     "rarity": "C",
     "name": "Inkay",
     "image": "cPK_10_010660_00_MAAIIKA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12220,7 +13747,8 @@
     "rarity": "U",
     "name": "Malamar",
     "image": "cPK_10_010670_00_CALAMANERO_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12228,7 +13756,8 @@
     "rarity": "C",
     "name": "Skrelp",
     "image": "cPK_10_010680_00_KUZUMO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12236,7 +13765,8 @@
     "rarity": "C",
     "name": "Dragalge",
     "image": "cPK_10_010690_00_DRAMIDORO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12244,15 +13774,17 @@
     "rarity": "R",
     "name": "Altaria",
     "image": "cPK_10_010700_00_TYLTALIS_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
     "number": 56,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_10_010710_00_KAMONEGI_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12260,7 +13792,8 @@
     "rarity": "C",
     "name": "Lickitung",
     "image": "cPK_10_010720_00_BERORINGA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12268,7 +13801,8 @@
     "rarity": "U",
     "name": "Lickilicky",
     "image": "cPK_10_010730_00_BEROBELT_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12276,7 +13810,8 @@
     "rarity": "R",
     "name": "Igglybuff",
     "image": "cPK_10_010740_00_PUPURIN_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12284,7 +13819,8 @@
     "rarity": "C",
     "name": "Teddiursa",
     "image": "cPK_10_010750_00_HIMEGUMA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12292,7 +13828,8 @@
     "rarity": "U",
     "name": "Ursaring",
     "image": "cPK_10_010760_00_RINGUMA_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12300,7 +13837,8 @@
     "rarity": "U",
     "name": "Miltank",
     "image": "cPK_10_010180_00_MILTANK_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12308,7 +13846,8 @@
     "rarity": "R",
     "name": "Azurill",
     "image": "cPK_10_010770_00_RURIRI_R.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12316,7 +13855,8 @@
     "rarity": "C",
     "name": "Swablu",
     "image": "cPK_10_010780_00_TYLTTO_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12324,7 +13864,8 @@
     "rarity": "U",
     "name": "Zangoose",
     "image": "cPK_10_010790_00_ZANGOOSE_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12332,7 +13873,8 @@
     "rarity": "C",
     "name": "Fletchling",
     "image": "cPK_10_010800_00_YAYAKOMA_C.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12340,7 +13882,8 @@
     "rarity": "U",
     "name": "Inflatable Boat",
     "image": "cTR_10_000820_00_WHOTABOTO_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12348,7 +13891,8 @@
     "rarity": "U",
     "name": "Memory Light",
     "image": "cTR_10_000830_00_MEMORYLIGHT_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12356,7 +13900,8 @@
     "rarity": "U",
     "name": "Whitney",
     "image": "cTR_10_000840_00_AKANE_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12364,7 +13909,8 @@
     "rarity": "U",
     "name": "Traveling Merchant",
     "image": "cTR_10_000850_00_TABINOGYOUSHOUNIN_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12372,7 +13918,8 @@
     "rarity": "U",
     "name": "Morty",
     "image": "cTR_10_000860_00_MATSUBA_U.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12380,7 +13927,8 @@
     "rarity": "AR",
     "name": "Milotic",
     "image": "cPK_20_010120_00_MILOKAROSS_AR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12388,7 +13936,8 @@
     "rarity": "AR",
     "name": "Stunfisk",
     "image": "cPK_20_010480_00_MAGGYO_AR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12396,7 +13945,8 @@
     "rarity": "AR",
     "name": "Yamper",
     "image": "cPK_20_010490_00_WANPACHI_AR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12404,7 +13954,8 @@
     "rarity": "AR",
     "name": "Latios",
     "image": "cPK_20_010550_00_LATIOS_AR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12412,7 +13963,8 @@
     "rarity": "AR",
     "name": "Phanpy",
     "image": "cPK_20_010190_00_GOMAZOU_AR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12420,7 +13972,8 @@
     "rarity": "AR",
     "name": "Azurill",
     "image": "cPK_20_010770_00_RURIRI_AR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12428,7 +13981,8 @@
     "rarity": "SR",
     "name": "Jumpluff ex",
     "image": "cPK_20_010240_00_WATACCOex_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12436,7 +13990,8 @@
     "rarity": "SR",
     "name": "Entei ex",
     "image": "cPK_20_010210_00_ENTEIex_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12444,7 +13999,8 @@
     "rarity": "SR",
     "name": "Suicune ex",
     "image": "cPK_20_010400_00_SUICUNEex_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12452,7 +14008,8 @@
     "rarity": "SR",
     "name": "Raikou ex",
     "image": "cPK_20_010440_00_RAIKOUex_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12460,7 +14017,8 @@
     "rarity": "SR",
     "name": "Poliwrath ex",
     "image": "cPK_20_010600_00_NYOROBONex_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12468,7 +14026,8 @@
     "rarity": "SR",
     "name": "Whitney",
     "image": "cTR_20_000840_00_AKANE_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12476,7 +14035,8 @@
     "rarity": "SR",
     "name": "Traveling Merchant",
     "image": "cTR_20_000850_00_TABINOGYOUSHOUNIN_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12484,7 +14044,8 @@
     "rarity": "SR",
     "name": "Morty",
     "image": "cTR_20_000860_00_MATSUBA_SR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12492,7 +14053,8 @@
     "rarity": "SAR",
     "name": "Jumpluff ex",
     "image": "cPK_20_010240_01_WATACCOex_SAR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12500,7 +14062,8 @@
     "rarity": "SAR",
     "name": "Entei ex",
     "image": "cPK_20_010210_01_ENTEIex_SAR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12508,7 +14071,8 @@
     "rarity": "SAR",
     "name": "Raikou ex",
     "image": "cPK_20_010440_01_RAIKOUex_SAR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12516,7 +14080,8 @@
     "rarity": "SAR",
     "name": "Poliwrath ex",
     "image": "cPK_20_010600_01_NYOROBONex_SAR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12524,7 +14089,8 @@
     "rarity": "IM",
     "name": "Suicune ex",
     "image": "cPK_20_010400_01_SUICUNEex_IM.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12532,7 +14098,8 @@
     "rarity": "S",
     "name": "Chimchar",
     "image": "cPK_20_003080_00_HIKOZARU_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12540,7 +14107,8 @@
     "rarity": "S",
     "name": "Monferno",
     "image": "cPK_20_003090_00_MOUKAZARU_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12548,7 +14116,8 @@
     "rarity": "S",
     "name": "Psyduck",
     "image": "cPK_20_000570_00_KODUCK_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12556,7 +14125,8 @@
     "rarity": "S",
     "name": "Golduck",
     "image": "cPK_20_000580_00_GOLDUCK_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12564,7 +14134,8 @@
     "rarity": "S",
     "name": "Krabby",
     "image": "cPK_20_000680_00_CRAB_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12572,7 +14143,8 @@
     "rarity": "S",
     "name": "Kingler",
     "image": "cPK_20_000690_00_KINGLER_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12580,7 +14152,8 @@
     "rarity": "S",
     "name": "Pyukumuku",
     "image": "cPK_20_006350_01_NAMAKOBUSHI_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12588,7 +14161,8 @@
     "rarity": "S",
     "name": "Gible",
     "image": "cPK_20_004690_00_FUKAMARU_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12596,7 +14170,8 @@
     "rarity": "S",
     "name": "Gabite",
     "image": "cPK_20_004700_00_GABITE_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12604,7 +14179,8 @@
     "rarity": "S",
     "name": "Paldean Wooper",
     "image": "cPK_20_005620_00_PALDEAUPAH_S.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12612,7 +14188,8 @@
     "rarity": "SSR",
     "name": "Infernape ex",
     "image": "cPK_20_003100_02_GOUKAZARUex_SSR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12620,7 +14197,8 @@
     "rarity": "SSR",
     "name": "Mew ex",
     "image": "cPK_20_002450_03_MEWex_SSR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12628,7 +14206,8 @@
     "rarity": "SSR",
     "name": "Garchomp ex",
     "image": "cPK_20_004710_02_GABURIASex_SSR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12636,7 +14215,8 @@
     "rarity": "SSR",
     "name": "Paldean Clodsire ex",
     "image": "cPK_20_005630_02_PALDEADOOHex_SSR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4a",
@@ -12644,7 +14224,8 @@
     "rarity": "UR",
     "name": "Mantyke",
     "image": "cPK_20_010420_00_TAMANTA_UR.webp",
-    "packs": ["Secluded"]
+    "packs": ["Secluded"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12652,7 +14233,8 @@
     "rarity": "C",
     "name": "Bulbasaur",
     "image": "cPK_10_000010_00_FUSHIGIDANE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12660,7 +14242,8 @@
     "rarity": "C",
     "name": "Bulbasaur",
     "image": "cPK_10_000010_01_FUSHIGIDANE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12668,7 +14251,8 @@
     "rarity": "U",
     "name": "Ivysaur",
     "image": "cPK_10_000020_00_FUSHIGISOU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12676,7 +14260,8 @@
     "rarity": "U",
     "name": "Ivysaur",
     "image": "cPK_10_000020_01_FUSHIGISOU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12684,7 +14269,8 @@
     "rarity": "RR",
     "name": "Venusaur ex",
     "image": "cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12692,7 +14278,8 @@
     "rarity": "C",
     "name": "Weedle",
     "image": "cPK_10_005210_00_BEEDLE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12700,7 +14287,8 @@
     "rarity": "C",
     "name": "Weedle",
     "image": "cPK_10_005210_01_BEEDLE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12708,7 +14296,8 @@
     "rarity": "U",
     "name": "Kakuna",
     "image": "cPK_10_005220_00_COCOON_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12716,7 +14305,8 @@
     "rarity": "U",
     "name": "Kakuna",
     "image": "cPK_10_005220_01_COCOON_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12724,7 +14314,8 @@
     "rarity": "RR",
     "name": "Beedrill ex",
     "image": "cPK_10_005230_00_SPEARex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12732,7 +14323,8 @@
     "rarity": "C",
     "name": "Exeggcute",
     "image": "cPK_10_000210_00_TAMATAMA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12740,7 +14332,8 @@
     "rarity": "C",
     "name": "Exeggcute",
     "image": "cPK_10_000210_01_TAMATAMA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12748,7 +14341,8 @@
     "rarity": "RR",
     "name": "Exeggutor ex",
     "image": "cPK_10_000230_00_NASSYex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12756,7 +14350,8 @@
     "rarity": "C",
     "name": "Hoppip",
     "image": "cPK_10_008690_00_HANECCO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12764,7 +14359,8 @@
     "rarity": "C",
     "name": "Hoppip",
     "image": "cPK_10_008690_01_HANECCO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12772,7 +14368,8 @@
     "rarity": "U",
     "name": "Skiploom",
     "image": "cPK_10_008700_00_POPOCCO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12780,7 +14377,8 @@
     "rarity": "U",
     "name": "Skiploom",
     "image": "cPK_10_008700_01_POPOCCO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12788,7 +14386,8 @@
     "rarity": "R",
     "name": "Jumpluff",
     "image": "cPK_10_008710_00_WATACCO_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12796,7 +14395,8 @@
     "rarity": "R",
     "name": "Jumpluff",
     "image": "cPK_10_008710_01_WATACCO_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12804,7 +14404,8 @@
     "rarity": "C",
     "name": "Yanma",
     "image": "cPK_10_002870_00_YANYANMA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12812,7 +14413,8 @@
     "rarity": "C",
     "name": "Yanma",
     "image": "cPK_10_002870_01_YANYANMA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12820,7 +14422,8 @@
     "rarity": "RR",
     "name": "Yanmega ex",
     "image": "cPK_10_002880_00_MEGAYANMAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12828,7 +14431,8 @@
     "rarity": "RR",
     "name": "Shuckle ex",
     "image": "cPK_10_008770_00_TSUBOTSUBOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12836,7 +14440,8 @@
     "rarity": "RR",
     "name": "Celebi ex",
     "image": "cPK_10_002170_00_CELEBIex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12844,7 +14449,8 @@
     "rarity": "C",
     "name": "Cherubi",
     "image": "cPK_10_008790_00_CHERINBO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12852,7 +14458,8 @@
     "rarity": "C",
     "name": "Cherubi",
     "image": "cPK_10_008790_01_CHERINBO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12860,7 +14467,8 @@
     "rarity": "U",
     "name": "Cherrim",
     "image": "cPK_10_008800_00_CHERRIM_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12868,7 +14476,8 @@
     "rarity": "U",
     "name": "Cherrim",
     "image": "cPK_10_008800_01_CHERRIM_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12876,7 +14485,8 @@
     "rarity": "RR",
     "name": "Leafeon ex",
     "image": "cPK_10_004340_00_LEAFIAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12884,7 +14494,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_10_003030_00_SHAYMIN_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12892,7 +14503,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_10_003030_01_SHAYMIN_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12900,7 +14512,8 @@
     "rarity": "C",
     "name": "Snivy",
     "image": "cPK_10_002180_00_TSUTARJA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12908,7 +14521,8 @@
     "rarity": "C",
     "name": "Snivy",
     "image": "cPK_10_002180_01_TSUTARJA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12916,7 +14530,8 @@
     "rarity": "U",
     "name": "Servine",
     "image": "cPK_10_002190_00_JANOVY_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12924,7 +14539,8 @@
     "rarity": "U",
     "name": "Servine",
     "image": "cPK_10_002190_01_JANOVY_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12932,7 +14548,8 @@
     "rarity": "R",
     "name": "Serperior",
     "image": "cPK_10_002200_00_JALORDA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12940,7 +14557,8 @@
     "rarity": "R",
     "name": "Serperior",
     "image": "cPK_10_002200_01_JALORDA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12948,7 +14566,8 @@
     "rarity": "C",
     "name": "Rowlet",
     "image": "cPK_10_005910_00_MOKUROH_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12956,7 +14575,8 @@
     "rarity": "C",
     "name": "Rowlet",
     "image": "cPK_10_005910_01_MOKUROH_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12964,7 +14584,8 @@
     "rarity": "U",
     "name": "Dartrix",
     "image": "cPK_10_005920_00_FUKUTHROW_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12972,7 +14593,8 @@
     "rarity": "U",
     "name": "Dartrix",
     "image": "cPK_10_005920_01_FUKUTHROW_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -12980,7 +14602,8 @@
     "rarity": "RR",
     "name": "Decidueye ex",
     "image": "cPK_10_005930_00_JUNAIPERex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12988,7 +14611,8 @@
     "rarity": "RR",
     "name": "Dhelmise ex",
     "image": "cPK_10_006040_00_DADARINex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -12996,7 +14620,8 @@
     "rarity": "RR",
     "name": "Buzzwole ex",
     "image": "cPK_10_007480_00_MASSIVOONex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13004,7 +14629,8 @@
     "rarity": "U",
     "name": "Pheromosa",
     "image": "cPK_10_007490_00_PHEROACHE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13012,7 +14638,8 @@
     "rarity": "U",
     "name": "Pheromosa",
     "image": "cPK_10_007490_01_PHEROACHE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13020,7 +14647,8 @@
     "rarity": "C",
     "name": "Kartana",
     "image": "cPK_10_007250_00_KAMITURUGI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13028,7 +14656,8 @@
     "rarity": "C",
     "name": "Kartana",
     "image": "cPK_10_007250_01_KAMITURUGI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13036,7 +14665,8 @@
     "rarity": "C",
     "name": "Sprigatito",
     "image": "cPK_10_005080_00_NYAHOJA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13044,7 +14674,8 @@
     "rarity": "C",
     "name": "Sprigatito",
     "image": "cPK_10_005080_01_NYAHOJA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13052,7 +14683,8 @@
     "rarity": "U",
     "name": "Floragato",
     "image": "cPK_10_005250_00_NYAROTE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13060,7 +14692,8 @@
     "rarity": "U",
     "name": "Floragato",
     "image": "cPK_10_005250_01_NYAROTE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13068,7 +14701,8 @@
     "rarity": "R",
     "name": "Meowscarada",
     "image": "cPK_10_005260_00_MASQUERNYA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13076,7 +14710,8 @@
     "rarity": "R",
     "name": "Meowscarada",
     "image": "cPK_10_005260_01_MASQUERNYA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13084,7 +14719,8 @@
     "rarity": "C",
     "name": "Charmander",
     "image": "cPK_10_000330_00_HITOKAGE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13092,7 +14728,8 @@
     "rarity": "C",
     "name": "Charmander",
     "image": "cPK_10_000330_01_HITOKAGE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13100,7 +14737,8 @@
     "rarity": "U",
     "name": "Charmeleon",
     "image": "cPK_10_000340_00_LIZARDO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13108,7 +14746,8 @@
     "rarity": "U",
     "name": "Charmeleon",
     "image": "cPK_10_000340_01_LIZARDO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13116,7 +14755,8 @@
     "rarity": "RR",
     "name": "Charizard ex",
     "image": "cPK_10_000360_00_LIZARDONex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13124,7 +14764,8 @@
     "rarity": "RR",
     "name": "Charizard ex",
     "image": "cPK_10_005290_00_LIZARDONex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13132,7 +14773,8 @@
     "rarity": "C",
     "name": "Growlithe",
     "image": "cPK_10_000390_00_GARDIE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13140,7 +14782,8 @@
     "rarity": "C",
     "name": "Growlithe",
     "image": "cPK_10_000390_01_GARDIE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13148,7 +14791,8 @@
     "rarity": "RR",
     "name": "Arcanine ex",
     "image": "cPK_10_000410_00_WINDIEex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13156,7 +14800,8 @@
     "rarity": "R",
     "name": "Flareon",
     "image": "cPK_10_008040_00_BOOSTER_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13164,7 +14809,8 @@
     "rarity": "R",
     "name": "Flareon",
     "image": "cPK_10_008040_01_BOOSTER_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13172,7 +14818,8 @@
     "rarity": "RR",
     "name": "Flareon ex",
     "image": "cPK_10_008050_00_BOOSTERex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13180,7 +14827,8 @@
     "rarity": "RR",
     "name": "Moltres ex",
     "image": "cPK_10_000470_00_FIREex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13188,7 +14836,8 @@
     "rarity": "RR",
     "name": "Ho-Oh ex",
     "image": "cPK_10_008900_00_HOUOUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13196,7 +14845,8 @@
     "rarity": "C",
     "name": "Torkoal",
     "image": "cPK_10_008060_00_COTOISE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13204,7 +14854,8 @@
     "rarity": "C",
     "name": "Torkoal",
     "image": "cPK_10_008060_01_COTOISE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13212,7 +14863,8 @@
     "rarity": "C",
     "name": "Chimchar",
     "image": "cPK_10_003080_00_HIKOZARU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13220,7 +14872,8 @@
     "rarity": "C",
     "name": "Chimchar",
     "image": "cPK_10_003080_01_HIKOZARU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13228,7 +14881,8 @@
     "rarity": "U",
     "name": "Monferno",
     "image": "cPK_10_003090_00_MOUKAZARU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13236,7 +14890,8 @@
     "rarity": "U",
     "name": "Monferno",
     "image": "cPK_10_003090_01_MOUKAZARU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13244,7 +14899,8 @@
     "rarity": "RR",
     "name": "Infernape ex",
     "image": "cPK_10_003100_00_GOUKAZARUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13252,7 +14908,8 @@
     "rarity": "R",
     "name": "Heatran",
     "image": "cPK_10_004370_00_HEATRAN_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13260,7 +14917,8 @@
     "rarity": "R",
     "name": "Heatran",
     "image": "cPK_10_004370_01_HEATRAN_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13268,7 +14926,8 @@
     "rarity": "C",
     "name": "Litten",
     "image": "cPK_10_006110_00_NYABBY_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13276,7 +14935,8 @@
     "rarity": "C",
     "name": "Litten",
     "image": "cPK_10_006110_01_NYABBY_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13284,7 +14944,8 @@
     "rarity": "U",
     "name": "Torracat",
     "image": "cPK_10_006130_00_NYAHEAT_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13292,7 +14953,8 @@
     "rarity": "U",
     "name": "Torracat",
     "image": "cPK_10_006130_01_NYAHEAT_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13300,7 +14962,8 @@
     "rarity": "RR",
     "name": "Incineroar ex",
     "image": "cPK_10_006140_00_GAOGAENex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13308,7 +14971,8 @@
     "rarity": "C",
     "name": "Squirtle",
     "image": "cPK_10_000530_00_ZENIGAME_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13316,7 +14980,8 @@
     "rarity": "C",
     "name": "Squirtle",
     "image": "cPK_10_000530_01_ZENIGAME_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13324,7 +14989,8 @@
     "rarity": "U",
     "name": "Wartortle",
     "image": "cPK_10_000540_00_KAMEIL_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13332,7 +14998,8 @@
     "rarity": "U",
     "name": "Wartortle",
     "image": "cPK_10_000540_01_KAMEIL_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13340,7 +15007,8 @@
     "rarity": "RR",
     "name": "Blastoise ex",
     "image": "cPK_10_000560_00_KAMEXex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13348,7 +15016,8 @@
     "rarity": "C",
     "name": "Horsea",
     "image": "cPK_10_008970_00_TATTU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13356,7 +15025,8 @@
     "rarity": "C",
     "name": "Horsea",
     "image": "cPK_10_008970_01_TATTU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13364,7 +15034,8 @@
     "rarity": "U",
     "name": "Seadra",
     "image": "cPK_10_008980_00_SEADRA_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13372,7 +15043,8 @@
     "rarity": "U",
     "name": "Seadra",
     "image": "cPK_10_008980_01_SEADRA_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13380,7 +15052,8 @@
     "rarity": "RR",
     "name": "Kingdra ex",
     "image": "cPK_10_008990_00_KINGDRAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13388,7 +15061,8 @@
     "rarity": "C",
     "name": "Staryu",
     "image": "cPK_10_000740_00_HITODEMAN_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13396,7 +15070,8 @@
     "rarity": "C",
     "name": "Staryu",
     "image": "cPK_10_000740_01_HITODEMAN_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13404,7 +15079,8 @@
     "rarity": "RR",
     "name": "Starmie ex",
     "image": "cPK_10_000760_00_STARMIEex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13412,7 +15088,8 @@
     "rarity": "C",
     "name": "Magikarp",
     "image": "cPK_10_002310_00_KOIKING_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13420,7 +15097,8 @@
     "rarity": "C",
     "name": "Magikarp",
     "image": "cPK_10_002310_01_KOIKING_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13428,7 +15106,8 @@
     "rarity": "RR",
     "name": "Gyarados ex",
     "image": "cPK_10_002320_00_GYARADOSex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13436,7 +15115,8 @@
     "rarity": "R",
     "name": "Vaporeon",
     "image": "cPK_10_002330_00_SHOWERS_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13444,7 +15124,8 @@
     "rarity": "R",
     "name": "Vaporeon",
     "image": "cPK_10_002330_01_SHOWERS_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13452,7 +15133,8 @@
     "rarity": "RR",
     "name": "Articuno ex",
     "image": "cPK_10_000840_00_FREEZERex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13460,7 +15142,8 @@
     "rarity": "C",
     "name": "Corphish",
     "image": "cPK_10_009160_00_HEIGANI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13468,7 +15151,8 @@
     "rarity": "C",
     "name": "Corphish",
     "image": "cPK_10_009160_01_HEIGANI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13476,7 +15160,8 @@
     "rarity": "R",
     "name": "Crawdaunt",
     "image": "cPK_10_009170_00_SHIZARIGER_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13484,7 +15169,8 @@
     "rarity": "R",
     "name": "Crawdaunt",
     "image": "cPK_10_009170_01_SHIZARIGER_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13492,7 +15178,8 @@
     "rarity": "RR",
     "name": "Glaceon ex",
     "image": "cPK_10_004460_00_GLACIAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13500,7 +15187,8 @@
     "rarity": "RR",
     "name": "Palkia ex",
     "image": "cPK_10_003300_00_PALKIAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13508,7 +15196,8 @@
     "rarity": "U",
     "name": "Manaphy",
     "image": "cPK_10_003310_00_MANAPHY_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13516,7 +15205,8 @@
     "rarity": "U",
     "name": "Manaphy",
     "image": "cPK_10_003310_01_MANAPHY_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13524,7 +15214,8 @@
     "rarity": "C",
     "name": "Froakie",
     "image": "cPK_10_000870_00_KEROMATSU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13532,7 +15223,8 @@
     "rarity": "C",
     "name": "Froakie",
     "image": "cPK_10_000870_01_KEROMATSU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13540,7 +15232,8 @@
     "rarity": "U",
     "name": "Frogadier",
     "image": "cPK_10_000880_00_GEKOGASHIRA_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13548,7 +15241,8 @@
     "rarity": "U",
     "name": "Frogadier",
     "image": "cPK_10_000880_01_GEKOGASHIRA_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13556,7 +15250,8 @@
     "rarity": "R",
     "name": "Greninja",
     "image": "cPK_10_000890_00_GEKKOUGA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13564,7 +15259,8 @@
     "rarity": "R",
     "name": "Greninja",
     "image": "cPK_10_000890_01_GEKKOUGA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13572,7 +15268,8 @@
     "rarity": "C",
     "name": "Popplio",
     "image": "cPK_10_008170_00_ASHIMARI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13580,7 +15277,8 @@
     "rarity": "C",
     "name": "Popplio",
     "image": "cPK_10_008170_01_ASHIMARI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13588,7 +15286,8 @@
     "rarity": "C",
     "name": "Brionne",
     "image": "cPK_10_008180_00_OSYAMARI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13596,7 +15295,8 @@
     "rarity": "C",
     "name": "Brionne",
     "image": "cPK_10_008180_01_OSYAMARI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13604,7 +15304,8 @@
     "rarity": "RR",
     "name": "Primarina ex",
     "image": "cPK_10_008190_00_ASHIRENEex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13612,7 +15313,8 @@
     "rarity": "RR",
     "name": "Crabominable ex",
     "image": "cPK_10_006300_00_KEKENKANIex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13620,7 +15322,8 @@
     "rarity": "C",
     "name": "Wishiwashi",
     "image": "cPK_10_006310_00_YOWASHITANDOKUNOSUGATA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13628,7 +15331,8 @@
     "rarity": "C",
     "name": "Wishiwashi",
     "image": "cPK_10_006310_01_YOWASHITANDOKUNOSUGATA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13636,7 +15340,8 @@
     "rarity": "RR",
     "name": "Wishiwashi ex",
     "image": "cPK_10_006320_00_YOWASHIMURETASUGATA_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13644,7 +15349,8 @@
     "rarity": "C",
     "name": "Wiglett",
     "image": "cPK_10_005370_00_UMIDIGDA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13652,7 +15358,8 @@
     "rarity": "C",
     "name": "Wiglett",
     "image": "cPK_10_005370_01_UMIDIGDA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13660,7 +15367,8 @@
     "rarity": "RR",
     "name": "Wugtrio ex",
     "image": "cPK_10_005380_00_UMITRIOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13668,7 +15376,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_10_000940_00_PIKACHU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13676,7 +15385,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_10_000940_01_PIKACHU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13684,7 +15394,8 @@
     "rarity": "RR",
     "name": "Alolan Raichu ex",
     "image": "cPK_10_006390_00_ALOLARAICHUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13692,7 +15403,8 @@
     "rarity": "RR",
     "name": "Pikachu ex",
     "image": "cPK_10_000960_00_PIKACHUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13700,7 +15412,8 @@
     "rarity": "RR",
     "name": "Pikachu ex",
     "image": "cPK_10_005410_00_PIKACHUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13708,7 +15421,8 @@
     "rarity": "C",
     "name": "Magnemite",
     "image": "cPK_10_000970_00_COIL_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13716,7 +15430,8 @@
     "rarity": "C",
     "name": "Magnemite",
     "image": "cPK_10_000970_01_COIL_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13724,7 +15439,8 @@
     "rarity": "R",
     "name": "Magneton",
     "image": "cPK_10_000980_00_RARECOIL_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13732,7 +15448,8 @@
     "rarity": "R",
     "name": "Magneton",
     "image": "cPK_10_000980_01_RARECOIL_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13740,7 +15457,8 @@
     "rarity": "R",
     "name": "Magnezone",
     "image": "cPK_10_003340_00_JIBACOIL_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13748,7 +15466,8 @@
     "rarity": "R",
     "name": "Magnezone",
     "image": "cPK_10_003340_01_JIBACOIL_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13756,7 +15475,8 @@
     "rarity": "RR",
     "name": "Zapdos ex",
     "image": "cPK_10_001040_00_THUNDERex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13764,7 +15484,8 @@
     "rarity": "C",
     "name": "Chinchou",
     "image": "cPK_10_009200_00_CHONCHIE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13772,7 +15493,8 @@
     "rarity": "C",
     "name": "Chinchou",
     "image": "cPK_10_009200_01_CHONCHIE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13780,7 +15502,8 @@
     "rarity": "RR",
     "name": "Lanturn ex",
     "image": "cPK_10_009210_00_LANTERNex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13788,7 +15511,8 @@
     "rarity": "U",
     "name": "Pachirisu",
     "image": "cPK_10_005060_00_PACHIRISU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13796,7 +15520,8 @@
     "rarity": "U",
     "name": "Pachirisu",
     "image": "cPK_10_005060_01_PACHIRISU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13804,7 +15529,8 @@
     "rarity": "RR",
     "name": "Pachirisu ex",
     "image": "cPK_10_003420_00_PACHIRISUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13812,7 +15538,8 @@
     "rarity": "R",
     "name": "Oricorio",
     "image": "cPK_10_006470_00_ODORIDORIPACHIPACHISTYLE_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13820,7 +15547,8 @@
     "rarity": "R",
     "name": "Oricorio",
     "image": "cPK_10_006470_01_ODORIDORIPACHIPACHISTYLE_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13828,7 +15556,8 @@
     "rarity": "RR",
     "name": "Tapu Koko ex",
     "image": "cPK_10_007420_00_KAPU-KOKEKOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13836,7 +15565,8 @@
     "rarity": "R",
     "name": "Zeraora",
     "image": "cPK_10_007410_00_ZERAORA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13844,7 +15574,8 @@
     "rarity": "R",
     "name": "Zeraora",
     "image": "cPK_10_007410_01_ZERAORA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13852,7 +15583,8 @@
     "rarity": "C",
     "name": "Gastly",
     "image": "cPK_10_001200_00_GHOS_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13860,7 +15592,8 @@
     "rarity": "C",
     "name": "Gastly",
     "image": "cPK_10_001200_01_GHOS_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13868,7 +15601,8 @@
     "rarity": "U",
     "name": "Haunter",
     "image": "cPK_10_001210_00_GHOST_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13876,7 +15610,8 @@
     "rarity": "U",
     "name": "Haunter",
     "image": "cPK_10_001210_01_GHOST_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13884,7 +15619,8 @@
     "rarity": "RR",
     "name": "Gengar ex",
     "image": "cPK_10_001230_00_GANGARex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13892,7 +15628,8 @@
     "rarity": "C",
     "name": "Jynx",
     "image": "cPK_10_001270_00_ROUGELA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13900,7 +15637,8 @@
     "rarity": "C",
     "name": "Jynx",
     "image": "cPK_10_001270_01_ROUGELA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13908,7 +15646,8 @@
     "rarity": "RR",
     "name": "Mewtwo ex",
     "image": "cPK_10_001290_00_MEWTWOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13916,7 +15655,8 @@
     "rarity": "RR",
     "name": "Mew ex",
     "image": "cPK_10_002450_00_MEWex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13924,7 +15664,8 @@
     "rarity": "RR",
     "name": "Espeon ex",
     "image": "cPK_10_009390_00_EIFIEex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13932,7 +15673,8 @@
     "rarity": "C",
     "name": "Misdreavus",
     "image": "cPK_10_003470_00_MUMA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13940,7 +15682,8 @@
     "rarity": "C",
     "name": "Misdreavus",
     "image": "cPK_10_003470_01_MUMA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13948,7 +15691,8 @@
     "rarity": "RR",
     "name": "Mismagius ex",
     "image": "cPK_10_003480_00_MUMARGIex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13956,7 +15700,8 @@
     "rarity": "C",
     "name": "Ralts",
     "image": "cPK_10_003490_00_RALTS_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13964,7 +15709,8 @@
     "rarity": "C",
     "name": "Ralts",
     "image": "cPK_10_003490_01_RALTS_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13972,7 +15718,8 @@
     "rarity": "C",
     "name": "Kirlia",
     "image": "cPK_10_003500_00_KIRLIA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13980,7 +15727,8 @@
     "rarity": "C",
     "name": "Kirlia",
     "image": "cPK_10_003500_01_KIRLIA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -13988,7 +15736,8 @@
     "rarity": "R",
     "name": "Gardevoir",
     "image": "cPK_10_001320_00_SIRNIGHT_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -13996,7 +15745,8 @@
     "rarity": "R",
     "name": "Gardevoir",
     "image": "cPK_10_001320_01_SIRNIGHT_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14004,7 +15754,8 @@
     "rarity": "R",
     "name": "Giratina",
     "image": "cPK_10_003590_00_ORIGINGIRATINA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14012,7 +15763,8 @@
     "rarity": "R",
     "name": "Giratina",
     "image": "cPK_10_003590_01_ORIGINGIRATINA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14020,7 +15772,8 @@
     "rarity": "RR",
     "name": "Giratina ex",
     "image": "cPK_10_005520_00_GIRATINAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14028,7 +15781,8 @@
     "rarity": "C",
     "name": "Swirlix",
     "image": "cPK_10_008250_00_PEROPPAFU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14036,7 +15790,8 @@
     "rarity": "C",
     "name": "Swirlix",
     "image": "cPK_10_008250_01_PEROPPAFU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14044,7 +15799,8 @@
     "rarity": "U",
     "name": "Slurpuff",
     "image": "cPK_10_008260_00_PEROREAM_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14052,7 +15808,8 @@
     "rarity": "U",
     "name": "Slurpuff",
     "image": "cPK_10_008260_01_PEROREAM_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14060,7 +15817,8 @@
     "rarity": "RR",
     "name": "Sylveon ex",
     "image": "cPK_10_008280_00_NYMPHIAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14068,7 +15826,8 @@
     "rarity": "U",
     "name": "Oricorio",
     "image": "cPK_10_006580_00_ODORIDORIMAIMAISTYLE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14076,7 +15835,8 @@
     "rarity": "U",
     "name": "Oricorio",
     "image": "cPK_10_006580_01_ODORIDORIMAIMAISTYLE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14084,7 +15844,8 @@
     "rarity": "C",
     "name": "Cosmog",
     "image": "cPK_10_006660_00_COSMOG_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14092,7 +15853,8 @@
     "rarity": "C",
     "name": "Cosmog",
     "image": "cPK_10_006660_01_COSMOG_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14100,7 +15862,8 @@
     "rarity": "U",
     "name": "Cosmoem",
     "image": "cPK_10_006670_00_COSMOVUM_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14108,7 +15871,8 @@
     "rarity": "U",
     "name": "Cosmoem",
     "image": "cPK_10_006670_01_COSMOVUM_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14116,7 +15880,8 @@
     "rarity": "RR",
     "name": "Lunala ex",
     "image": "cPK_10_006680_00_LUNALAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14124,7 +15889,8 @@
     "rarity": "C",
     "name": "Milcery",
     "image": "cPK_10_008300_00_MAHOMIL_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14132,7 +15898,8 @@
     "rarity": "C",
     "name": "Milcery",
     "image": "cPK_10_008300_01_MAHOMIL_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14140,7 +15907,8 @@
     "rarity": "U",
     "name": "Alcremie",
     "image": "cPK_10_007340_00_MAWHIP_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14148,7 +15916,8 @@
     "rarity": "U",
     "name": "Alcremie",
     "image": "cPK_10_007340_01_MAWHIP_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14156,7 +15925,8 @@
     "rarity": "C",
     "name": "Machop",
     "image": "cPK_10_001430_00_WANRIKY_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14164,7 +15934,8 @@
     "rarity": "C",
     "name": "Machop",
     "image": "cPK_10_001430_01_WANRIKY_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14172,7 +15943,8 @@
     "rarity": "U",
     "name": "Machoke",
     "image": "cPK_10_001440_00_GORIKY_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14180,7 +15952,8 @@
     "rarity": "U",
     "name": "Machoke",
     "image": "cPK_10_001440_01_GORIKY_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14188,7 +15961,8 @@
     "rarity": "RR",
     "name": "Machamp ex",
     "image": "cPK_10_001460_00_KAIRIKYex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14196,7 +15970,8 @@
     "rarity": "C",
     "name": "Cubone",
     "image": "cPK_10_001510_00_KARAKARA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14204,7 +15979,8 @@
     "rarity": "C",
     "name": "Cubone",
     "image": "cPK_10_001510_01_KARAKARA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14212,7 +15988,8 @@
     "rarity": "RR",
     "name": "Marowak ex",
     "image": "cPK_10_001530_00_GARAGARAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14220,7 +15997,8 @@
     "rarity": "RR",
     "name": "Aerodactyl ex",
     "image": "cPK_10_002590_00_PTERAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14228,7 +16006,8 @@
     "rarity": "U",
     "name": "Sudowoodo",
     "image": "cPK_10_004600_00_USOKKIE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14236,7 +16015,8 @@
     "rarity": "U",
     "name": "Sudowoodo",
     "image": "cPK_10_004600_01_USOKKIE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14244,7 +16024,8 @@
     "rarity": "C",
     "name": "Phanpy",
     "image": "cPK_10_009550_00_GOMAZOU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14252,7 +16033,8 @@
     "rarity": "C",
     "name": "Phanpy",
     "image": "cPK_10_009550_01_GOMAZOU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14260,7 +16042,8 @@
     "rarity": "RR",
     "name": "Donphan ex",
     "image": "cPK_10_009560_00_DONFANex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14268,7 +16051,8 @@
     "rarity": "C",
     "name": "Nosepass",
     "image": "cPK_10_004660_00_NOSEPASS_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14276,7 +16060,8 @@
     "rarity": "C",
     "name": "Nosepass",
     "image": "cPK_10_004660_01_NOSEPASS_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14284,7 +16069,8 @@
     "rarity": "C",
     "name": "Gible",
     "image": "cPK_10_004690_00_FUKAMARU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14292,7 +16078,8 @@
     "rarity": "C",
     "name": "Gible",
     "image": "cPK_10_004690_01_FUKAMARU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14300,7 +16087,8 @@
     "rarity": "C",
     "name": "Gabite",
     "image": "cPK_10_004700_00_GABITE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14308,7 +16096,8 @@
     "rarity": "C",
     "name": "Gabite",
     "image": "cPK_10_004700_01_GABITE_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14316,7 +16105,8 @@
     "rarity": "RR",
     "name": "Garchomp ex",
     "image": "cPK_10_004710_00_GABURIASex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14324,7 +16114,8 @@
     "rarity": "C",
     "name": "Riolu",
     "image": "cPK_10_005070_00_RIOLU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14332,7 +16123,8 @@
     "rarity": "C",
     "name": "Riolu",
     "image": "cPK_10_005070_01_RIOLU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14340,7 +16132,8 @@
     "rarity": "R",
     "name": "Lucario",
     "image": "cPK_10_003730_00_LUCARIO_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14348,7 +16141,8 @@
     "rarity": "R",
     "name": "Lucario",
     "image": "cPK_10_003730_01_LUCARIO_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14356,7 +16150,8 @@
     "rarity": "RR",
     "name": "Lucario ex",
     "image": "cPK_10_005580_00_LUCARIOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14364,7 +16159,8 @@
     "rarity": "RR",
     "name": "Gallade ex",
     "image": "cPK_10_003760_00_ERUREIDOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14372,7 +16168,8 @@
     "rarity": "C",
     "name": "Drilbur",
     "image": "cPK_10_006740_00_MOGUREW_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14380,7 +16177,8 @@
     "rarity": "C",
     "name": "Drilbur",
     "image": "cPK_10_006740_01_MOGUREW_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14388,7 +16186,8 @@
     "rarity": "C",
     "name": "Crabrawler",
     "image": "cPK_10_006780_00_MAKENKANI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14396,7 +16195,8 @@
     "rarity": "C",
     "name": "Crabrawler",
     "image": "cPK_10_006780_01_MAKENKANI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14404,7 +16204,8 @@
     "rarity": "C",
     "name": "Rockruff",
     "image": "cPK_10_007690_00_IWANKO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14412,7 +16213,8 @@
     "rarity": "C",
     "name": "Rockruff",
     "image": "cPK_10_007690_01_IWANKO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14420,7 +16222,8 @@
     "rarity": "RR",
     "name": "Lycanroc ex",
     "image": "cPK_10_007700_00_LUGARUGANTASOGARENOSUGATA_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14428,7 +16231,8 @@
     "rarity": "RR",
     "name": "Passimian ex",
     "image": "cPK_10_006850_00_NAGETUKESARUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14436,7 +16240,8 @@
     "rarity": "R",
     "name": "Marshadow",
     "image": "cPK_10_002600_00_MARSHADOW_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14444,7 +16249,8 @@
     "rarity": "R",
     "name": "Marshadow",
     "image": "cPK_10_002600_01_MARSHADOW_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14452,7 +16258,8 @@
     "rarity": "C",
     "name": "Zubat",
     "image": "cPK_10_004720_00_ZUBAT_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14460,7 +16267,8 @@
     "rarity": "C",
     "name": "Zubat",
     "image": "cPK_10_004720_01_ZUBAT_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14468,7 +16276,8 @@
     "rarity": "C",
     "name": "Golbat",
     "image": "cPK_10_004730_00_GOLBAT_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14476,7 +16285,8 @@
     "rarity": "C",
     "name": "Golbat",
     "image": "cPK_10_004730_01_GOLBAT_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14484,7 +16294,8 @@
     "rarity": "R",
     "name": "Crobat",
     "image": "cPK_10_004740_00_CROBAT_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14492,7 +16303,8 @@
     "rarity": "R",
     "name": "Crobat",
     "image": "cPK_10_004740_01_CROBAT_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14500,7 +16312,8 @@
     "rarity": "RR",
     "name": "Crobat ex",
     "image": "cPK_10_009650_00_CROBATex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14508,7 +16321,8 @@
     "rarity": "C",
     "name": "Alolan Grimer",
     "image": "cPK_10_006910_00_ALOLABETBETER_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14516,7 +16330,8 @@
     "rarity": "C",
     "name": "Alolan Grimer",
     "image": "cPK_10_006910_01_ALOLABETBETER_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14524,7 +16339,8 @@
     "rarity": "RR",
     "name": "Alolan Muk ex",
     "image": "cPK_10_006920_00_ALOLABETBETONex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14532,7 +16348,8 @@
     "rarity": "C",
     "name": "Paldean Wooper",
     "image": "cPK_10_005620_00_PALDEAUPAH_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14540,7 +16357,8 @@
     "rarity": "C",
     "name": "Paldean Wooper",
     "image": "cPK_10_005620_01_PALDEAUPAH_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14548,7 +16366,8 @@
     "rarity": "RR",
     "name": "Paldean Clodsire ex",
     "image": "cPK_10_005630_00_PALDEADOOHex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14556,7 +16375,8 @@
     "rarity": "R",
     "name": "Umbreon",
     "image": "cPK_10_008360_00_BRACKY_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14564,7 +16384,8 @@
     "rarity": "R",
     "name": "Umbreon",
     "image": "cPK_10_008360_01_BRACKY_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14572,7 +16393,8 @@
     "rarity": "RR",
     "name": "Umbreon ex",
     "image": "cPK_10_009680_00_BRACKYex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14580,7 +16402,8 @@
     "rarity": "C",
     "name": "Sneasel",
     "image": "cPK_10_003790_00_NYULA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14588,7 +16411,8 @@
     "rarity": "C",
     "name": "Sneasel",
     "image": "cPK_10_003790_01_NYULA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14596,7 +16420,8 @@
     "rarity": "RR",
     "name": "Weavile ex",
     "image": "cPK_10_003800_00_MANYULAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14604,7 +16429,8 @@
     "rarity": "RR",
     "name": "Darkrai ex",
     "image": "cPK_10_003910_00_DARKRAIex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14612,7 +16438,8 @@
     "rarity": "R",
     "name": "Nihilego",
     "image": "cPK_10_007790_00_UTUROID_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14620,7 +16447,8 @@
     "rarity": "R",
     "name": "Nihilego",
     "image": "cPK_10_007790_01_UTUROID_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14628,7 +16456,8 @@
     "rarity": "RR",
     "name": "Guzzlord ex",
     "image": "cPK_10_007800_00_AKUZIKINGex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14636,7 +16465,8 @@
     "rarity": "C",
     "name": "Alolan Diglett",
     "image": "cPK_10_007820_00_ALOLADIGDA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14644,7 +16474,8 @@
     "rarity": "C",
     "name": "Alolan Diglett",
     "image": "cPK_10_007820_01_ALOLADIGDA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14652,7 +16483,8 @@
     "rarity": "RR",
     "name": "Alolan Dugtrio ex",
     "image": "cPK_10_007830_00_ALOLADUGTRIOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14660,7 +16492,8 @@
     "rarity": "RR",
     "name": "Skarmory ex",
     "image": "cPK_10_009800_00_AIRMDex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14668,7 +16501,8 @@
     "rarity": "RR",
     "name": "Probopass ex",
     "image": "cPK_10_004810_00_DAINOSEex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14676,7 +16510,8 @@
     "rarity": "RR",
     "name": "Dialga ex",
     "image": "cPK_10_004000_00_DIALGAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14684,7 +16519,8 @@
     "rarity": "U",
     "name": "Excadrill",
     "image": "cPK_10_007000_00_DORYUZU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14692,7 +16528,8 @@
     "rarity": "U",
     "name": "Excadrill",
     "image": "cPK_10_007000_01_DORYUZU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14700,7 +16537,8 @@
     "rarity": "R",
     "name": "Klefki",
     "image": "cPK_10_007020_00_CLEFFY_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14708,7 +16546,8 @@
     "rarity": "R",
     "name": "Klefki",
     "image": "cPK_10_007020_01_CLEFFY_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14716,7 +16555,8 @@
     "rarity": "RR",
     "name": "Solgaleo ex",
     "image": "cPK_10_007030_00_SOLGALEOex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14724,7 +16564,8 @@
     "rarity": "R",
     "name": "Magearna",
     "image": "cPK_10_007040_00_MAGEARNA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14732,7 +16573,8 @@
     "rarity": "R",
     "name": "Magearna",
     "image": "cPK_10_007040_01_MAGEARNA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14740,7 +16582,8 @@
     "rarity": "C",
     "name": "Tinkatink",
     "image": "cPK_10_005670_00_KANUCHAN_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14748,7 +16591,8 @@
     "rarity": "C",
     "name": "Tinkatink",
     "image": "cPK_10_005670_01_KANUCHAN_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14756,7 +16600,8 @@
     "rarity": "U",
     "name": "Tinkatuff",
     "image": "cPK_10_005680_00_NAKANUCHAN_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14764,7 +16609,8 @@
     "rarity": "U",
     "name": "Tinkatuff",
     "image": "cPK_10_005680_01_NAKANUCHAN_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14772,7 +16618,8 @@
     "rarity": "RR",
     "name": "Tinkaton ex",
     "image": "cPK_10_005690_00_DEKANUCHANex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14780,7 +16627,8 @@
     "rarity": "C",
     "name": "Dratini",
     "image": "cPK_10_008430_00_MINIRYU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14788,7 +16636,8 @@
     "rarity": "C",
     "name": "Dratini",
     "image": "cPK_10_008430_01_MINIRYU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14796,7 +16645,8 @@
     "rarity": "C",
     "name": "Dragonair",
     "image": "cPK_10_008440_00_HAKURYU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14804,7 +16654,8 @@
     "rarity": "C",
     "name": "Dragonair",
     "image": "cPK_10_008440_01_HAKURYU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14812,7 +16663,8 @@
     "rarity": "RR",
     "name": "Dragonite ex",
     "image": "cPK_10_008450_00_KAIRYUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14820,7 +16672,8 @@
     "rarity": "C",
     "name": "Pidgey",
     "image": "cPK_10_002700_00_POPPO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14828,7 +16681,8 @@
     "rarity": "C",
     "name": "Pidgey",
     "image": "cPK_10_002700_01_POPPO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14836,7 +16690,8 @@
     "rarity": "C",
     "name": "Pidgeotto",
     "image": "cPK_10_002710_00_PIGEON_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14844,7 +16699,8 @@
     "rarity": "C",
     "name": "Pidgeotto",
     "image": "cPK_10_002710_01_PIGEON_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14852,7 +16708,8 @@
     "rarity": "RR",
     "name": "Pidgeot ex",
     "image": "cPK_10_002720_00_PIGEOTex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14860,7 +16717,8 @@
     "rarity": "C",
     "name": "Jigglypuff",
     "image": "cPK_10_001930_00_PURIN_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14868,7 +16726,8 @@
     "rarity": "C",
     "name": "Jigglypuff",
     "image": "cPK_10_001930_01_PURIN_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14876,23 +16735,26 @@
     "rarity": "RR",
     "name": "Wigglytuff ex",
     "image": "cPK_10_001950_00_PUKURINex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
     "number": 280,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_10_001980_00_KAMONEGI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
     "number": 281,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_10_001980_01_KAMONEGI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14900,7 +16762,8 @@
     "rarity": "C",
     "name": "Lickitung",
     "image": "cPK_10_004050_00_BERORINGA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14908,7 +16771,8 @@
     "rarity": "C",
     "name": "Lickitung",
     "image": "cPK_10_004050_01_BERORINGA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14916,7 +16780,8 @@
     "rarity": "RR",
     "name": "Lickilicky ex",
     "image": "cPK_10_004060_00_BEROBELTex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14924,7 +16789,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_008470_00_EIEVUI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14932,7 +16798,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_008470_01_EIEVUI_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14940,7 +16807,8 @@
     "rarity": "RR",
     "name": "Eevee ex",
     "image": "cPK_10_008480_00_EIEVUIex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14948,7 +16816,8 @@
     "rarity": "RR",
     "name": "Snorlax ex",
     "image": "cPK_10_008490_00_KABIGONex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14956,7 +16825,8 @@
     "rarity": "RR",
     "name": "Lugia ex",
     "image": "cPK_10_010050_00_LUGIAex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14964,7 +16834,8 @@
     "rarity": "C",
     "name": "Skitty",
     "image": "cPK_10_007100_00_ENECO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14972,7 +16843,8 @@
     "rarity": "C",
     "name": "Skitty",
     "image": "cPK_10_007100_01_ENECO_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14980,7 +16852,8 @@
     "rarity": "U",
     "name": "Delcatty",
     "image": "cPK_10_007110_00_ENEKORORO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -14988,7 +16861,8 @@
     "rarity": "U",
     "name": "Delcatty",
     "image": "cPK_10_007110_01_ENEKORORO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -14996,7 +16870,8 @@
     "rarity": "C",
     "name": "Bidoof",
     "image": "cPK_10_005040_00_BIPPA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15004,7 +16879,8 @@
     "rarity": "C",
     "name": "Bidoof",
     "image": "cPK_10_005040_01_BIPPA_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15012,7 +16888,8 @@
     "rarity": "RR",
     "name": "Bibarel ex",
     "image": "cPK_10_005790_00_BEADARUex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15020,7 +16897,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_10_004930_00_SHAYMIN_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15028,7 +16906,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_10_004930_01_SHAYMIN_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15036,7 +16915,8 @@
     "rarity": "RR",
     "name": "Arceus ex",
     "image": "cPK_10_004950_00_ARCEUSex_RR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15044,7 +16924,8 @@
     "rarity": "U",
     "name": "Type: Null",
     "image": "cPK_10_007940_00_TYPENULL_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15052,7 +16933,8 @@
     "rarity": "U",
     "name": "Type: Null",
     "image": "cPK_10_007940_01_TYPENULL_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15060,7 +16942,8 @@
     "rarity": "R",
     "name": "Silvally",
     "image": "cPK_10_007950_00_SILVADY_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15068,7 +16951,8 @@
     "rarity": "R",
     "name": "Silvally",
     "image": "cPK_10_007950_01_SILVADY_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15076,7 +16960,8 @@
     "rarity": "R",
     "name": "Celesteela",
     "image": "cPK_10_007960_00_TEKKAGUYA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15084,7 +16969,8 @@
     "rarity": "R",
     "name": "Celesteela",
     "image": "cPK_10_007960_01_TEKKAGUYA_R.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15092,7 +16978,8 @@
     "rarity": "U",
     "name": "Cyclizar",
     "image": "cPK_10_005090_00_MOTOTOKAGE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15100,7 +16987,8 @@
     "rarity": "U",
     "name": "Cyclizar",
     "image": "cPK_10_005090_01_MOTOTOKAGE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15108,7 +16996,8 @@
     "rarity": "U",
     "name": "Eevee Bag",
     "image": "cTR_10_000670_00_IIBUINOBAKKU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15116,7 +17005,8 @@
     "rarity": "U",
     "name": "Eevee Bag",
     "image": "cTR_10_000670_01_IIBUINOBAKKU_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15124,7 +17014,8 @@
     "rarity": "U",
     "name": "Elemental Switch",
     "image": "cTR_10_000710_00_EREMENTARUTSUKEKAE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15132,7 +17023,8 @@
     "rarity": "U",
     "name": "Elemental Switch",
     "image": "cTR_10_000710_01_EREMENTARUTSUKEKAE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15140,7 +17032,8 @@
     "rarity": "C",
     "name": "Old Amber",
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15148,7 +17041,8 @@
     "rarity": "C",
     "name": "Old Amber",
     "image": "cTR_10_000100_01_HIMITSUNOKOHAKU_C.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15156,7 +17050,8 @@
     "rarity": "U",
     "name": "Rare Candy",
     "image": "cTR_10_000480_00_FUSHIGINAAME_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15164,23 +17059,26 @@
     "rarity": "U",
     "name": "Rare Candy",
     "image": "cTR_10_000480_01_FUSHIGINAAME_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
     "number": 316,
     "rarity": "U",
-    "name": "Pokémon Communication",
+    "name": "Pok\u00e9mon Communication",
     "image": "cTR_10_000280_00_POKEMONTSUUSHIN_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
     "number": 317,
     "rarity": "U",
-    "name": "Pokémon Communication",
+    "name": "Pok\u00e9mon Communication",
     "image": "cTR_10_000280_01_POKEMONTSUUSHIN_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15188,7 +17086,8 @@
     "rarity": "U",
     "name": "Electrical Cord",
     "image": "cTR_10_000620_00_EREKIKORD_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15196,7 +17095,8 @@
     "rarity": "U",
     "name": "Electrical Cord",
     "image": "cTR_10_000620_01_EREKIKORD_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15204,7 +17104,8 @@
     "rarity": "U",
     "name": "Giant Cape",
     "image": "cTR_10_000290_00_OOKINAMANTO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15212,7 +17113,8 @@
     "rarity": "U",
     "name": "Giant Cape",
     "image": "cTR_10_000290_01_OOKINAMANTO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15220,7 +17122,8 @@
     "rarity": "U",
     "name": "Rocky Helmet",
     "image": "cTR_10_000300_00_GOTSUGOTSUMETTO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15228,7 +17131,8 @@
     "rarity": "U",
     "name": "Rocky Helmet",
     "image": "cTR_10_000300_01_GOTSUGOTSUMETTO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15236,7 +17140,8 @@
     "rarity": "U",
     "name": "Leaf Cape",
     "image": "cTR_10_000510_00_LEAFMANTO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15244,7 +17149,8 @@
     "rarity": "U",
     "name": "Leaf Cape",
     "image": "cTR_10_000510_01_LEAFMANTO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15252,7 +17158,8 @@
     "rarity": "U",
     "name": "Cyrus",
     "image": "cTR_10_000320_00_AKAGI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15260,7 +17167,8 @@
     "rarity": "U",
     "name": "Cyrus",
     "image": "cTR_10_000320_01_AKAGI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15268,7 +17176,8 @@
     "rarity": "U",
     "name": "Erika",
     "image": "cTR_10_000110_00_ERIKA_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15276,7 +17185,8 @@
     "rarity": "U",
     "name": "Erika",
     "image": "cTR_10_000110_01_ERIKA_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15284,7 +17194,8 @@
     "rarity": "U",
     "name": "Irida",
     "image": "cTR_10_000380_00_KAI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15292,7 +17203,8 @@
     "rarity": "U",
     "name": "Irida",
     "image": "cTR_10_000380_01_KAI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15300,7 +17212,8 @@
     "rarity": "U",
     "name": "Lyra",
     "image": "cTR_10_000770_00_KOTONE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15308,7 +17221,8 @@
     "rarity": "U",
     "name": "Lyra",
     "image": "cTR_10_000770_01_KOTONE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15316,7 +17230,8 @@
     "rarity": "U",
     "name": "Giovanni",
     "image": "cTR_10_000150_00_SAKAKI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15324,7 +17239,8 @@
     "rarity": "U",
     "name": "Giovanni",
     "image": "cTR_10_000150_01_SAKAKI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15332,7 +17248,8 @@
     "rarity": "U",
     "name": "Silver",
     "image": "cTR_10_000780_00_SILVER_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15340,7 +17257,8 @@
     "rarity": "U",
     "name": "Silver",
     "image": "cTR_10_000780_01_SILVER_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15348,7 +17266,8 @@
     "rarity": "U",
     "name": "Sabrina",
     "image": "cTR_10_000170_00_NATSUME_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15356,7 +17275,8 @@
     "rarity": "U",
     "name": "Sabrina",
     "image": "cTR_10_000170_01_NATSUME_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15364,7 +17284,8 @@
     "rarity": "U",
     "name": "Iono",
     "image": "cTR_10_000420_00_NANJYAMO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15372,7 +17293,8 @@
     "rarity": "U",
     "name": "Iono",
     "image": "cTR_10_000420_01_NANJYAMO_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15380,7 +17302,8 @@
     "rarity": "U",
     "name": "Dawn",
     "image": "cTR_10_000360_00_HIKARI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15388,7 +17311,8 @@
     "rarity": "U",
     "name": "Dawn",
     "image": "cTR_10_000360_01_HIKARI_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15396,7 +17320,8 @@
     "rarity": "U",
     "name": "Mars",
     "image": "cTR_10_000370_00_MARS_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15404,7 +17329,8 @@
     "rarity": "U",
     "name": "Mars",
     "image": "cTR_10_000370_01_MARS_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15412,7 +17338,8 @@
     "rarity": "U",
     "name": "Leaf",
     "image": "cTR_10_000230_00_LEAF_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15420,7 +17347,8 @@
     "rarity": "U",
     "name": "Leaf",
     "image": "cTR_10_000230_01_LEAF_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15428,7 +17356,8 @@
     "rarity": "U",
     "name": "Lillie",
     "image": "cTR_10_000590_00_LILIE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15436,7 +17365,8 @@
     "rarity": "U",
     "name": "Lillie",
     "image": "cTR_10_000590_01_LILIE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15444,7 +17374,8 @@
     "rarity": "U",
     "name": "Lusamine",
     "image": "cTR_10_000660_00_LUSAMINE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15452,7 +17383,8 @@
     "rarity": "U",
     "name": "Lusamine",
     "image": "cTR_10_000660_01_LUSAMINE_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15460,7 +17392,8 @@
     "rarity": "U",
     "name": "Red",
     "image": "cTR_10_000440_00_RED_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15468,7 +17401,8 @@
     "rarity": "U",
     "name": "Red",
     "image": "cTR_10_000440_01_RED_U.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15476,7 +17410,8 @@
     "rarity": "AR",
     "name": "Floragato",
     "image": "cPK_20_005250_00_NYAROTE_AR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15484,7 +17419,8 @@
     "rarity": "AR",
     "name": "Crawdaunt",
     "image": "cPK_20_009170_00_SHIZARIGER_AR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15492,7 +17428,8 @@
     "rarity": "AR",
     "name": "Greninja",
     "image": "cPK_20_000890_01_GEKKOUGA_AR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15500,7 +17437,8 @@
     "rarity": "AR",
     "name": "Gardevoir",
     "image": "cPK_20_001320_01_SIRNIGHT_AR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15508,15 +17446,17 @@
     "rarity": "AR",
     "name": "Slurpuff",
     "image": "cPK_20_008260_00_PEROREAM_AR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
     "number": 359,
     "rarity": "AR",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_20_001980_01_KAMONEGI_AR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15524,7 +17464,8 @@
     "rarity": "SR",
     "name": "Buzzwole ex",
     "image": "cPK_20_007480_02_MASSIVOONex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15532,7 +17473,8 @@
     "rarity": "SR",
     "name": "Charizard ex",
     "image": "cPK_20_000360_03_LIZARDONex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15540,7 +17482,8 @@
     "rarity": "SR",
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_03_HOUOUex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15548,7 +17491,8 @@
     "rarity": "SR",
     "name": "Palkia ex",
     "image": "cPK_20_003300_03_PALKIAex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15556,7 +17500,8 @@
     "rarity": "SR",
     "name": "Pikachu ex",
     "image": "cPK_20_000960_03_PIKACHUex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15564,7 +17509,8 @@
     "rarity": "SR",
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_03_MEWTWOex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15572,7 +17518,8 @@
     "rarity": "SR",
     "name": "Mew ex",
     "image": "cPK_20_002450_04_MEWex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15580,7 +17527,8 @@
     "rarity": "SR",
     "name": "Lunala ex",
     "image": "cPK_20_006680_03_LUNALAex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15588,7 +17536,8 @@
     "rarity": "SR",
     "name": "Dialga ex",
     "image": "cPK_20_004000_03_DIALGAex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15596,7 +17545,8 @@
     "rarity": "SR",
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_03_SOLGALEOex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15604,7 +17554,8 @@
     "rarity": "SR",
     "name": "Eevee ex",
     "image": "cPK_20_008480_02_EIEVUIex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15612,7 +17563,8 @@
     "rarity": "SR",
     "name": "Lugia ex",
     "image": "cPK_20_010050_03_LUGIAex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15620,15 +17572,17 @@
     "rarity": "SR",
     "name": "Arceus ex",
     "image": "cPK_20_004950_03_ARCEUSex_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
     "number": 373,
     "rarity": "SR",
-    "name": "Professor’s Research",
+    "name": "Professor\u2019s Research",
     "image": "cTR_20_000040_00_HAKASENOKENKYU_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15636,7 +17590,8 @@
     "rarity": "SR",
     "name": "Lillie",
     "image": "cTR_20_000590_02_LILIE_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15644,7 +17599,8 @@
     "rarity": "SR",
     "name": "Lusamine",
     "image": "cTR_20_000660_01_LUSAMINE_SR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": true
   },
   {
     "set": "A4b",
@@ -15652,7 +17608,8 @@
     "rarity": "IM",
     "name": "Pikachu ex",
     "image": "cPK_20_000960_04_PIKACHUex_IM.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15660,7 +17617,8 @@
     "rarity": "SSR",
     "name": "Giratina ex",
     "image": "cPK_20_005520_02_GIRATINAex_SSR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15668,7 +17626,8 @@
     "rarity": "SSR",
     "name": "Darkrai ex",
     "image": "cPK_20_003910_02_DARKRAIex_SSR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "A4b",
@@ -15676,91 +17635,104 @@
     "rarity": "UR",
     "name": "Rare Candy",
     "image": "cTR_20_000480_00_FUSHIGINAAME_UR.webp",
-    "packs": ["Deluxe"]
+    "packs": ["Deluxe"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 1,
     "rarity": "C",
     "name": "Potion",
-    "image": "cTR_90_000010_00_KIZUGUSURI_C.webp"
+    "image": "cTR_90_000010_00_KIZUGUSURI_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 2,
     "rarity": "C",
     "name": "X Speed",
-    "image": "cTR_90_000020_00_SPEEDER_C.webp"
+    "image": "cTR_90_000020_00_SPEEDER_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 3,
     "rarity": "C",
     "name": "Hand Scope",
-    "image": "cTR_90_000050_00_HANDSCOPE_C.webp"
+    "image": "cTR_90_000050_00_HANDSCOPE_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 4,
     "rarity": "C",
-    "name": "Pokédex",
-    "image": "cTR_90_000060_00_POKEMONZUKAN_C.webp"
+    "name": "Pok\u00e9dex",
+    "image": "cTR_90_000060_00_POKEMONZUKAN_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 5,
     "rarity": "C",
-    "name": "Poké Ball",
-    "image": "cTR_90_000030_00_MONSTERBALL_C.webp"
+    "name": "Pok\u00e9 Ball",
+    "image": "cTR_90_000030_00_MONSTERBALL_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 6,
     "rarity": "C",
     "name": "Red Card",
-    "image": "cTR_90_000070_00_REDCARD_C.webp"
+    "image": "cTR_90_000070_00_REDCARD_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 7,
     "rarity": "C",
-    "name": "Professor’s Research",
-    "image": "cTR_90_000040_00_HAKASENOKENKYU_C.webp"
+    "name": "Professor\u2019s Research",
+    "image": "cTR_90_000040_00_HAKASENOKENKYU_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 8,
     "rarity": "C",
-    "name": "Pokédex",
-    "image": "cTR_90_000060_01_POKEMONZUKAN_C.webp"
+    "name": "Pok\u00e9dex",
+    "image": "cTR_90_000060_01_POKEMONZUKAN_C.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 9,
     "rarity": "AR",
     "name": "Pikachu",
-    "image": "cPK_90_000940_02_PIKACHU_AR.webp"
+    "image": "cPK_90_000940_02_PIKACHU_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 10,
     "rarity": "AR",
     "name": "Mewtwo",
-    "image": "cPK_90_001280_00_MEWTWO_AR.webp"
+    "image": "cPK_90_001280_00_MEWTWO_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 11,
     "rarity": "R",
     "name": "Chansey",
-    "image": "cPK_90_002020_00_LUCKY_R.webp"
+    "image": "cPK_90_002020_00_LUCKY_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 12,
     "rarity": "R",
     "name": "Meowth",
-    "image": "cPK_90_001960_00_NYARTH_R.webp"
+    "image": "cPK_90_001960_00_NYARTH_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15768,7 +17740,8 @@
     "rarity": "R",
     "name": "Butterfree",
     "image": "cPK_90_000070_00_BUTTERFREE_R.webp",
-    "packs": ["Vol. 1"]
+    "packs": ["Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15776,7 +17749,8 @@
     "rarity": "RR",
     "name": "Lapras ex",
     "image": "cPK_90_002760_00_LAPLACEex_RR.webp",
-    "packs": ["Vol. 1"]
+    "packs": ["Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15784,7 +17758,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_90_000940_01_PIKACHU_C.webp",
-    "packs": ["Vol. 1"]
+    "packs": ["Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15792,7 +17767,8 @@
     "rarity": "C",
     "name": "Clefairy",
     "image": "cPK_90_001130_00_PIPPI_C.webp",
-    "packs": ["Vol. 1"]
+    "packs": ["Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15800,7 +17776,8 @@
     "rarity": "C",
     "name": "Mankey",
     "image": "cPK_90_002770_00_MANKEY_C.webp",
-    "packs": ["Vol. 1"]
+    "packs": ["Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15808,7 +17785,8 @@
     "rarity": "AR",
     "name": "Venusaur",
     "image": "cPK_90_000030_00_FUSHIGIBANA_AR.webp",
-    "packs": ["Vol. 2"]
+    "packs": ["Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15816,7 +17794,8 @@
     "rarity": "R",
     "name": "Greninja",
     "image": "cPK_90_000890_00_GEKKOUGA_R.webp",
-    "packs": ["Vol. 2"]
+    "packs": ["Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15824,7 +17803,8 @@
     "rarity": "C",
     "name": "Haunter",
     "image": "cPK_90_002780_00_GHOST_C.webp",
-    "packs": ["Vol. 2"]
+    "packs": ["Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15832,7 +17812,8 @@
     "rarity": "C",
     "name": "Onix",
     "image": "cPK_90_001500_00_IWARK_C.webp",
-    "packs": ["Vol. 2"]
+    "packs": ["Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15840,35 +17821,40 @@
     "rarity": "C",
     "name": "Jigglypuff",
     "image": "cPK_90_002790_00_PURIN_C.webp",
-    "packs": ["Vol. 2"]
+    "packs": ["Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 23,
     "rarity": "R",
     "name": "Bulbasaur",
-    "image": "cPK_90_000010_00_FUSHIGIDANE_R.webp"
+    "image": "cPK_90_000010_00_FUSHIGIDANE_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 24,
     "rarity": "R",
     "name": "Magnemite",
-    "image": "cPK_90_000970_00_COIL_R.webp"
+    "image": "cPK_90_000970_00_COIL_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 25,
     "rarity": "RR",
     "name": "Moltres ex",
-    "image": "cPK_90_000470_00_FIREex_RR.webp"
+    "image": "cPK_90_000470_00_FIREex_RR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 26,
     "rarity": "AR",
     "name": "Pikachu",
-    "image": "cPK_90_000940_00_PIKACHU_AR.webp"
+    "image": "cPK_90_000940_00_PIKACHU_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15876,7 +17862,8 @@
     "rarity": "C",
     "name": "Snivy",
     "image": "cPK_90_002800_00_TSUTARJA_C.webp",
-    "packs": ["Vol. 3"]
+    "packs": ["Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15884,7 +17871,8 @@
     "rarity": "R",
     "name": "Volcarona",
     "image": "cPK_90_002280_00_ULGAMOTH_R.webp",
-    "packs": ["Vol. 3"]
+    "packs": ["Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15892,7 +17880,8 @@
     "rarity": "AR",
     "name": "Blastoise",
     "image": "cPK_90_000550_00_KAMEX_AR.webp",
-    "packs": ["Vol. 3"]
+    "packs": ["Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15900,7 +17889,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_90_002810_00_EIEVUI_C.webp",
-    "packs": ["Vol. 3"]
+    "packs": ["Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15908,28 +17898,32 @@
     "rarity": "C",
     "name": "Cinccino",
     "image": "cPK_90_002110_00_CHILLACCINO_C.webp",
-    "packs": ["Vol. 3"]
+    "packs": ["Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 32,
     "rarity": "R",
     "name": "Charmander",
-    "image": "cPK_90_000330_00_HITOKAGE_R.webp"
+    "image": "cPK_90_000330_00_HITOKAGE_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 33,
     "rarity": "R",
     "name": "Squirtle",
-    "image": "cPK_90_000530_00_ZENIGAME_R.webp"
+    "image": "cPK_90_000530_00_ZENIGAME_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 34,
     "rarity": "AR",
     "name": "Piplup",
-    "image": "cPK_90_003160_00_POCHAMA_AR.webp"
+    "image": "cPK_90_003160_00_POCHAMA_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15937,7 +17931,8 @@
     "rarity": "C",
     "name": "Turtwig",
     "image": "cPK_90_002910_00_NAETLE_C.webp",
-    "packs": ["Vol. 4"]
+    "packs": ["Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15945,7 +17940,8 @@
     "rarity": "R",
     "name": "Electivire",
     "image": "cPK_90_003380_00_ELEKIBLE_R.webp",
-    "packs": ["Vol. 4"]
+    "packs": ["Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15953,7 +17949,8 @@
     "rarity": "RR",
     "name": "Cresselia ex",
     "image": "cPK_90_004960_00_CRESSELIAex_RR.webp",
-    "packs": ["Vol. 4"]
+    "packs": ["Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15961,7 +17958,8 @@
     "rarity": "C",
     "name": "Misdreavus",
     "image": "cPK_90_004970_00_MUMA_C.webp",
-    "packs": ["Vol. 4"]
+    "packs": ["Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15969,28 +17967,32 @@
     "rarity": "C",
     "name": "Skarmory",
     "image": "cPK_90_003920_00_AIRMD_C.webp",
-    "packs": ["Vol. 4"]
+    "packs": ["Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 40,
     "rarity": "R",
     "name": "Chimchar",
-    "image": "cPK_90_003080_00_HIKOZARU_R.webp"
+    "image": "cPK_90_003080_00_HIKOZARU_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 41,
     "rarity": "R",
     "name": "Togepi",
-    "image": "cPK_90_003440_00_TOGEPY_R.webp"
+    "image": "cPK_90_003440_00_TOGEPY_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 42,
     "rarity": "RR",
     "name": "Darkrai ex",
-    "image": "cPK_90_003910_00_DARKRAIex_RR.webp"
+    "image": "cPK_90_003910_00_DARKRAIex_RR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -15998,7 +18000,8 @@
     "rarity": "C",
     "name": "Cherrim",
     "image": "cPK_90_004320_00_CHERRIM_C.webp",
-    "packs": ["Vol. 5"]
+    "packs": ["Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16006,7 +18009,8 @@
     "rarity": "R",
     "name": "Raichu",
     "image": "cPK_90_004500_00_RAICHU_R.webp",
-    "packs": ["Vol. 5"]
+    "packs": ["Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16014,7 +18018,8 @@
     "rarity": "C",
     "name": "Nosepass",
     "image": "cPK_90_004980_00_NOSEPASS_C.webp",
-    "packs": ["Vol. 5"]
+    "packs": ["Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16022,7 +18027,8 @@
     "rarity": "AR",
     "name": "Gible",
     "image": "cPK_90_004690_00_FUKAMARU_AR.webp",
-    "packs": ["Vol. 5"]
+    "packs": ["Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16030,42 +18036,48 @@
     "rarity": "C",
     "name": "Staraptor",
     "image": "cPK_90_004990_00_MUKUHAWK_C.webp",
-    "packs": ["Vol. 5"]
+    "packs": ["Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 48,
     "rarity": "R",
     "name": "Manaphy",
-    "image": "cPK_90_003310_00_MANAPHY_R.webp"
+    "image": "cPK_90_003310_00_MANAPHY_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 49,
     "rarity": "R",
     "name": "Snorlax",
-    "image": "cPK_90_004870_00_KABIGON_R.webp"
+    "image": "cPK_90_004870_00_KABIGON_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 50,
     "rarity": "SSR",
     "name": "Mewtwo ex",
-    "image": "cPK_90_001290_00_MEWTWOex_SSR.webp"
+    "image": "cPK_90_001290_00_MEWTWOex_SSR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 51,
     "rarity": "S",
     "name": "Cyclizar",
-    "image": "cPK_90_005090_00_MOTOTOKAGE_S.webp"
+    "image": "cPK_90_005090_00_MOTOTOKAGE_S.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 52,
     "rarity": "AR",
     "name": "Sprigatito",
-    "image": "cPK_90_005080_00_NYAHOJA_AR.webp"
+    "image": "cPK_90_005080_00_NYAHOJA_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16073,7 +18085,8 @@
     "rarity": "C",
     "name": "Floatzel",
     "image": "cPK_90_005000_00_FLOAZEL_C.webp",
-    "packs": ["Vol. 6"]
+    "packs": ["Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16081,7 +18094,8 @@
     "rarity": "AR",
     "name": "Pawmot",
     "image": "cPK_90_005010_00_PARMOT_AR.webp",
-    "packs": ["Vol. 6"]
+    "packs": ["Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16089,7 +18103,8 @@
     "rarity": "R",
     "name": "Machamp",
     "image": "cPK_90_005020_00_KAIRIKY_R.webp",
-    "packs": ["Vol. 6"]
+    "packs": ["Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16097,7 +18112,8 @@
     "rarity": "C",
     "name": "Ekans",
     "image": "cPK_90_005030_00_ARBO_C.webp",
-    "packs": ["Vol. 6"]
+    "packs": ["Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16105,21 +18121,24 @@
     "rarity": "C",
     "name": "Bidoof",
     "image": "cPK_90_005040_00_BIPPA_C.webp",
-    "packs": ["Vol. 6"]
+    "packs": ["Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 58,
     "rarity": "R",
     "name": "Pachirisu",
-    "image": "cPK_90_005060_00_PACHIRISU_R.webp"
+    "image": "cPK_90_005060_00_PACHIRISU_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 59,
     "rarity": "R",
     "name": "Riolu",
-    "image": "cPK_90_005070_00_RIOLU_R.webp"
+    "image": "cPK_90_005070_00_RIOLU_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16127,7 +18146,8 @@
     "rarity": "C",
     "name": "Exeggcute",
     "image": "cPK_90_002150_00_TAMATAMA_C.webp",
-    "packs": ["Vol. 7"]
+    "packs": ["Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16135,15 +18155,17 @@
     "rarity": "C",
     "name": "Froakie",
     "image": "cPK_90_000870_00_KEROMATSU_C.webp",
-    "packs": ["Vol. 7"]
+    "packs": ["Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 62,
     "rarity": "C",
-    "name": "Farfetch’d",
+    "name": "Farfetch\u2019d",
     "image": "cPK_90_001980_00_KAMONEGI_C.webp",
-    "packs": ["Vol. 7"]
+    "packs": ["Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16151,7 +18173,8 @@
     "rarity": "R",
     "name": "Rayquaza",
     "image": "cPK_90_010810_00_RAYQUAZA_R.webp",
-    "packs": ["Vol. 7"]
+    "packs": ["Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16159,35 +18182,40 @@
     "rarity": "RR",
     "name": "Rayquaza ex",
     "image": "cPK_90_010820_00_RAYQUAZAex_RR.webp",
-    "packs": ["Vol. 7"]
+    "packs": ["Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 65,
     "rarity": "SR",
     "name": "Rayquaza ex",
-    "image": "cPK_90_010820_01_RAYQUAZAex_SR.webp"
+    "image": "cPK_90_010820_01_RAYQUAZAex_SR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 66,
     "rarity": "AR",
     "name": "Mimikyu",
-    "image": "cPK_90_006640_00_MIMIKKYU_AR.webp"
+    "image": "cPK_90_006640_00_MIMIKKYU_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 67,
     "rarity": "R",
     "name": "Cosmog",
-    "image": "cPK_90_006660_00_COSMOG_R.webp"
+    "image": "cPK_90_006660_00_COSMOG_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 68,
     "rarity": "R",
     "name": "Lycanroc",
-    "image": "cPK_90_006810_00_LUGARUGAN_R.webp"
+    "image": "cPK_90_006810_00_LUGARUGAN_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16195,7 +18223,8 @@
     "rarity": "R",
     "name": "Alolan Exeggutor",
     "image": "cPK_90_005830_00_ALOLANASSY_R.webp",
-    "packs": ["Vol. 8"]
+    "packs": ["Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16203,7 +18232,8 @@
     "rarity": "AR",
     "name": "Alolan Ninetales",
     "image": "cPK_90_006220_00_ALOLAKYUKON_AR.webp",
-    "packs": ["Vol. 8"]
+    "packs": ["Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16211,7 +18241,8 @@
     "rarity": "C",
     "name": "Crabrawler",
     "image": "cPK_90_006780_00_MAKENKANI_C.webp",
-    "packs": ["Vol. 8"]
+    "packs": ["Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16219,7 +18250,8 @@
     "rarity": "C",
     "name": "Alolan Grimer",
     "image": "cPK_90_007230_00_ALOLABETBETER_C.webp",
-    "packs": ["Vol. 8"]
+    "packs": ["Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16227,14 +18259,16 @@
     "rarity": "C",
     "name": "Toucannon",
     "image": "cPK_90_007240_00_DODEKABASHI_C.webp",
-    "packs": ["Vol. 8"]
+    "packs": ["Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 74,
     "rarity": "AR",
     "name": "Zeraora",
-    "image": "cPK_90_007410_00_ZERAORA_AR.webp"
+    "image": "cPK_90_007410_00_ZERAORA_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16242,7 +18276,8 @@
     "rarity": "C",
     "name": "Kartana",
     "image": "cPK_90_007250_00_KAMITURUGI_C.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16250,7 +18285,8 @@
     "rarity": "C",
     "name": "Blacephalon",
     "image": "cPK_90_007260_00_ZUGADOON_C.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16258,7 +18294,8 @@
     "rarity": "C",
     "name": "Xurkitree",
     "image": "cPK_90_007270_00_DENJYUMOKU_C.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16266,7 +18303,8 @@
     "rarity": "R",
     "name": "Dawn Wings Necrozma",
     "image": "cPK_90_007280_00_NECROZMAAKATSUKINOTSUBASA_R.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16274,7 +18312,8 @@
     "rarity": "R",
     "name": "Dusk Mane Necrozma",
     "image": "cPK_90_007290_00_NECROZMATASOGARENOTATEGAMI_R.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16282,7 +18321,8 @@
     "rarity": "C",
     "name": "Stakataka",
     "image": "cPK_90_007300_00_TUNDETUNDE_C.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16290,28 +18330,32 @@
     "rarity": "RR",
     "name": "Ultra Necrozma ex",
     "image": "cPK_90_007310_00_NECROZMAULTRANECROZMAex_RR.webp",
-    "packs": ["Vol. 9"]
+    "packs": ["Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 82,
     "rarity": "R",
     "name": "Poipole",
-    "image": "cPK_90_007370_00_BEVENOM_R.webp"
+    "image": "cPK_90_007370_00_BEVENOM_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 83,
     "rarity": "R",
     "name": "Stufful",
-    "image": "cPK_90_007380_00_NUIKOGUMA_R.webp"
+    "image": "cPK_90_007380_00_NUIKOGUMA_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 84,
     "rarity": "RR",
     "name": "Tapu Koko ex",
-    "image": "cPK_90_007420_00_KAPU-KOKEKOex_RR.webp"
+    "image": "cPK_90_007420_00_KAPU-KOKEKOex_RR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16319,7 +18363,8 @@
     "rarity": "C",
     "name": "Vanillite",
     "image": "cPK_90_007320_00_VANIPETI_C.webp",
-    "packs": ["Vol. 10"]
+    "packs": ["Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16327,7 +18372,8 @@
     "rarity": "R",
     "name": "Jolteon",
     "image": "cPK_90_007330_00_THUNDERS_R.webp",
-    "packs": ["Vol. 10"]
+    "packs": ["Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16335,7 +18381,8 @@
     "rarity": "AR",
     "name": "Alcremie",
     "image": "cPK_90_007340_00_MAWHIP_AR.webp",
-    "packs": ["Vol. 10"]
+    "packs": ["Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16343,7 +18390,8 @@
     "rarity": "C",
     "name": "Dragonair",
     "image": "cPK_90_007350_00_HAKURYU_C.webp",
-    "packs": ["Vol. 10"]
+    "packs": ["Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16351,35 +18399,40 @@
     "rarity": "C",
     "name": "Audino",
     "image": "cPK_90_007360_00_TABUNNE_C.webp",
-    "packs": ["Vol. 10"]
+    "packs": ["Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 90,
     "rarity": "R",
     "name": "Togedemaru",
-    "image": "cPK_90_007390_00_TOGEDEMARU_R.webp"
+    "image": "cPK_90_007390_00_TOGEDEMARU_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 91,
     "rarity": "R",
     "name": "Greedent",
-    "image": "cPK_90_007400_00_YOKUBARISU_R.webp"
+    "image": "cPK_90_007400_00_YOKUBARISU_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 92,
     "rarity": "R",
     "name": "Eevee",
-    "image": "cPK_90_002060_00_EIEVUI_R.webp"
+    "image": "cPK_90_002060_00_EIEVUI_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 93,
     "rarity": "AR",
     "name": "Cleffa",
-    "image": "cPK_90_009330_00_PY_AR.webp"
+    "image": "cPK_90_009330_00_PY_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16387,7 +18440,8 @@
     "rarity": "C",
     "name": "Horsea",
     "image": "cPK_90_010070_00_TATTU_C.webp",
-    "packs": ["Vol. 11"]
+    "packs": ["Vol. 11"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16395,7 +18449,8 @@
     "rarity": "C",
     "name": "Chinchou",
     "image": "cPK_90_010080_00_CHONCHIE_C.webp",
-    "packs": ["Vol. 11"]
+    "packs": ["Vol. 11"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16403,7 +18458,8 @@
     "rarity": "C",
     "name": "Houndoom",
     "image": "cPK_90_009740_00_HELLGAR_C.webp",
-    "packs": ["Vol. 11"]
+    "packs": ["Vol. 11"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16411,7 +18467,8 @@
     "rarity": "R",
     "name": "Kangaskhan",
     "image": "cPK_90_009890_00_GARURA_R.webp",
-    "packs": ["Vol. 11"]
+    "packs": ["Vol. 11"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16419,28 +18476,32 @@
     "rarity": "RR",
     "name": "Blissey ex",
     "image": "cPK_90_010090_00_HAPPINASex_RR.webp",
-    "packs": ["Vol. 11"]
+    "packs": ["Vol. 11"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 99,
     "rarity": "R",
     "name": "Marill",
-    "image": "cPK_90_009050_00_MARIL_R.webp"
+    "image": "cPK_90_009050_00_MARIL_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 100,
     "rarity": "R",
     "name": "Weavile",
-    "image": "cPK_90_009720_00_MANYULA_R.webp"
+    "image": "cPK_90_009720_00_MANYULA_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 101,
     "rarity": "AR",
     "name": "Latias",
-    "image": "cPK_90_010200_00_LATIAS_AR.webp"
+    "image": "cPK_90_010200_00_LATIAS_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16448,7 +18509,8 @@
     "rarity": "C",
     "name": "Tropius",
     "image": "cPK_90_010100_00_TROPIUS_C.webp",
-    "packs": ["Vol. 12"]
+    "packs": ["Vol. 12"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16456,7 +18518,8 @@
     "rarity": "C",
     "name": "Poliwag",
     "image": "cPK_90_010110_00_NYOROMO_C.webp",
-    "packs": ["Vol. 12"]
+    "packs": ["Vol. 12"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16464,7 +18527,8 @@
     "rarity": "R",
     "name": "Milotic",
     "image": "cPK_90_010120_00_MILOKAROSS_R.webp",
-    "packs": ["Vol. 12"]
+    "packs": ["Vol. 12"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16472,7 +18536,8 @@
     "rarity": "C",
     "name": "Zorua",
     "image": "cPK_90_010130_00_ZORUA_C.webp",
-    "packs": ["Vol. 12"]
+    "packs": ["Vol. 12"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16480,35 +18545,40 @@
     "rarity": "AR",
     "name": "Zoroark",
     "image": "cPK_90_010140_00_ZOROARK_AR.webp",
-    "packs": ["Vol. 12"]
+    "packs": ["Vol. 12"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 107,
     "rarity": "R",
     "name": "Miltank",
-    "image": "cPK_90_010180_00_MILTANK_R.webp"
+    "image": "cPK_90_010180_00_MILTANK_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 108,
     "rarity": "R",
     "name": "Phanpy",
-    "image": "cPK_90_010190_00_GOMAZOU_R.webp"
+    "image": "cPK_90_010190_00_GOMAZOU_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 109,
     "rarity": "SAR",
     "name": "Eevee ex",
-    "image": "cPK_90_008480_00_EIEVUIex_SAR.webp"
+    "image": "cPK_90_008480_00_EIEVUIex_SAR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 110,
     "rarity": "RR",
     "name": "Entei ex",
-    "image": "cPK_90_010210_00_ENTEIex_RR.webp"
+    "image": "cPK_90_010210_00_ENTEIex_RR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16516,7 +18586,8 @@
     "rarity": "C",
     "name": "Pikachu",
     "image": "cPK_90_010150_00_PIKACHU_C.webp",
-    "packs": ["Vol. 13"]
+    "packs": ["Vol. 13"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16524,7 +18595,8 @@
     "rarity": "RR",
     "name": "Raichu ex",
     "image": "cPK_90_010160_00_RAICHUex_RR.webp",
-    "packs": ["Vol. 13"]
+    "packs": ["Vol. 13"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16532,7 +18604,8 @@
     "rarity": "C",
     "name": "Mimikyu",
     "image": "cPK_90_008290_00_MIMIKKYU_C.webp",
-    "packs": ["Vol. 13"]
+    "packs": ["Vol. 13"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16540,7 +18613,8 @@
     "rarity": "C",
     "name": "Machamp",
     "image": "cPK_90_010170_00_KAIRIKY_C.webp",
-    "packs": ["Vol. 13"]
+    "packs": ["Vol. 13"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
@@ -16548,21 +18622,24 @@
     "rarity": "R",
     "name": "Regigigas",
     "image": "cPK_90_004240_00_REGIGIGAS_R.webp",
-    "packs": ["Vol. 13"]
+    "packs": ["Vol. 13"],
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 116,
     "rarity": "R",
     "name": "Shaymin",
-    "image": "cPK_90_003030_00_SHAYMIN_R.webp"
+    "image": "cPK_90_003030_00_SHAYMIN_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-A",
     "number": 117,
     "rarity": "R",
     "name": "Absol",
-    "image": "cPK_90_009760_00_ABSOL_R.webp"
+    "image": "cPK_90_009760_00_ABSOL_R.webp",
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16570,7 +18647,8 @@
     "rarity": "C",
     "name": "Pinsir",
     "image": "cPK_10_010830_00_KAILIOS_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16578,7 +18656,8 @@
     "rarity": "RR",
     "name": "Mega Pinsir ex",
     "image": "cPK_10_010840_00_MEGAKAILIOSex_RR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16586,7 +18665,8 @@
     "rarity": "C",
     "name": "Wurmple",
     "image": "cPK_10_010850_00_KEMUSSO_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16594,7 +18674,8 @@
     "rarity": "C",
     "name": "Silcoon",
     "image": "cPK_10_010860_00_KARASALIS_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16602,7 +18683,8 @@
     "rarity": "R",
     "name": "Beautifly",
     "image": "cPK_10_010870_00_AGEHUNT_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16610,7 +18692,8 @@
     "rarity": "C",
     "name": "Cascoon",
     "image": "cPK_10_010880_00_MAYULD_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16618,7 +18701,8 @@
     "rarity": "R",
     "name": "Dustox",
     "image": "cPK_10_010890_00_DOKUCALE_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16626,7 +18710,8 @@
     "rarity": "C",
     "name": "Seedot",
     "image": "cPK_10_010900_00_TANEBOH_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16634,7 +18719,8 @@
     "rarity": "U",
     "name": "Nuzleaf",
     "image": "cPK_10_010910_00_KONOHANA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16642,7 +18728,8 @@
     "rarity": "R",
     "name": "Shiftry",
     "image": "cPK_10_010920_00_DIRTENG_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16650,7 +18737,8 @@
     "rarity": "C",
     "name": "Shroomish",
     "image": "cPK_10_010930_00_KINOCOCO_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16658,7 +18746,8 @@
     "rarity": "U",
     "name": "Breloom",
     "image": "cPK_10_010940_00_KINOGASSA_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16666,7 +18755,8 @@
     "rarity": "C",
     "name": "Pansage",
     "image": "cPK_10_010950_00_YANAPPU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16674,7 +18764,8 @@
     "rarity": "C",
     "name": "Simisage",
     "image": "cPK_10_010960_00_YANAKKIE_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16682,7 +18773,8 @@
     "rarity": "C",
     "name": "Cottonee",
     "image": "cPK_10_010970_00_MONMEN_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16690,7 +18782,8 @@
     "rarity": "RR",
     "name": "Whimsicott ex",
     "image": "cPK_10_010980_00_ELFUUNex_RR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16698,7 +18791,8 @@
     "rarity": "C",
     "name": "Petilil",
     "image": "cPK_10_010990_00_CHURINE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16706,7 +18800,8 @@
     "rarity": "R",
     "name": "Lilligant",
     "image": "cPK_10_011000_00_DREDEAR_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16714,7 +18809,8 @@
     "rarity": "C",
     "name": "Maractus",
     "image": "cPK_10_011010_00_MARACACCHI_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16722,7 +18818,8 @@
     "rarity": "R",
     "name": "Virizion",
     "image": "cPK_10_011020_00_VIRIZION_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16730,7 +18827,8 @@
     "rarity": "C",
     "name": "Skiddo",
     "image": "cPK_10_011030_00_MEECLE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16738,7 +18836,8 @@
     "rarity": "C",
     "name": "Gogoat",
     "image": "cPK_10_011040_00_GOGOAT_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16746,7 +18845,8 @@
     "rarity": "C",
     "name": "Phantump",
     "image": "cPK_10_011050_00_BOKUREI_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16754,7 +18854,8 @@
     "rarity": "U",
     "name": "Trevenant",
     "image": "cPK_10_011060_00_OHROT_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16762,7 +18863,8 @@
     "rarity": "C",
     "name": "Grookey",
     "image": "cPK_10_011070_00_SARUNORI_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16770,7 +18872,8 @@
     "rarity": "U",
     "name": "Thwackey",
     "image": "cPK_10_011080_00_BACHINKEY_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16778,7 +18881,8 @@
     "rarity": "R",
     "name": "Rillaboom",
     "image": "cPK_10_011090_00_GORIRANDER_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16786,7 +18890,8 @@
     "rarity": "C",
     "name": "Growlithe",
     "image": "cPK_10_011100_00_GARDIE_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16794,7 +18899,8 @@
     "rarity": "U",
     "name": "Arcanine",
     "image": "cPK_10_011110_00_WINDIE_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16802,7 +18908,8 @@
     "rarity": "C",
     "name": "Ponyta",
     "image": "cPK_10_011120_00_PONYTA_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16810,7 +18917,8 @@
     "rarity": "RR",
     "name": "Rapidash ex",
     "image": "cPK_10_011130_00_GALLOPex_RR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16818,7 +18926,8 @@
     "rarity": "R",
     "name": "Ho-Oh",
     "image": "cPK_10_011140_00_HOUOU_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16826,7 +18935,8 @@
     "rarity": "C",
     "name": "Torchic",
     "image": "cPK_10_011150_00_ACHAMO_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16834,7 +18944,8 @@
     "rarity": "U",
     "name": "Combusken",
     "image": "cPK_10_011160_00_WAKASYAMO_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16842,7 +18953,8 @@
     "rarity": "R",
     "name": "Blaziken",
     "image": "cPK_10_011170_00_BURSYAMO_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16850,7 +18962,8 @@
     "rarity": "RR",
     "name": "Mega Blaziken ex",
     "image": "cPK_10_011180_00_MEGABURSYAMOex_RR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16858,7 +18971,8 @@
     "rarity": "C",
     "name": "Pansear",
     "image": "cPK_10_011190_00_BAOPPU_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16866,7 +18980,8 @@
     "rarity": "C",
     "name": "Simisear",
     "image": "cPK_10_011200_00_BAOKKIE_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16874,7 +18989,8 @@
     "rarity": "C",
     "name": "Darumaka",
     "image": "cPK_10_011210_00_DARUMAKKA_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16882,7 +18998,8 @@
     "rarity": "U",
     "name": "Darmanitan",
     "image": "cPK_10_011220_00_HIHIDARUMA_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16890,7 +19007,8 @@
     "rarity": "C",
     "name": "Litwick",
     "image": "cPK_10_011230_00_HITOMOSHI_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16898,7 +19016,8 @@
     "rarity": "U",
     "name": "Lampent",
     "image": "cPK_10_011240_00_LAMPLER_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16906,7 +19025,8 @@
     "rarity": "R",
     "name": "Chandelure",
     "image": "cPK_10_011250_00_CHANDELA_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16914,7 +19034,8 @@
     "rarity": "C",
     "name": "Heatmor",
     "image": "cPK_10_011260_00_KUITARAN_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16922,7 +19043,8 @@
     "rarity": "C",
     "name": "Litleo",
     "image": "cPK_10_011270_00_SHISHIKO_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16930,7 +19052,8 @@
     "rarity": "R",
     "name": "Pyroar",
     "image": "cPK_10_011280_00_KAENJISHI_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16938,7 +19061,8 @@
     "rarity": "U",
     "name": "Turtonator",
     "image": "cPK_10_011290_00_BAKUGAMES_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16946,7 +19070,8 @@
     "rarity": "C",
     "name": "Psyduck",
     "image": "cPK_10_011300_00_KODUCK_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16954,7 +19079,8 @@
     "rarity": "C",
     "name": "Golduck",
     "image": "cPK_10_011310_00_GOLDUCK_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16962,7 +19088,8 @@
     "rarity": "C",
     "name": "Magikarp",
     "image": "cPK_10_011320_00_KOIKING_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16970,7 +19097,8 @@
     "rarity": "R",
     "name": "Gyarados",
     "image": "cPK_10_011330_00_GYARADOS_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16978,7 +19106,8 @@
     "rarity": "RR",
     "name": "Mega Gyarados ex",
     "image": "cPK_10_011340_00_MEGAGYARADOSex_RR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16986,7 +19115,8 @@
     "rarity": "C",
     "name": "Lotad",
     "image": "cPK_10_011350_00_HASSBOH_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -16994,7 +19124,8 @@
     "rarity": "U",
     "name": "Lombre",
     "image": "cPK_10_011360_00_HASUBRERO_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17002,7 +19133,8 @@
     "rarity": "R",
     "name": "Ludicolo",
     "image": "cPK_10_011370_00_RUNPAPPA_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17010,7 +19142,8 @@
     "rarity": "C",
     "name": "Wailmer",
     "image": "cPK_10_011380_00_HOERUKO_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17018,7 +19151,8 @@
     "rarity": "R",
     "name": "Wailord",
     "image": "cPK_10_011390_00_WHALOH_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17026,7 +19160,8 @@
     "rarity": "C",
     "name": "Corphish",
     "image": "cPK_10_011400_00_HEIGANI_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17034,7 +19169,8 @@
     "rarity": "U",
     "name": "Crawdaunt",
     "image": "cPK_10_011410_00_SHIZARIGER_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17042,7 +19178,8 @@
     "rarity": "C",
     "name": "Luvdisc",
     "image": "cPK_10_011420_00_LOVECUS_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17050,7 +19187,8 @@
     "rarity": "C",
     "name": "Panpour",
     "image": "cPK_10_011430_00_HIYAPPU_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17058,7 +19196,8 @@
     "rarity": "C",
     "name": "Simipour",
     "image": "cPK_10_011440_00_HIYAKKIE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17066,7 +19205,8 @@
     "rarity": "C",
     "name": "Tympole",
     "image": "cPK_10_011450_00_OTAMARO_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17074,7 +19214,8 @@
     "rarity": "C",
     "name": "Palpitoad",
     "image": "cPK_10_011460_00_GAMAGARU_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17082,7 +19223,8 @@
     "rarity": "U",
     "name": "Seismitoad",
     "image": "cPK_10_011470_00_GAMAGEROGE_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17090,7 +19232,8 @@
     "rarity": "U",
     "name": "Tirtouga",
     "image": "cPK_10_011480_00_PROTOGA_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17098,7 +19241,8 @@
     "rarity": "R",
     "name": "Carracosta",
     "image": "cPK_10_011490_00_ABAGOURA_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17106,7 +19250,8 @@
     "rarity": "C",
     "name": "Frillish",
     "image": "cPK_10_011500_00_PURURILL_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17114,7 +19259,8 @@
     "rarity": "R",
     "name": "Jellicent",
     "image": "cPK_10_011510_00_BURUNGEL_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17122,7 +19268,8 @@
     "rarity": "R",
     "name": "Keldeo",
     "image": "cPK_10_011520_00_KELDEOITSUMONOSUGATA_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17130,7 +19277,8 @@
     "rarity": "C",
     "name": "Froakie",
     "image": "cPK_10_011530_00_KEROMATSU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17138,7 +19286,8 @@
     "rarity": "U",
     "name": "Frogadier",
     "image": "cPK_10_011540_00_GEKOGASHIRA_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17146,7 +19295,8 @@
     "rarity": "RR",
     "name": "Greninja ex",
     "image": "cPK_10_011550_00_GEKKOUGAex_RR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17154,7 +19304,8 @@
     "rarity": "C",
     "name": "Bergmite",
     "image": "cPK_10_011560_00_KACHIKOHRU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17162,7 +19313,8 @@
     "rarity": "U",
     "name": "Avalugg",
     "image": "cPK_10_011570_00_CREBASE_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17170,7 +19322,8 @@
     "rarity": "C",
     "name": "Chewtle",
     "image": "cPK_10_011580_00_KAMUKAME_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17178,7 +19331,8 @@
     "rarity": "U",
     "name": "Drednaw",
     "image": "cPK_10_011590_00_KAJIRIGAME_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17186,7 +19340,8 @@
     "rarity": "C",
     "name": "Arrokuda",
     "image": "cPK_10_011600_00_SASIKAMASU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17194,7 +19349,8 @@
     "rarity": "U",
     "name": "Barraskewda",
     "image": "cPK_10_011610_00_KAMASUJAW_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17202,7 +19358,8 @@
     "rarity": "R",
     "name": "Eiscue",
     "image": "cPK_10_011620_00_KORIPPO_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17210,7 +19367,8 @@
     "rarity": "RR",
     "name": "Jolteon ex",
     "image": "cPK_10_011630_00_THUNDERSex_RR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17218,7 +19376,8 @@
     "rarity": "C",
     "name": "Mareep",
     "image": "cPK_10_011640_00_MERRIEP_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17226,7 +19385,8 @@
     "rarity": "U",
     "name": "Flaaffy",
     "image": "cPK_10_011650_00_MOKOKO_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17234,7 +19394,8 @@
     "rarity": "R",
     "name": "Ampharos",
     "image": "cPK_10_011660_00_DENRYU_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17242,7 +19403,8 @@
     "rarity": "RR",
     "name": "Mega Ampharos ex",
     "image": "cPK_10_011670_00_MEGADENRYUex_RR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17250,7 +19412,8 @@
     "rarity": "C",
     "name": "Shinx",
     "image": "cPK_10_011680_00_KOLINK_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17258,7 +19421,8 @@
     "rarity": "U",
     "name": "Luxio",
     "image": "cPK_10_011690_00_LUXIO_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17266,7 +19430,8 @@
     "rarity": "R",
     "name": "Luxray",
     "image": "cPK_10_011700_00_RENTORAR_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17274,7 +19439,8 @@
     "rarity": "C",
     "name": "Pachirisu",
     "image": "cPK_10_011710_00_PACHIRISU_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17282,7 +19448,8 @@
     "rarity": "C",
     "name": "Blitzle",
     "image": "cPK_10_011720_00_SHIMAMA_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17290,7 +19457,8 @@
     "rarity": "U",
     "name": "Zebstrika",
     "image": "cPK_10_011730_00_ZEBRAIKA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17298,7 +19466,8 @@
     "rarity": "C",
     "name": "Joltik",
     "image": "cPK_10_011740_00_BACHURU_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17306,7 +19475,8 @@
     "rarity": "U",
     "name": "Galvantula",
     "image": "cPK_10_011750_00_DENTULA_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17314,7 +19484,8 @@
     "rarity": "C",
     "name": "Dedenne",
     "image": "cPK_10_011760_00_DEDENNE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17322,7 +19493,8 @@
     "rarity": "C",
     "name": "Yamper",
     "image": "cPK_10_011770_00_WANPACHI_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17330,7 +19502,8 @@
     "rarity": "U",
     "name": "Boltund",
     "image": "cPK_10_011780_00_PULSEWAN_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17338,7 +19511,8 @@
     "rarity": "C",
     "name": "Natu",
     "image": "cPK_10_011790_00_NATY_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17346,7 +19520,8 @@
     "rarity": "U",
     "name": "Xatu",
     "image": "cPK_10_011800_00_NATIO_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17354,7 +19529,8 @@
     "rarity": "C",
     "name": "Misdreavus",
     "image": "cPK_10_011810_00_MUMA_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17362,7 +19538,8 @@
     "rarity": "U",
     "name": "Mismagius",
     "image": "cPK_10_011820_00_MUMARGI_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17370,7 +19547,8 @@
     "rarity": "C",
     "name": "Sableye",
     "image": "cPK_10_011830_00_YAMIRAMI_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17378,7 +19556,8 @@
     "rarity": "RR",
     "name": "Mega Altaria ex",
     "image": "cPK_10_011840_00_MEGATYLTALISex_RR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17386,7 +19565,8 @@
     "rarity": "C",
     "name": "Duskull",
     "image": "cPK_10_011850_00_YOMAWARU_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17394,7 +19574,8 @@
     "rarity": "U",
     "name": "Dusclops",
     "image": "cPK_10_011860_00_SAMAYOURU_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17402,7 +19583,8 @@
     "rarity": "R",
     "name": "Dusknoir",
     "image": "cPK_10_011870_00_YONOIR_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17410,7 +19592,8 @@
     "rarity": "R",
     "name": "Jirachi",
     "image": "cPK_10_011880_00_JIRACHI_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17418,7 +19601,8 @@
     "rarity": "C",
     "name": "Drifloon",
     "image": "cPK_10_011890_00_FUWANTE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17426,7 +19610,8 @@
     "rarity": "U",
     "name": "Drifblim",
     "image": "cPK_10_011900_00_FUWARIDE_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17434,7 +19619,8 @@
     "rarity": "R",
     "name": "Chingling",
     "image": "cPK_10_011910_00_LISYAN_R.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17442,7 +19628,8 @@
     "rarity": "C",
     "name": "Yamask",
     "image": "cPK_10_011920_00_DESUMASU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17450,7 +19637,8 @@
     "rarity": "R",
     "name": "Cofagrigus",
     "image": "cPK_10_011930_00_DESUKARN_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17458,7 +19646,8 @@
     "rarity": "C",
     "name": "Gothita",
     "image": "cPK_10_011940_00_GOTHIMU_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17466,7 +19655,8 @@
     "rarity": "U",
     "name": "Gothorita",
     "image": "cPK_10_011950_00_GOTHIMIRU_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17474,7 +19664,8 @@
     "rarity": "R",
     "name": "Gothitelle",
     "image": "cPK_10_011960_00_GOTHIRUSELLE_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17482,7 +19673,8 @@
     "rarity": "C",
     "name": "Spritzee",
     "image": "cPK_10_011970_00_SHUSHUPU_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17490,7 +19682,8 @@
     "rarity": "U",
     "name": "Aromatisse",
     "image": "cPK_10_011980_00_FREFUWAN_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17498,7 +19691,8 @@
     "rarity": "C",
     "name": "Swirlix",
     "image": "cPK_10_011990_00_PEROPPAFU_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17506,7 +19700,8 @@
     "rarity": "U",
     "name": "Slurpuff",
     "image": "cPK_10_012000_00_PEROREAM_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17514,7 +19709,8 @@
     "rarity": "C",
     "name": "Carbink",
     "image": "cPK_10_012010_00_MELECIE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17522,7 +19718,8 @@
     "rarity": "R",
     "name": "Klefki",
     "image": "cPK_10_012020_00_CLEFFY_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17530,7 +19727,8 @@
     "rarity": "RR",
     "name": "Indeedee ex",
     "image": "cPK_10_012030_00_YESSANMESUNOSUGATA_RR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17538,7 +19736,8 @@
     "rarity": "C",
     "name": "Sandshrew",
     "image": "cPK_10_012040_00_SAND_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17546,7 +19745,8 @@
     "rarity": "U",
     "name": "Sandslash",
     "image": "cPK_10_012050_00_SANDPAN_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17554,7 +19754,8 @@
     "rarity": "RR",
     "name": "Hitmonchan ex",
     "image": "cPK_10_012060_00_EBIWALARex_RR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17562,7 +19763,8 @@
     "rarity": "C",
     "name": "Sudowoodo",
     "image": "cPK_10_012070_00_USOKKIE_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17570,7 +19772,8 @@
     "rarity": "C",
     "name": "Makuhita",
     "image": "cPK_10_012080_00_MAKUNOSHITA_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17578,7 +19781,8 @@
     "rarity": "U",
     "name": "Hariyama",
     "image": "cPK_10_012090_00_HARITEYAMA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17586,7 +19790,8 @@
     "rarity": "C",
     "name": "Hippopotas",
     "image": "cPK_10_012100_00_HIPPOPOTAS_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17594,7 +19799,8 @@
     "rarity": "U",
     "name": "Hippowdon",
     "image": "cPK_10_012110_00_KABALDON_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17602,7 +19808,8 @@
     "rarity": "C",
     "name": "Sandile",
     "image": "cPK_10_012120_00_MEGUROCO_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17610,7 +19817,8 @@
     "rarity": "U",
     "name": "Krokorok",
     "image": "cPK_10_012130_00_WARUVILE_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17618,7 +19826,8 @@
     "rarity": "R",
     "name": "Krookodile",
     "image": "cPK_10_012140_00_WARUVIAL_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17626,7 +19835,8 @@
     "rarity": "U",
     "name": "Archen",
     "image": "cPK_10_012150_00_ARCHEN_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17634,7 +19844,8 @@
     "rarity": "R",
     "name": "Archeops",
     "image": "cPK_10_012160_00_ARCHEOS_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17642,7 +19853,8 @@
     "rarity": "C",
     "name": "Golett",
     "image": "cPK_10_012170_00_GOBIT_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17650,7 +19862,8 @@
     "rarity": "R",
     "name": "Golurk",
     "image": "cPK_10_012180_00_GOLOOG_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17658,7 +19871,8 @@
     "rarity": "R",
     "name": "Terrakion",
     "image": "cPK_10_012190_00_TERRAKION_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17666,7 +19880,8 @@
     "rarity": "C",
     "name": "Pancham",
     "image": "cPK_10_012200_00_YANCHAM_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17674,7 +19889,8 @@
     "rarity": "C",
     "name": "Crabrawler",
     "image": "cPK_10_012210_00_MAKENKANI_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17682,7 +19898,8 @@
     "rarity": "U",
     "name": "Crabominable",
     "image": "cPK_10_012220_00_KEKENKANI_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17690,7 +19907,8 @@
     "rarity": "C",
     "name": "Stufful",
     "image": "cPK_10_012230_00_NUIKOGUMA_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17698,7 +19916,8 @@
     "rarity": "U",
     "name": "Bewear",
     "image": "cPK_10_012240_00_KITERUGUMA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17706,7 +19925,8 @@
     "rarity": "C",
     "name": "Sandygast",
     "image": "cPK_10_012250_00_SUNABA_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17714,7 +19934,8 @@
     "rarity": "U",
     "name": "Palossand",
     "image": "cPK_10_012260_00_SIRODETHNA_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17722,7 +19943,8 @@
     "rarity": "C",
     "name": "Rolycoly",
     "image": "cPK_10_012270_00_TANDON_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17730,7 +19952,8 @@
     "rarity": "U",
     "name": "Carkol",
     "image": "cPK_10_012280_00_TOROGGON_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17738,7 +19961,8 @@
     "rarity": "R",
     "name": "Coalossal",
     "image": "cPK_10_012290_00_SEKITANZAN_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17746,7 +19970,8 @@
     "rarity": "C",
     "name": "Murkrow",
     "image": "cPK_10_012300_00_YAMIKARASU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17754,7 +19979,8 @@
     "rarity": "R",
     "name": "Honchkrow",
     "image": "cPK_10_012310_00_DONGKARASU_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17762,7 +19988,8 @@
     "rarity": "U",
     "name": "Absol",
     "image": "cPK_10_012320_00_ABSOL_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17770,7 +19997,8 @@
     "rarity": "RR",
     "name": "Mega Absol ex",
     "image": "cPK_10_012330_00_MEGAABSOLex_RR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17778,7 +20006,8 @@
     "rarity": "C",
     "name": "Skorupi",
     "image": "cPK_10_012340_00_SCORUPI_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17786,7 +20015,8 @@
     "rarity": "U",
     "name": "Drapion",
     "image": "cPK_10_012350_00_DORAPION_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17794,7 +20024,8 @@
     "rarity": "R",
     "name": "Darkrai",
     "image": "cPK_10_012360_00_DARKRAI_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17802,7 +20033,8 @@
     "rarity": "C",
     "name": "Deino",
     "image": "cPK_10_012370_00_MONOZU_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17810,7 +20042,8 @@
     "rarity": "U",
     "name": "Zweilous",
     "image": "cPK_10_012380_00_DIHEAD_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17818,7 +20051,8 @@
     "rarity": "R",
     "name": "Hydreigon",
     "image": "cPK_10_012390_00_SAZANDORA_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17826,7 +20060,8 @@
     "rarity": "R",
     "name": "Pangoro",
     "image": "cPK_10_012400_00_GORONDA_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17834,7 +20069,8 @@
     "rarity": "C",
     "name": "Skrelp",
     "image": "cPK_10_012410_00_KUZUMO_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17842,7 +20078,8 @@
     "rarity": "RR",
     "name": "Dragalge ex",
     "image": "cPK_10_012420_00_DRAMIDOROex_RR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17850,7 +20087,8 @@
     "rarity": "C",
     "name": "Mareanie",
     "image": "cPK_10_012430_00_HIDOIDE_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17858,7 +20096,8 @@
     "rarity": "U",
     "name": "Toxapex",
     "image": "cPK_10_012440_00_DOHIDOIDE_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17866,7 +20105,8 @@
     "rarity": "C",
     "name": "Impidimp",
     "image": "cPK_10_012450_00_BEROBA_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17874,7 +20114,8 @@
     "rarity": "U",
     "name": "Morgrem",
     "image": "cPK_10_012460_00_GIMOH_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17882,7 +20123,8 @@
     "rarity": "R",
     "name": "Grimmsnarl",
     "image": "cPK_10_012470_00_OHLONGE_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17890,7 +20132,8 @@
     "rarity": "C",
     "name": "Ferroseed",
     "image": "cPK_10_012480_00_TESSEED_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17898,7 +20141,8 @@
     "rarity": "U",
     "name": "Ferrothorn",
     "image": "cPK_10_012490_00_NUTREY_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17906,7 +20150,8 @@
     "rarity": "C",
     "name": "Durant",
     "image": "cPK_10_012500_00_AIANT_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17914,7 +20159,8 @@
     "rarity": "R",
     "name": "Cobalion",
     "image": "cPK_10_012510_00_COBALON_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17922,7 +20168,8 @@
     "rarity": "C",
     "name": "Honedge",
     "image": "cPK_10_012520_00_HITOTSUKI_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17930,7 +20177,8 @@
     "rarity": "U",
     "name": "Doublade",
     "image": "cPK_10_012530_00_NIDANGILL_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17938,7 +20186,8 @@
     "rarity": "R",
     "name": "Aegislash",
     "image": "cPK_10_012540_00_GILLGARDBLADEFORME_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17946,7 +20195,8 @@
     "rarity": "C",
     "name": "Meltan",
     "image": "cPK_10_012550_00_MELTAN_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17954,7 +20204,8 @@
     "rarity": "RR",
     "name": "Melmetal ex",
     "image": "cPK_10_012560_00_MELMETALex_RR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17962,7 +20213,8 @@
     "rarity": "R",
     "name": "Corviknight",
     "image": "cPK_10_012570_00_ARMORGA_R.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17970,7 +20222,8 @@
     "rarity": "C",
     "name": "Druddigon",
     "image": "cPK_10_012580_00_CRIMGAN_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17978,7 +20231,8 @@
     "rarity": "C",
     "name": "Goomy",
     "image": "cPK_10_012590_00_NUMERA_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17986,7 +20240,8 @@
     "rarity": "U",
     "name": "Sliggoo",
     "image": "cPK_10_012600_00_NUMEIL_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -17994,7 +20249,8 @@
     "rarity": "R",
     "name": "Goodra",
     "image": "cPK_10_012610_00_NUMELGON_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18002,7 +20258,8 @@
     "rarity": "C",
     "name": "Pidgey",
     "image": "cPK_10_012620_00_POPPO_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18010,7 +20267,8 @@
     "rarity": "C",
     "name": "Pidgeotto",
     "image": "cPK_10_012630_00_PIGEON_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18018,7 +20276,8 @@
     "rarity": "U",
     "name": "Pidgeot",
     "image": "cPK_10_012640_00_PIGEOT_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18026,7 +20285,8 @@
     "rarity": "RR",
     "name": "Tauros ex",
     "image": "cPK_10_012650_00_KENTAUROSex_RR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18034,7 +20294,8 @@
     "rarity": "C",
     "name": "Eevee",
     "image": "cPK_10_012660_00_EIEVUI_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18042,7 +20303,8 @@
     "rarity": "C",
     "name": "Aipom",
     "image": "cPK_10_012670_00_EIPAM_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18050,7 +20312,8 @@
     "rarity": "U",
     "name": "Ambipom",
     "image": "cPK_10_012680_00_ETEBOTH_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18058,7 +20321,8 @@
     "rarity": "C",
     "name": "Miltank",
     "image": "cPK_10_012690_00_MILTANK_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18066,7 +20330,8 @@
     "rarity": "C",
     "name": "Zigzagoon",
     "image": "cPK_10_012700_00_JIGUZAGUMA_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18074,7 +20339,8 @@
     "rarity": "U",
     "name": "Linoone",
     "image": "cPK_10_012710_00_MASSUGUMA_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18082,7 +20348,8 @@
     "rarity": "C",
     "name": "Whismur",
     "image": "cPK_10_012720_00_GONYONYO_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18090,7 +20357,8 @@
     "rarity": "C",
     "name": "Loudred",
     "image": "cPK_10_012730_00_DOGOHMB_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18098,7 +20366,8 @@
     "rarity": "R",
     "name": "Exploud",
     "image": "cPK_10_012740_00_BAKUONG_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18106,7 +20375,8 @@
     "rarity": "C",
     "name": "Skitty",
     "image": "cPK_10_012750_00_ENECO_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18114,7 +20384,8 @@
     "rarity": "R",
     "name": "Delcatty",
     "image": "cPK_10_012760_00_ENEKORORO_R.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18122,7 +20393,8 @@
     "rarity": "C",
     "name": "Spinda",
     "image": "cPK_10_012770_00_PATCHEEL_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18130,7 +20402,8 @@
     "rarity": "C",
     "name": "Swablu",
     "image": "cPK_10_012780_00_TYLTTO_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18138,7 +20411,8 @@
     "rarity": "R",
     "name": "Altaria",
     "image": "cPK_10_012790_00_TYLTALIS_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18146,7 +20420,8 @@
     "rarity": "C",
     "name": "Chatot",
     "image": "cPK_10_012800_00_PERAP_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18154,7 +20429,8 @@
     "rarity": "C",
     "name": "Patrat",
     "image": "cPK_10_012810_00_MINEZUMI_C.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18162,7 +20438,8 @@
     "rarity": "U",
     "name": "Watchog",
     "image": "cPK_10_012820_00_MIRUHOG_U.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18170,7 +20447,8 @@
     "rarity": "C",
     "name": "Lillipup",
     "image": "cPK_10_012830_00_YORTERRIE_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18178,7 +20456,8 @@
     "rarity": "U",
     "name": "Herdier",
     "image": "cPK_10_012840_00_HERDERRIE_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18186,7 +20465,8 @@
     "rarity": "R",
     "name": "Stoutland",
     "image": "cPK_10_012850_00_MOOLAND_R.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18194,7 +20474,8 @@
     "rarity": "C",
     "name": "Rufflet",
     "image": "cPK_10_012860_00_WASHIBON_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18202,7 +20483,8 @@
     "rarity": "U",
     "name": "Braviary",
     "image": "cPK_10_012870_00_WARRGLE_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18210,7 +20492,8 @@
     "rarity": "U",
     "name": "Furfrou",
     "image": "cPK_10_012880_00_TRIMMIENYASEINOSUGATA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18218,7 +20501,8 @@
     "rarity": "U",
     "name": "Furfrou",
     "image": "cPK_10_012880_01_TRIMMIENHEARTCUT_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18226,7 +20510,8 @@
     "rarity": "U",
     "name": "Furfrou",
     "image": "cPK_10_012880_02_TRIMMIENKINGDOMCUT_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18234,7 +20519,8 @@
     "rarity": "C",
     "name": "Rookidee",
     "image": "cPK_10_012890_00_KOKOGARA_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18242,7 +20528,8 @@
     "rarity": "U",
     "name": "Corvisquire",
     "image": "cPK_10_012900_00_AOGARASU_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18250,7 +20537,8 @@
     "rarity": "C",
     "name": "Wooloo",
     "image": "cPK_10_012910_00_WOOLUU_C.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18258,7 +20546,8 @@
     "rarity": "U",
     "name": "Dubwool",
     "image": "cPK_10_012920_00_BAIWOOLUU_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18266,7 +20555,8 @@
     "rarity": "U",
     "name": "Prank Spinner",
     "image": "cTR_10_000870_00_ITAZURAROULETTE_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18274,7 +20564,8 @@
     "rarity": "C",
     "name": "Plume Fossil",
     "image": "cTR_10_000880_00_HANENOKASEKI_C.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18282,7 +20573,8 @@
     "rarity": "U",
     "name": "Hitting Hammer",
     "image": "cTR_10_000890_00_HITHAMMER_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18290,7 +20582,8 @@
     "rarity": "C",
     "name": "Cover Fossil",
     "image": "cTR_10_000900_00_FUTANOKASEKI_C.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18298,7 +20591,8 @@
     "rarity": "U",
     "name": "Flame Patch",
     "image": "cTR_10_000910_00_FUREIMUPACCHI_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18306,7 +20600,8 @@
     "rarity": "U",
     "name": "Sitrus Berry",
     "image": "cTR_10_000920_00_OBONNOMI_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18314,7 +20609,8 @@
     "rarity": "U",
     "name": "Heavy Helmet",
     "image": "cTR_10_000930_00_BABYMET_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18322,7 +20618,8 @@
     "rarity": "U",
     "name": "Lucky Mittens",
     "image": "cTR_10_000940_00_LUCKYMITTENS_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18330,7 +20627,8 @@
     "rarity": "U",
     "name": "Marlon",
     "image": "cTR_10_000950_00_SHIZUI_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18338,7 +20636,8 @@
     "rarity": "U",
     "name": "Hala",
     "image": "cTR_10_000960_00_HALA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18346,7 +20645,8 @@
     "rarity": "U",
     "name": "May",
     "image": "cTR_10_000970_00_HARUKA_U.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18354,7 +20654,8 @@
     "rarity": "U",
     "name": "Fantina",
     "image": "cTR_10_000980_00_MELISSA_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18362,7 +20663,8 @@
     "rarity": "U",
     "name": "Copycat",
     "image": "cTR_10_000990_00_MONOMANEMUSUME_U.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18370,7 +20672,8 @@
     "rarity": "U",
     "name": "Lisia",
     "image": "cTR_10_001000_00_RUCHIA_U.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18378,7 +20681,8 @@
     "rarity": "AR",
     "name": "Beautifly",
     "image": "cPK_20_010870_00_AGEHUNT_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18386,7 +20690,8 @@
     "rarity": "AR",
     "name": "Skiddo",
     "image": "cPK_20_011030_00_MEECLE_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18394,7 +20699,8 @@
     "rarity": "AR",
     "name": "Rillaboom",
     "image": "cPK_20_011090_00_GORIRANDER_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18402,7 +20708,8 @@
     "rarity": "AR",
     "name": "Growlithe",
     "image": "cPK_20_011100_00_GARDIE_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18410,7 +20717,8 @@
     "rarity": "AR",
     "name": "Chandelure",
     "image": "cPK_20_011250_00_CHANDELA_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18418,7 +20726,8 @@
     "rarity": "AR",
     "name": "Magikarp",
     "image": "cPK_20_011320_00_KOIKING_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18426,7 +20735,8 @@
     "rarity": "AR",
     "name": "Ludicolo",
     "image": "cPK_20_011370_00_RUNPAPPA_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18434,7 +20744,8 @@
     "rarity": "AR",
     "name": "Jellicent",
     "image": "cPK_20_011510_00_BURUNGEL_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18442,7 +20753,8 @@
     "rarity": "AR",
     "name": "Keldeo",
     "image": "cPK_20_011520_00_KELDEOITSUMONOSUGATA_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18450,7 +20762,8 @@
     "rarity": "AR",
     "name": "Eiscue",
     "image": "cPK_20_011620_00_KORIPPO_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18458,7 +20771,8 @@
     "rarity": "AR",
     "name": "Luxray",
     "image": "cPK_20_011700_00_RENTORAR_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18466,7 +20780,8 @@
     "rarity": "AR",
     "name": "Cofagrigus",
     "image": "cPK_20_011930_00_DESUKARN_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18474,7 +20789,8 @@
     "rarity": "AR",
     "name": "Gothita",
     "image": "cPK_20_011940_00_GOTHIMU_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18482,7 +20798,8 @@
     "rarity": "AR",
     "name": "Makuhita",
     "image": "cPK_20_012080_00_MAKUNOSHITA_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18490,7 +20807,8 @@
     "rarity": "AR",
     "name": "Hippowdon",
     "image": "cPK_20_012110_00_KABALDON_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18498,7 +20816,8 @@
     "rarity": "AR",
     "name": "Archeops",
     "image": "cPK_20_012160_00_ARCHEOS_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18506,7 +20825,8 @@
     "rarity": "AR",
     "name": "Pancham",
     "image": "cPK_20_012200_00_YANCHAM_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18514,7 +20834,8 @@
     "rarity": "AR",
     "name": "Honchkrow",
     "image": "cPK_20_012310_00_DONGKARASU_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18522,7 +20843,8 @@
     "rarity": "AR",
     "name": "Hydreigon",
     "image": "cPK_20_012390_00_SAZANDORA_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18530,7 +20852,8 @@
     "rarity": "AR",
     "name": "Corviknight",
     "image": "cPK_20_012570_00_ARMORGA_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18538,7 +20861,8 @@
     "rarity": "AR",
     "name": "Goomy",
     "image": "cPK_20_012590_00_NUMERA_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18546,7 +20870,8 @@
     "rarity": "AR",
     "name": "Delcatty",
     "image": "cPK_20_012760_00_ENEKORORO_AR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18554,7 +20879,8 @@
     "rarity": "AR",
     "name": "Stoutland",
     "image": "cPK_20_012850_00_MOOLAND_AR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18562,7 +20888,8 @@
     "rarity": "AR",
     "name": "Rufflet",
     "image": "cPK_20_012860_00_WASHIBON_AR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18570,7 +20897,8 @@
     "rarity": "SR",
     "name": "Mega Pinsir ex",
     "image": "cPK_20_010840_00_MEGAKAILIOSex_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18578,7 +20906,8 @@
     "rarity": "SR",
     "name": "Whimsicott ex",
     "image": "cPK_20_010980_00_ELFUUNex_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18586,7 +20915,8 @@
     "rarity": "SR",
     "name": "Rapidash ex",
     "image": "cPK_20_011130_00_GALLOPex_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18594,7 +20924,8 @@
     "rarity": "SR",
     "name": "Mega Blaziken ex",
     "image": "cPK_20_011180_00_MEGABURSYAMOex_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18602,7 +20933,8 @@
     "rarity": "SR",
     "name": "Mega Gyarados ex",
     "image": "cPK_20_011340_00_MEGAGYARADOSex_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18610,7 +20942,8 @@
     "rarity": "SR",
     "name": "Greninja ex",
     "image": "cPK_20_011550_00_GEKKOUGAex_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18618,7 +20951,8 @@
     "rarity": "SR",
     "name": "Jolteon ex",
     "image": "cPK_20_011630_00_THUNDERSex_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18626,7 +20960,8 @@
     "rarity": "SR",
     "name": "Mega Ampharos ex",
     "image": "cPK_20_011670_00_MEGADENRYUex_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18634,7 +20969,8 @@
     "rarity": "SR",
     "name": "Mega Altaria ex",
     "image": "cPK_20_011840_00_MEGATYLTALISex_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18642,7 +20978,8 @@
     "rarity": "SR",
     "name": "Indeedee ex",
     "image": "cPK_20_012030_00_YESSANMESUNOSUGATA_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18650,7 +20987,8 @@
     "rarity": "SR",
     "name": "Hitmonchan ex",
     "image": "cPK_20_012060_00_EBIWALARex_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18658,7 +20996,8 @@
     "rarity": "SR",
     "name": "Mega Absol ex",
     "image": "cPK_20_012330_00_MEGAABSOLex_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18666,7 +21005,8 @@
     "rarity": "SR",
     "name": "Dragalge ex",
     "image": "cPK_20_012420_00_DRAMIDOROex_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18674,7 +21014,8 @@
     "rarity": "SR",
     "name": "Melmetal ex",
     "image": "cPK_20_012560_00_MELMETALex_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18682,7 +21023,8 @@
     "rarity": "SR",
     "name": "Tauros ex",
     "image": "cPK_20_012650_00_KENTAUROSex_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18690,7 +21032,8 @@
     "rarity": "SR",
     "name": "Marlon",
     "image": "cTR_20_000950_00_SHIZUI_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18698,7 +21041,8 @@
     "rarity": "SR",
     "name": "Hala",
     "image": "cTR_20_000960_00_HALA_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18706,7 +21050,8 @@
     "rarity": "SR",
     "name": "May",
     "image": "cTR_20_000970_00_HARUKA_SR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18714,7 +21059,8 @@
     "rarity": "SR",
     "name": "Fantina",
     "image": "cTR_20_000980_00_MELISSA_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18722,7 +21068,8 @@
     "rarity": "SR",
     "name": "Copycat",
     "image": "cTR_20_000990_00_MONOMANEMUSUME_SR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18730,7 +21077,8 @@
     "rarity": "SR",
     "name": "Lisia",
     "image": "cTR_20_001000_00_RUCHIA_SR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18738,7 +21086,8 @@
     "rarity": "SAR",
     "name": "Mega Pinsir ex",
     "image": "cPK_20_010840_01_MEGAKAILIOSex_SAR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18746,7 +21095,8 @@
     "rarity": "SAR",
     "name": "Whimsicott ex",
     "image": "cPK_20_010980_01_ELFUUNex_SAR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18754,7 +21104,8 @@
     "rarity": "SAR",
     "name": "Rapidash ex",
     "image": "cPK_20_011130_01_GALLOPex_SAR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18762,7 +21113,8 @@
     "rarity": "SAR",
     "name": "Greninja ex",
     "image": "cPK_20_011550_01_GEKKOUGAex_SAR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18770,7 +21122,8 @@
     "rarity": "SAR",
     "name": "Jolteon ex",
     "image": "cPK_20_011630_01_THUNDERSex_SAR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18778,7 +21131,8 @@
     "rarity": "SAR",
     "name": "Mega Ampharos ex",
     "image": "cPK_20_011670_01_MEGADENRYUex_SAR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18786,7 +21140,8 @@
     "rarity": "SAR",
     "name": "Indeedee ex",
     "image": "cPK_20_012030_01_YESSANMESUNOSUGATA_SAR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18794,7 +21149,8 @@
     "rarity": "SAR",
     "name": "Hitmonchan ex",
     "image": "cPK_20_012060_01_EBIWALARex_SAR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18802,7 +21158,8 @@
     "rarity": "SAR",
     "name": "Mega Absol ex",
     "image": "cPK_20_012330_01_MEGAABSOLex_SAR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18810,7 +21167,8 @@
     "rarity": "SAR",
     "name": "Dragalge ex",
     "image": "cPK_20_012420_01_DRAMIDOROex_SAR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18818,7 +21176,8 @@
     "rarity": "SAR",
     "name": "Melmetal ex",
     "image": "cPK_20_012560_01_MELMETALex_SAR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18826,7 +21185,8 @@
     "rarity": "SAR",
     "name": "Tauros ex",
     "image": "cPK_20_012650_01_KENTAUROSex_SAR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18834,7 +21194,8 @@
     "rarity": "IM",
     "name": "Mega Blaziken ex",
     "image": "cPK_20_011180_01_MEGABURSYAMOex_IM.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18842,7 +21203,8 @@
     "rarity": "IM",
     "name": "Mega Gyarados ex",
     "image": "cPK_20_011340_01_MEGAGYARADOSex_IM.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18850,7 +21212,8 @@
     "rarity": "IM",
     "name": "Mega Altaria ex",
     "image": "cPK_20_011840_01_MEGATYLTALISex_IM.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18858,7 +21221,8 @@
     "rarity": "S",
     "name": "Bellsprout",
     "image": "cPK_20_000180_00_MADATSUBOMI_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18866,7 +21230,8 @@
     "rarity": "S",
     "name": "Weepinbell",
     "image": "cPK_20_000190_00_UTSUDON_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18874,7 +21239,8 @@
     "rarity": "S",
     "name": "Victreebel",
     "image": "cPK_20_000200_00_UTSUBOT_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18882,7 +21248,8 @@
     "rarity": "S",
     "name": "Rowlet",
     "image": "cPK_20_005910_00_MOKUROH_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18890,7 +21257,8 @@
     "rarity": "S",
     "name": "Dartrix",
     "image": "cPK_20_007460_00_FUKUTHROW_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18898,7 +21266,8 @@
     "rarity": "S",
     "name": "Moltres",
     "image": "cPK_20_000460_00_FIRE_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18906,7 +21275,8 @@
     "rarity": "S",
     "name": "Litten",
     "image": "cPK_20_006110_00_NYABBY_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18914,7 +21284,8 @@
     "rarity": "S",
     "name": "Torracat",
     "image": "cPK_20_006130_00_NYAHEAT_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18922,7 +21293,8 @@
     "rarity": "S",
     "name": "Poliwag",
     "image": "cPK_20_010330_00_NYOROMO_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18930,7 +21302,8 @@
     "rarity": "S",
     "name": "Poliwhirl",
     "image": "cPK_20_000600_00_NYOROZO_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18938,7 +21311,8 @@
     "rarity": "S",
     "name": "Poliwrath",
     "image": "cPK_20_000610_00_NYOROBON_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18946,7 +21320,8 @@
     "rarity": "S",
     "name": "Articuno",
     "image": "cPK_20_000830_00_FREEZER_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18954,7 +21329,8 @@
     "rarity": "S",
     "name": "Manaphy",
     "image": "cPK_20_003310_01_MANAPHY_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18962,7 +21338,8 @@
     "rarity": "S",
     "name": "Popplio",
     "image": "cPK_20_006260_00_ASHIMARI_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18970,7 +21347,8 @@
     "rarity": "S",
     "name": "Brionne",
     "image": "cPK_20_008180_00_OSYAMARI_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18978,7 +21356,8 @@
     "rarity": "S",
     "name": "Zapdos",
     "image": "cPK_20_001030_00_THUNDER_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18986,7 +21365,8 @@
     "rarity": "S",
     "name": "Oricorio",
     "image": "cPK_20_006470_01_ODORIDORIPACHIPACHISTYLE_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -18994,7 +21374,8 @@
     "rarity": "S",
     "name": "Zeraora",
     "image": "cPK_20_007410_00_ZERAORA_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19002,7 +21383,8 @@
     "rarity": "S",
     "name": "Drowzee",
     "image": "cPK_20_001240_00_SLEEPE_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19010,7 +21392,8 @@
     "rarity": "S",
     "name": "Hypno",
     "image": "cPK_20_001250_00_SLEEPER_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19018,7 +21401,8 @@
     "rarity": "S",
     "name": "Geodude",
     "image": "cPK_20_001470_00_ISITSUBUTE_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19026,7 +21410,8 @@
     "rarity": "S",
     "name": "Graveler",
     "image": "cPK_20_002570_00_GOLONE_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19034,7 +21419,8 @@
     "rarity": "S",
     "name": "Golem",
     "image": "cPK_20_002580_00_GOLONYA_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19042,7 +21428,8 @@
     "rarity": "S",
     "name": "Rockruff",
     "image": "cPK_20_006790_01_IWANKO_S.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19050,7 +21437,8 @@
     "rarity": "S",
     "name": "Alolan Diglett",
     "image": "cPK_20_006980_00_ALOLADIGDA_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19058,7 +21446,8 @@
     "rarity": "S",
     "name": "Meowth",
     "image": "cPK_20_001960_01_NYARTH_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19066,7 +21455,8 @@
     "rarity": "S",
     "name": "Persian",
     "image": "cPK_20_001970_00_PERSIAN_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19074,7 +21464,8 @@
     "rarity": "S",
     "name": "Doduo",
     "image": "cPK_20_001990_00_DODO_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19082,7 +21473,8 @@
     "rarity": "S",
     "name": "Dodrio",
     "image": "cPK_20_002000_00_DODORIO_S.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19090,7 +21482,8 @@
     "rarity": "S",
     "name": "Bidoof",
     "image": "cPK_20_004160_01_BIPPA_S.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19098,7 +21491,8 @@
     "rarity": "SSR",
     "name": "Decidueye ex",
     "image": "cPK_20_005930_02_JUNAIPERex_SSR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19106,7 +21500,8 @@
     "rarity": "SSR",
     "name": "Incineroar ex",
     "image": "cPK_20_006140_02_GAOGAENex_SSR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19114,7 +21509,8 @@
     "rarity": "SSR",
     "name": "Palkia ex",
     "image": "cPK_20_003300_04_PALKIAex_SSR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19122,7 +21518,8 @@
     "rarity": "SSR",
     "name": "Primarina ex",
     "image": "cPK_20_008190_02_ASHIRENEex_SSR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19130,7 +21527,8 @@
     "rarity": "SSR",
     "name": "Pikachu ex",
     "image": "cPK_20_005410_02_PIKACHUex_SSR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19138,7 +21536,8 @@
     "rarity": "SSR",
     "name": "Tapu Koko ex",
     "image": "cPK_20_007420_02_KAPU-KOKEKOex_SSR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19146,7 +21545,8 @@
     "rarity": "SSR",
     "name": "Lycanroc ex",
     "image": "cPK_20_007700_02_LUGARUGANex_SSR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19154,7 +21554,8 @@
     "rarity": "SSR",
     "name": "Passimian ex",
     "image": "cPK_20_006850_02_NAGETUKESARUex_SSR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19162,7 +21563,8 @@
     "rarity": "SSR",
     "name": "Alolan Dugtrio ex",
     "image": "cPK_20_007830_02_ALOLADUGTRIOex_SSR.webp",
-    "packs": ["Mega Blaziken"]
+    "packs": ["Mega Blaziken"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19170,7 +21572,8 @@
     "rarity": "SSR",
     "name": "Dialga ex",
     "image": "cPK_20_004000_04_DIALGAex_SSR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19178,7 +21581,8 @@
     "rarity": "SSR",
     "name": "Bibarel ex",
     "image": "cPK_20_005790_02_BEADARUex_SSR.webp",
-    "packs": ["Mega Altaria"]
+    "packs": ["Mega Altaria"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19186,7 +21590,8 @@
     "rarity": "SSR",
     "name": "Arceus ex",
     "image": "cPK_20_004950_04_ARCEUSex_SSR.webp",
-    "packs": ["Mega Gyarados"]
+    "packs": ["Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19194,7 +21599,8 @@
     "rarity": "UR",
     "name": "Lilligant",
     "image": "cPK_20_011000_00_DREDEAR_UR.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19202,7 +21608,8 @@
     "rarity": "UR",
     "name": "Klefki",
     "image": "cPK_20_012020_00_CLEFFY_UR.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1",
@@ -19210,7 +21617,8 @@
     "rarity": "UR",
     "name": "Flame Patch",
     "image": "cTR_20_000910_00_FUREIMUPACCHI_UR.webp",
-    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"]
+    "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19218,7 +21626,8 @@
     "rarity": "C",
     "image": "cPK_10_013070_00_FUSHIGIDANE_C.webp",
     "name": "Bulbasaur",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19226,7 +21635,8 @@
     "rarity": "U",
     "image": "cPK_10_013080_00_FUSHIGISOU_U.webp",
     "name": "Ivysaur",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19234,7 +21644,8 @@
     "rarity": "R",
     "image": "cPK_10_013090_00_FUSHIGIBANA_R.webp",
     "name": "Venusaur",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19242,7 +21653,8 @@
     "rarity": "RR",
     "image": "cPK_10_013100_00_MEGAFUSHIGIBANAex_RR.webp",
     "name": "Mega Venusaur ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19250,7 +21662,8 @@
     "rarity": "C",
     "image": "cPK_10_013110_00_ITOMARU_C.webp",
     "name": "Spinarak",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19258,7 +21671,8 @@
     "rarity": "U",
     "image": "cPK_10_013120_00_ARIADOS_U.webp",
     "name": "Ariados",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19266,7 +21680,8 @@
     "rarity": "C",
     "image": "cPK_10_013130_00_HIMANUTS_C.webp",
     "name": "Sunkern",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19274,7 +21689,8 @@
     "rarity": "U",
     "image": "cPK_10_013140_00_KIMAWARI_U.webp",
     "name": "Sunflora",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19282,7 +21698,8 @@
     "rarity": "C",
     "image": "cPK_10_013150_00_MINOMUCCHI_C.webp",
     "name": "Burmy",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19290,7 +21707,8 @@
     "rarity": "C",
     "image": "cPK_10_013160_00_GAMALE_C.webp",
     "name": "Mothim",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19298,7 +21716,8 @@
     "rarity": "C",
     "image": "cPK_10_013170_00_HITOKAGE_C.webp",
     "name": "Charmander",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19306,7 +21725,8 @@
     "rarity": "U",
     "image": "cPK_10_012980_00_LIZARDO_U.webp",
     "name": "Charmeleon",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19314,7 +21734,8 @@
     "rarity": "R",
     "image": "cPK_10_013180_00_LIZARDON_R.webp",
     "name": "Charizard",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19322,7 +21743,8 @@
     "rarity": "RR",
     "image": "cPK_10_013190_00_MEGALIZARDONYex_RR.webp",
     "name": "Mega Charizard Y ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19330,7 +21752,8 @@
     "rarity": "C",
     "image": "cPK_10_013200_00_DELVIL_C.webp",
     "name": "Houndour",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19338,7 +21761,8 @@
     "rarity": "C",
     "image": "cPK_10_013210_00_HELLGAR_C.webp",
     "name": "Houndoom",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19346,7 +21770,8 @@
     "rarity": "C",
     "image": "cPK_10_013220_00_ZENIGAME_C.webp",
     "name": "Squirtle",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19354,7 +21779,8 @@
     "rarity": "U",
     "image": "cPK_10_013230_00_KAMEIL_U.webp",
     "name": "Wartortle",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19362,7 +21788,8 @@
     "rarity": "R",
     "image": "cPK_10_013240_00_KAMEX_R.webp",
     "name": "Blastoise",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19370,7 +21797,8 @@
     "rarity": "RR",
     "image": "cPK_10_013250_00_MEGAKAMEXex_RR.webp",
     "name": "Mega Blastoise ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19378,7 +21806,8 @@
     "rarity": "C",
     "image": "cPK_10_013260_00_BASSRAOAKASUJINOSUGATA_C.webp",
     "name": "Basculin",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19386,7 +21815,8 @@
     "rarity": "C",
     "image": "cPK_10_013270_00_UDEPPOU_C.webp",
     "name": "Clauncher",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19394,7 +21824,8 @@
     "rarity": "U",
     "image": "cPK_10_013280_00_BLOSTER_U.webp",
     "name": "Clawitzer",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19402,7 +21833,8 @@
     "rarity": "C",
     "image": "cPK_10_013290_00_COIL_C.webp",
     "name": "Magnemite",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19410,7 +21842,8 @@
     "rarity": "U",
     "image": "cPK_10_013300_00_RARECOIL_U.webp",
     "name": "Magneton",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19418,7 +21851,8 @@
     "rarity": "R",
     "image": "cPK_10_013310_00_JIBACOIL_R.webp",
     "name": "Magnezone",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19426,7 +21860,8 @@
     "rarity": "C",
     "image": "cPK_10_013320_00_EMOLGA_C.webp",
     "name": "Emolga",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19434,7 +21869,8 @@
     "rarity": "C",
     "image": "cPK_10_013330_00_ERIKITERU_C.webp",
     "name": "Helioptile",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19442,7 +21878,8 @@
     "rarity": "U",
     "image": "cPK_10_013030_00_ELEZARD_U.webp",
     "name": "Heliolisk",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19450,7 +21887,8 @@
     "rarity": "C",
     "image": "cPK_10_013340_00_MUMA_C.webp",
     "name": "Misdreavus",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19458,7 +21896,8 @@
     "rarity": "U",
     "image": "cPK_10_013350_00_MUMARGI_U.webp",
     "name": "Mismagius",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19466,7 +21905,8 @@
     "rarity": "C",
     "image": "cPK_10_013360_00_UNIRAN_C.webp",
     "name": "Solosis",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19474,7 +21914,8 @@
     "rarity": "C",
     "image": "cPK_10_013370_00_DOUBLAN_C.webp",
     "name": "Duosion",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19482,7 +21923,8 @@
     "rarity": "R",
     "image": "cPK_10_013380_00_LANCULUS_R.webp",
     "name": "Reuniclus",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19490,7 +21932,8 @@
     "rarity": "C",
     "image": "cPK_10_013390_00_SHUSHUPU_C.webp",
     "name": "Spritzee",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19498,7 +21941,8 @@
     "rarity": "C",
     "image": "cPK_10_013400_00_FREFUWAN_C.webp",
     "name": "Aromatisse",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19506,7 +21950,8 @@
     "rarity": "R",
     "image": "cPK_10_013410_00_XERNEAS_R.webp",
     "name": "Xerneas",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19514,7 +21959,8 @@
     "rarity": "C",
     "image": "cPK_10_013420_00_IWARK_C.webp",
     "name": "Onix",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19522,7 +21968,8 @@
     "rarity": "C",
     "image": "cPK_10_013430_00_MAKUNOSHITA_C.webp",
     "name": "Makuhita",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19530,7 +21977,8 @@
     "rarity": "U",
     "image": "cPK_10_013440_00_HARITEYAMA_U.webp",
     "name": "Hariyama",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19538,7 +21986,8 @@
     "rarity": "C",
     "image": "cPK_10_013450_00_NOSEPASS_C.webp",
     "name": "Nosepass",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19546,7 +21995,8 @@
     "rarity": "RR",
     "image": "cPK_10_013460_00_MEGAMIMILOPex_RR.webp",
     "name": "Mega Lopunny ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19554,7 +22004,8 @@
     "rarity": "C",
     "image": "cPK_10_013470_00_KOJOFU_C.webp",
     "name": "Mienfoo",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19562,7 +22013,8 @@
     "rarity": "C",
     "image": "cPK_10_013480_00_KOJONDO_C.webp",
     "name": "Mienshao",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19570,7 +22022,8 @@
     "rarity": "C",
     "image": "cPK_10_013490_00_BETBETER_C.webp",
     "name": "Grimer",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19578,7 +22031,8 @@
     "rarity": "C",
     "image": "cPK_10_013500_00_BETBETON_C.webp",
     "name": "Muk",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19586,7 +22040,8 @@
     "rarity": "C",
     "image": "cPK_10_013510_00_CHORONEKO_C.webp",
     "name": "Purrloin",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19594,7 +22049,8 @@
     "rarity": "U",
     "image": "cPK_10_013520_00_LEPARDAS_U.webp",
     "name": "Liepard",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19602,7 +22058,8 @@
     "rarity": "C",
     "image": "cPK_10_013530_00_YABUKURON_C.webp",
     "name": "Trubbish",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19610,7 +22067,8 @@
     "rarity": "U",
     "image": "cPK_10_013540_00_DUSTDAS_U.webp",
     "name": "Garbodor",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19618,7 +22076,8 @@
     "rarity": "U",
     "image": "cPK_10_013550_00_HAGANEIL_U.webp",
     "name": "Steelix",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19626,7 +22085,8 @@
     "rarity": "RR",
     "image": "cPK_10_013560_00_MEGAHAGANEILex_RR.webp",
     "name": "Mega Steelix ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19634,7 +22094,8 @@
     "rarity": "U",
     "image": "cPK_10_013570_00_DAINOSE_U.webp",
     "name": "Probopass",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19642,7 +22103,8 @@
     "rarity": "R",
     "image": "cPK_10_013010_00_GENESECT_R.webp",
     "name": "Genesect",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19650,7 +22112,8 @@
     "rarity": "U",
     "image": "cPK_10_013060_00_METAMON_U.webp",
     "name": "Ditto",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19658,7 +22121,8 @@
     "rarity": "C",
     "image": "cPK_10_013580_00_PORYGON_C.webp",
     "name": "Porygon",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19666,7 +22130,8 @@
     "rarity": "U",
     "image": "cPK_10_013590_00_PORYGON2_U.webp",
     "name": "Porygon2",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19674,7 +22139,8 @@
     "rarity": "R",
     "image": "cPK_10_013600_00_PORYGON-Z_R.webp",
     "name": "Porygon-Z",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19682,7 +22148,8 @@
     "rarity": "C",
     "image": "cPK_10_013610_00_MUKKURU_C.webp",
     "name": "Starly",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19690,7 +22157,8 @@
     "rarity": "C",
     "image": "cPK_10_013620_00_MUKUBIRD_C.webp",
     "name": "Staravia",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19698,7 +22166,8 @@
     "rarity": "U",
     "image": "cPK_10_013630_00_MUKUHAWK_U.webp",
     "name": "Staraptor",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19706,7 +22175,8 @@
     "rarity": "C",
     "image": "cPK_10_013040_00_MIMIROL_C.webp",
     "name": "Buneary",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19714,7 +22184,8 @@
     "rarity": "U",
     "image": "cPK_10_013640_00_MIMILOP_U.webp",
     "name": "Lopunny",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19722,7 +22193,8 @@
     "rarity": "U",
     "image": "cPK_10_013650_00_BUFFRON_U.webp",
     "name": "Bouffalant",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19730,15 +22202,17 @@
     "rarity": "U",
     "image": "cPK_10_013660_00_TRIMMIENKABUKICUT_U.webp",
     "name": "Furfrou",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
     "number": 66,
     "rarity": "U",
     "image": "cTR_10_001010_00_CITRONNORYUKKU_U.webp",
-    "name": "Clemont’s Backpack",
-    "packs": ["Crimson Blaze"]
+    "name": "Clemont\u2019s Backpack",
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19746,7 +22220,8 @@
     "rarity": "U",
     "image": "cTR_10_001020_00_SOUJYUKUEKISU_U.webp",
     "name": "Quick-Grow Extract",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19754,7 +22229,8 @@
     "rarity": "U",
     "image": "cTR_10_001030_00_CITRON_U.webp",
     "name": "Clemont",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19762,7 +22238,8 @@
     "rarity": "U",
     "image": "cTR_10_001040_00_SERENA_U.webp",
     "name": "Serena",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19770,7 +22247,8 @@
     "rarity": "AR",
     "image": "cPK_20_013120_00_ARIADOS_AR.webp",
     "name": "Ariados",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19778,7 +22256,8 @@
     "rarity": "AR",
     "image": "cPK_20_013140_00_KIMAWARI_AR.webp",
     "name": "Sunflora",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19786,7 +22265,8 @@
     "rarity": "AR",
     "image": "cPK_20_013380_00_LANCULUS_AR.webp",
     "name": "Reuniclus",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19794,7 +22274,8 @@
     "rarity": "AR",
     "image": "cPK_20_013410_00_XERNEAS_AR.webp",
     "name": "Xerneas",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19802,7 +22283,8 @@
     "rarity": "AR",
     "image": "cPK_20_013530_00_YABUKURON_AR.webp",
     "name": "Trubbish",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19810,7 +22292,8 @@
     "rarity": "AR",
     "image": "cPK_20_013040_00_MIMIROL_AR.webp",
     "name": "Buneary",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19818,7 +22301,8 @@
     "rarity": "SR",
     "image": "cPK_20_013100_00_MEGAFUSHIGIBANAex_SR.webp",
     "name": "Mega Venusaur ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19826,7 +22310,8 @@
     "rarity": "SR",
     "image": "cPK_20_013190_00_MEGALIZARDONYex_SR.webp",
     "name": "Mega Charizard Y ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19834,7 +22319,8 @@
     "rarity": "SR",
     "image": "cPK_20_013250_00_MEGAKAMEXex_SR.webp",
     "name": "Mega Blastoise ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19842,7 +22328,8 @@
     "rarity": "SR",
     "image": "cPK_20_013460_00_MEGAMIMILOPex_SR.webp",
     "name": "Mega Lopunny ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19850,7 +22337,8 @@
     "rarity": "SR",
     "image": "cPK_20_013560_00_MEGAHAGANEILex_SR.webp",
     "name": "Mega Steelix ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19858,7 +22346,8 @@
     "rarity": "SR",
     "image": "cTR_20_001030_00_CITRON_SR.webp",
     "name": "Clemont",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19866,7 +22355,8 @@
     "rarity": "SR",
     "image": "cTR_20_001040_00_SERENA_SR.webp",
     "name": "Serena",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19874,7 +22364,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013100_01_MEGAFUSHIGIBANAex_SAR.webp",
     "name": "Mega Venusaur ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19882,7 +22373,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013250_01_MEGAKAMEXex_SAR.webp",
     "name": "Mega Blastoise ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19890,7 +22382,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013460_01_MEGAMIMILOPex_SAR.webp",
     "name": "Mega Lopunny ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19898,7 +22391,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013560_01_MEGAHAGANEILex_SAR.webp",
     "name": "Mega Steelix ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19906,7 +22400,8 @@
     "rarity": "IM",
     "image": "cPK_20_013190_01_MEGALIZARDONYex_IM.webp",
     "name": "Mega Charizard Y ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19914,7 +22409,8 @@
     "rarity": "S",
     "image": "cPK_20_008570_00_NAZONOKUSA_S.webp",
     "name": "Oddish",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19922,7 +22418,8 @@
     "rarity": "S",
     "image": "cPK_20_008580_00_KUSAIHANA_S.webp",
     "name": "Gloom",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19930,7 +22427,8 @@
     "rarity": "S",
     "image": "cPK_20_000130_00_RUFFRESIA_S.webp",
     "name": "Vileplume",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19938,7 +22436,8 @@
     "rarity": "S",
     "image": "cPK_20_013180_00_LIZARDON_S.webp",
     "name": "Charizard",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19946,7 +22445,8 @@
     "rarity": "S",
     "image": "cPK_20_006230_00_SHELLDER_S.webp",
     "name": "Shellder",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19954,7 +22454,8 @@
     "rarity": "S",
     "image": "cPK_20_006240_00_PARSHEN_S.webp",
     "name": "Cloyster",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19962,7 +22463,8 @@
     "rarity": "S",
     "image": "cPK_20_012040_00_SAND_S.webp",
     "name": "Sandshrew",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19970,7 +22472,8 @@
     "rarity": "S",
     "image": "cPK_20_012050_00_SANDPAN_S.webp",
     "name": "Sandslash",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19978,7 +22481,8 @@
     "rarity": "S",
     "image": "cPK_20_007940_00_TYPENULL_S.webp",
     "name": "Type: Null",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19986,7 +22490,8 @@
     "rarity": "S",
     "image": "cPK_20_007950_01_SILVADY_S.webp",
     "name": "Silvally",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -19994,7 +22499,8 @@
     "rarity": "SSR",
     "image": "cPK_20_007480_03_MASSIVOONex_SSR.webp",
     "name": "Buzzwole ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -20002,7 +22508,8 @@
     "rarity": "SSR",
     "image": "cPK_20_006680_04_LUNALAex_SSR.webp",
     "name": "Lunala ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -20010,7 +22517,8 @@
     "rarity": "SSR",
     "image": "cPK_20_007800_02_AKUZIKINGex_SSR.webp",
     "name": "Guzzlord ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -20018,7 +22526,8 @@
     "rarity": "SSR",
     "image": "cPK_20_007030_04_SOLGALEOex_SSR.webp",
     "name": "Solgaleo ex",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -20026,7 +22535,8 @@
     "rarity": "UR",
     "image": "cPK_20_012540_00_GILLGARDBLADEFORME_UR.webp",
     "name": "Aegislash",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B1a",
@@ -20034,7 +22544,8 @@
     "rarity": "UR",
     "image": "cTR_20_001020_00_SOUJYUKUEKISU_UR.webp",
     "name": "Quick-Grow Extract",
-    "packs": ["Crimson Blaze"]
+    "packs": ["Crimson Blaze"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20042,7 +22553,8 @@
     "rarity": "C",
     "image": "cPK_10_013670_00_REDIBA_C.webp",
     "name": "Ledyba",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20050,7 +22562,8 @@
     "rarity": "C",
     "image": "cPK_10_013680_00_REDIAN_C.webp",
     "name": "Ledian",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20058,7 +22571,8 @@
     "rarity": "C",
     "image": "cPK_10_013690_00_TSUBOTSUBO_C.webp",
     "name": "Shuckle",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20066,7 +22580,8 @@
     "rarity": "C",
     "image": "cPK_10_013700_00_ROSELIA_C.webp",
     "name": "Roselia",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20074,7 +22589,8 @@
     "rarity": "R",
     "image": "cPK_10_013710_00_ROSERADE_R.webp",
     "name": "Roserade",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20082,7 +22598,8 @@
     "rarity": "C",
     "image": "cPK_10_013720_00_SABONEA_C.webp",
     "name": "Cacnea",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20090,7 +22607,8 @@
     "rarity": "U",
     "image": "cPK_10_013730_00_NOCTUS_U.webp",
     "name": "Cacturne",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20098,7 +22616,8 @@
     "rarity": "C",
     "image": "cPK_10_013740_00_HARIMARON_C.webp",
     "name": "Chespin",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20106,7 +22625,8 @@
     "rarity": "U",
     "image": "cPK_10_013750_00_HARIBORG_U.webp",
     "name": "Quilladin",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20114,7 +22634,8 @@
     "rarity": "R",
     "image": "cPK_10_013760_00_BRIGARRON_R.webp",
     "name": "Chesnaught",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20122,7 +22643,8 @@
     "rarity": "C",
     "image": "cPK_10_013770_00_KOFUKIMUSHI_C.webp",
     "name": "Scatterbug",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20130,7 +22652,8 @@
     "rarity": "C",
     "image": "cPK_10_013780_00_KOFUURAI_C.webp",
     "name": "Spewpa",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20138,7 +22661,8 @@
     "rarity": "U",
     "image": "cPK_10_013790_00_VIVIYON_U.webp",
     "name": "Vivillon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20146,7 +22670,8 @@
     "rarity": "R",
     "image": "cPK_10_013800_00_MASSIVOON_R.webp",
     "name": "Buzzwole",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20154,7 +22679,8 @@
     "rarity": "C",
     "image": "cPK_10_013810_00_HIMENKA_C.webp",
     "name": "Gossifleur",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20162,7 +22688,8 @@
     "rarity": "U",
     "image": "cPK_10_013820_00_WATASHIRAGA_U.webp",
     "name": "Eldegoss",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20170,7 +22697,8 @@
     "rarity": "RR",
     "image": "cPK_10_013830_00_OGERPONMIDORINOMENex_RR.webp",
     "name": "Teal Mask Ogerpon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20178,7 +22706,8 @@
     "rarity": "U",
     "image": "cPK_10_013840_00_ALOLAGARAGARA_U.webp",
     "name": "Alolan Marowak",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20186,7 +22715,8 @@
     "rarity": "R",
     "image": "cPK_10_013850_00_RESHIRAM_R.webp",
     "name": "Reshiram",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20194,7 +22724,8 @@
     "rarity": "C",
     "image": "cPK_10_013860_00_SHISHIKO_C.webp",
     "name": "Litleo",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20202,7 +22733,8 @@
     "rarity": "U",
     "image": "cPK_10_013870_00_KAENJISHI_U.webp",
     "name": "Pyroar",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20210,7 +22742,8 @@
     "rarity": "U",
     "image": "cPK_10_013880_00_ODORIDORI_U.webp",
     "name": "Oricorio",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20218,7 +22751,8 @@
     "rarity": "RR",
     "image": "cPK_10_013890_00_ZUGADOONex_RR.webp",
     "name": "Blacephalon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20226,7 +22760,8 @@
     "rarity": "C",
     "image": "cPK_10_013900_00_HIBANNY_C.webp",
     "name": "Scorbunny",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20234,7 +22769,8 @@
     "rarity": "U",
     "image": "cPK_10_013910_00_RABBIFUTO_U.webp",
     "name": "Raboot",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20242,7 +22778,8 @@
     "rarity": "R",
     "image": "cPK_10_013920_00_ACEBURN_R.webp",
     "name": "Cinderace",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20250,7 +22787,8 @@
     "rarity": "R",
     "image": "cPK_10_013930_00_OGERPONKAMADONOMEN_R.webp",
     "name": "Hearthflame Mask Ogerpon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20258,7 +22796,8 @@
     "rarity": "C",
     "image": "cPK_10_013940_00_ALOLAROKON_C.webp",
     "name": "Alolan Vulpix",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20266,7 +22805,8 @@
     "rarity": "RR",
     "image": "cPK_10_013950_00_ALOLAKYUKONex_RR.webp",
     "name": "Alolan Ninetales ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20274,7 +22814,8 @@
     "rarity": "C",
     "image": "cPK_10_013960_00_GALARBARRIERD_C.webp",
     "name": "Galarian Mr. Mime",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20282,7 +22823,8 @@
     "rarity": "U",
     "image": "cPK_10_013970_00_GALARBARRIKOHRU_U.webp",
     "name": "Galarian Mr. Rime",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20290,7 +22832,8 @@
     "rarity": "U",
     "image": "cPK_10_013980_00_DELIBIRD_U.webp",
     "name": "Delibird",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20298,7 +22841,8 @@
     "rarity": "C",
     "image": "cPK_10_013990_00_MIZUGOROU_C.webp",
     "name": "Mudkip",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20306,7 +22850,8 @@
     "rarity": "U",
     "image": "cPK_10_014000_00_NUMACRAW_U.webp",
     "name": "Marshtomp",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20314,7 +22859,8 @@
     "rarity": "R",
     "image": "cPK_10_014010_00_LAGLARGE_R.webp",
     "name": "Swampert",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20322,7 +22868,8 @@
     "rarity": "RR",
     "image": "cPK_10_014020_00_MEGALAGLARGEex_RR.webp",
     "name": "Mega Swampert ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20330,7 +22877,8 @@
     "rarity": "C",
     "image": "cPK_10_014030_00_VANIPETI_C.webp",
     "name": "Vanillite",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20338,7 +22886,8 @@
     "rarity": "C",
     "image": "cPK_10_014040_00_VANIRICH_C.webp",
     "name": "Vanillish",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20346,7 +22895,8 @@
     "rarity": "U",
     "image": "cPK_10_014050_00_BAIVANILLA_U.webp",
     "name": "Vanilluxe",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20354,7 +22904,8 @@
     "rarity": "C",
     "image": "cPK_10_014060_00_FREEGEO_C.webp",
     "name": "Cryogonal",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20362,7 +22913,8 @@
     "rarity": "U",
     "image": "cPK_10_014070_00_AMARUS_U.webp",
     "name": "Amaura",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20370,7 +22922,8 @@
     "rarity": "R",
     "image": "cPK_10_014080_00_AMARURUGA_R.webp",
     "name": "Aurorus",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20378,7 +22931,8 @@
     "rarity": "C",
     "image": "cPK_10_014090_00_KAMUKAME_C.webp",
     "name": "Chewtle",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20386,7 +22940,8 @@
     "rarity": "U",
     "image": "cPK_10_014100_00_KAJIRIGAME_U.webp",
     "name": "Drednaw",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20394,7 +22949,8 @@
     "rarity": "C",
     "image": "cPK_10_014110_00_UU_C.webp",
     "name": "Cramorant",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20402,7 +22958,8 @@
     "rarity": "C",
     "image": "cPK_10_014120_00_SASIKAMASU_C.webp",
     "name": "Arrokuda",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20410,7 +22967,8 @@
     "rarity": "C",
     "image": "cPK_10_014130_00_KAMASUJAW_C.webp",
     "name": "Barraskewda",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20418,7 +22976,8 @@
     "rarity": "R",
     "image": "cPK_10_014140_00_OGERPONIDONOMEN_R.webp",
     "name": "Wellspring Mask Ogerpon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20426,7 +22985,8 @@
     "rarity": "C",
     "image": "cPK_10_014150_00_PIKACHU_C.webp",
     "name": "Pikachu",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20434,7 +22994,8 @@
     "rarity": "R",
     "image": "cPK_10_014160_00_ALOLARAICHU_R.webp",
     "name": "Alolan Raichu",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20442,7 +23003,8 @@
     "rarity": "R",
     "image": "cPK_10_014170_00_THUNDER_R.webp",
     "name": "Zapdos",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20450,7 +23012,8 @@
     "rarity": "C",
     "image": "cPK_10_014180_00_PRASLE_C.webp",
     "name": "Plusle",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20458,7 +23021,8 @@
     "rarity": "C",
     "image": "cPK_10_014190_00_MINUN_C.webp",
     "name": "Minun",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20466,7 +23030,8 @@
     "rarity": "C",
     "image": "cPK_10_014200_00_ELESON_C.webp",
     "name": "Toxel",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20474,7 +23039,8 @@
     "rarity": "RR",
     "image": "cPK_10_014210_00_STRINDERex_RR.webp",
     "name": "Toxtricity ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20482,7 +23048,8 @@
     "rarity": "C",
     "image": "cPK_10_014220_00_ZUPIKA_C.webp",
     "name": "Tadbulb",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20490,7 +23057,8 @@
     "rarity": "U",
     "image": "cPK_10_014230_00_HARABARIE_U.webp",
     "name": "Bellibolt",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20498,7 +23066,8 @@
     "rarity": "C",
     "image": "cPK_10_014240_00_GALARPONYTA_C.webp",
     "name": "Galarian Ponyta",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20506,7 +23075,8 @@
     "rarity": "U",
     "image": "cPK_10_014250_00_GALARGALLOP_U.webp",
     "name": "Galarian Rapidash",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20514,7 +23084,8 @@
     "rarity": "C",
     "image": "cPK_10_014260_00_SONANS_C.webp",
     "name": "Wobbuffet",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20522,7 +23093,8 @@
     "rarity": "C",
     "image": "cPK_10_014270_00_BULU_C.webp",
     "name": "Snubbull",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20530,7 +23102,8 @@
     "rarity": "U",
     "image": "cPK_10_014280_00_GRANBULU_U.webp",
     "name": "Granbull",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20538,7 +23111,8 @@
     "rarity": "C",
     "image": "cPK_10_014290_00_RALTS_C.webp",
     "name": "Ralts",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20546,7 +23120,8 @@
     "rarity": "U",
     "image": "cPK_10_014300_00_KIRLIA_U.webp",
     "name": "Kirlia",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20554,7 +23129,8 @@
     "rarity": "R",
     "image": "cPK_10_014310_00_SIRNIGHT_R.webp",
     "name": "Gardevoir",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20562,7 +23138,8 @@
     "rarity": "RR",
     "image": "cPK_10_014320_00_MEGASIRNIGHTex_RR.webp",
     "name": "Mega Gardevoir ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20570,7 +23147,8 @@
     "rarity": "C",
     "image": "cPK_10_014330_00_HITOMOSHI_C.webp",
     "name": "Litwick",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20578,7 +23156,8 @@
     "rarity": "U",
     "image": "cPK_10_014340_00_LAMPLER_U.webp",
     "name": "Lampent",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20586,7 +23165,8 @@
     "rarity": "R",
     "image": "cPK_10_014350_00_CHANDELA_R.webp",
     "name": "Chandelure",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20594,7 +23174,8 @@
     "rarity": "U",
     "image": "cPK_10_014360_00_MELOETTA_U.webp",
     "name": "Meloetta",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20602,7 +23183,8 @@
     "rarity": "C",
     "image": "cPK_10_014370_00_BAKECCHA_C.webp",
     "name": "Pumpkaboo",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20610,7 +23192,8 @@
     "rarity": "R",
     "image": "cPK_10_014380_00_PUMPJIN_R.webp",
     "name": "Gourgeist",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20618,7 +23201,8 @@
     "rarity": "RR",
     "image": "cPK_10_014390_00_MIMIKKYUex_RR.webp",
     "name": "Mimikyu ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20626,7 +23210,8 @@
     "rarity": "C",
     "image": "cPK_10_014400_00_YABACHA_C.webp",
     "name": "Sinistea",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20634,7 +23219,8 @@
     "rarity": "U",
     "image": "cPK_10_014410_00_POTDEATH_U.webp",
     "name": "Polteageist",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20642,7 +23228,8 @@
     "rarity": "C",
     "image": "cPK_10_014420_00_YESSAN_C.webp",
     "name": "Indeedee",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20650,7 +23237,8 @@
     "rarity": "C",
     "image": "cPK_10_014430_00_SAND_C.webp",
     "name": "Sandshrew",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20658,7 +23246,8 @@
     "rarity": "C",
     "image": "cPK_10_014440_00_SANDPAN_C.webp",
     "name": "Sandslash",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20666,7 +23255,8 @@
     "rarity": "C",
     "image": "cPK_10_014450_00_WANRIKY_C.webp",
     "name": "Machop",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20674,7 +23264,8 @@
     "rarity": "C",
     "image": "cPK_10_014460_00_GORIKY_C.webp",
     "name": "Machoke",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20682,7 +23273,8 @@
     "rarity": "U",
     "image": "cPK_10_014470_00_KAIRIKY_U.webp",
     "name": "Machamp",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20690,7 +23282,8 @@
     "rarity": "C",
     "image": "cPK_10_014480_00_KARAKARA_C.webp",
     "name": "Cubone",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20698,7 +23291,8 @@
     "rarity": "C",
     "image": "cPK_10_014490_00_ASANAN_C.webp",
     "name": "Meditite",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20706,7 +23300,8 @@
     "rarity": "U",
     "image": "cPK_10_014500_00_CHAREM_U.webp",
     "name": "Medicham",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20714,7 +23309,8 @@
     "rarity": "C",
     "image": "cPK_10_014510_00_DANGORO_C.webp",
     "name": "Roggenrola",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20722,7 +23318,8 @@
     "rarity": "U",
     "image": "cPK_10_014520_00_GANTLE_U.webp",
     "name": "Boldore",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20730,7 +23327,8 @@
     "rarity": "RR",
     "image": "cPK_10_014530_00_GIGAIATHex_RR.webp",
     "name": "Gigalith ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20738,7 +23336,8 @@
     "rarity": "C",
     "image": "cPK_10_014540_00_MOGUREW_C.webp",
     "name": "Drilbur",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20746,7 +23345,8 @@
     "rarity": "U",
     "image": "cPK_10_014550_00_CHIGORAS_U.webp",
     "name": "Tyrunt",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20754,7 +23354,8 @@
     "rarity": "R",
     "image": "cPK_10_014560_00_GACHIGORAS_R.webp",
     "name": "Tyrantrum",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20762,7 +23363,8 @@
     "rarity": "C",
     "image": "cPK_10_014570_00_NAGETUKESARU_C.webp",
     "name": "Passimian",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20770,7 +23372,8 @@
     "rarity": "U",
     "image": "cPK_10_014580_00_TAIRETSU_U.webp",
     "name": "Falinks",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20778,7 +23381,8 @@
     "rarity": "R",
     "image": "cPK_10_014590_00_OGERPONISHIZUENOMEN_R.webp",
     "name": "Cornerstone Mask Ogerpon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20786,7 +23390,8 @@
     "rarity": "C",
     "image": "cPK_10_014600_00_ALOLANYARTH_C.webp",
     "name": "Alolan Meowth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20794,7 +23399,8 @@
     "rarity": "U",
     "image": "cPK_10_014610_00_ALOLAPERSIAN_U.webp",
     "name": "Alolan Persian",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20802,7 +23408,8 @@
     "rarity": "C",
     "image": "cPK_10_014620_00_ALOLABETBETER_C.webp",
     "name": "Alolan Grimer",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20810,7 +23417,8 @@
     "rarity": "R",
     "image": "cPK_10_014630_00_ALOLABETBETON_R.webp",
     "name": "Alolan Muk",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20818,7 +23426,8 @@
     "rarity": "C",
     "image": "cPK_10_014640_00_GALARJIGUZAGUMA_C.webp",
     "name": "Galarian Zigzagoon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20826,7 +23435,8 @@
     "rarity": "U",
     "image": "cPK_10_014650_00_GALARMASSUGUMA_U.webp",
     "name": "Galarian Linoone",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20834,7 +23444,8 @@
     "rarity": "R",
     "image": "cPK_10_014660_00_GALARTACHIFUSAGUMA_R.webp",
     "name": "Galarian Obstagoon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20842,7 +23453,8 @@
     "rarity": "C",
     "image": "cPK_10_014670_00_SKUNPUU_C.webp",
     "name": "Stunky",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20850,7 +23462,8 @@
     "rarity": "U",
     "image": "cPK_10_014680_00_SKUTANK_U.webp",
     "name": "Skuntank",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20858,7 +23471,8 @@
     "rarity": "R",
     "image": "cPK_10_014690_00_MIKARUGE_R.webp",
     "name": "Spiritomb",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20866,7 +23480,8 @@
     "rarity": "C",
     "image": "cPK_10_014700_00_CHORONEKO_C.webp",
     "name": "Purrloin",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20874,7 +23489,8 @@
     "rarity": "U",
     "image": "cPK_10_014710_00_LEPARDAS_U.webp",
     "name": "Liepard",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20882,7 +23498,8 @@
     "rarity": "C",
     "image": "cPK_10_014720_00_ZURUGGU_C.webp",
     "name": "Scraggy",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20890,7 +23507,8 @@
     "rarity": "U",
     "image": "cPK_10_014730_00_ZURUZUKIN_U.webp",
     "name": "Scrafty",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20898,7 +23516,8 @@
     "rarity": "R",
     "image": "cPK_10_014740_00_YVELTAL_R.webp",
     "name": "Yveltal",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20906,7 +23525,8 @@
     "rarity": "R",
     "image": "cPK_10_014750_00_AKUZIKING_R.webp",
     "name": "Guzzlord",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20914,7 +23534,8 @@
     "rarity": "C",
     "image": "cPK_10_014760_00_GALARNYARTH_C.webp",
     "name": "Galarian Meowth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20922,7 +23543,8 @@
     "rarity": "R",
     "image": "cPK_10_014770_00_GALARNYAIKING_R.webp",
     "name": "Galarian Perrserker",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20930,7 +23552,8 @@
     "rarity": "C",
     "image": "cPK_10_014780_00_KUCHEAT_C.webp",
     "name": "Mawile",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20938,7 +23561,8 @@
     "rarity": "RR",
     "image": "cPK_10_014790_00_MEGAKUCHEATex_RR.webp",
     "name": "Mega Mawile ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20946,7 +23570,8 @@
     "rarity": "U",
     "image": "cPK_10_014800_00_DORYUZU_U.webp",
     "name": "Excadrill",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20954,7 +23579,8 @@
     "rarity": "C",
     "image": "cPK_10_014810_00_TESSEED_C.webp",
     "name": "Ferroseed",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20962,7 +23588,8 @@
     "rarity": "C",
     "image": "cPK_10_014820_00_NUTREY_C.webp",
     "name": "Ferrothorn",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20970,7 +23597,8 @@
     "rarity": "U",
     "image": "cPK_10_014830_00_GALARMAGGYO_U.webp",
     "name": "Galarian Stunfisk",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20978,7 +23606,8 @@
     "rarity": "C",
     "image": "cPK_10_014840_00_HITOTSUKI_C.webp",
     "name": "Honedge",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20986,7 +23615,8 @@
     "rarity": "U",
     "image": "cPK_10_014850_00_NIDANGILL_U.webp",
     "name": "Doublade",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -20994,7 +23624,8 @@
     "rarity": "R",
     "image": "cPK_10_014860_00_GILLGARD_R.webp",
     "name": "Aegislash",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21002,7 +23633,8 @@
     "rarity": "C",
     "image": "cPK_10_014870_00_TATSUBAY_C.webp",
     "name": "Bagon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21010,7 +23642,8 @@
     "rarity": "U",
     "image": "cPK_10_014880_00_KOMORUU_U.webp",
     "name": "Shelgon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21018,7 +23651,8 @@
     "rarity": "R",
     "image": "cPK_10_014890_00_BOHMANDER_R.webp",
     "name": "Salamence",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21026,7 +23660,8 @@
     "rarity": "C",
     "image": "cPK_10_014900_00_NYARTH_C.webp",
     "name": "Meowth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21034,7 +23669,8 @@
     "rarity": "C",
     "image": "cPK_10_014910_00_PERSIAN_C.webp",
     "name": "Persian",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21042,7 +23678,8 @@
     "rarity": "U",
     "image": "cPK_10_014920_00_GARURA_U.webp",
     "name": "Kangaskhan",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21050,7 +23687,8 @@
     "rarity": "RR",
     "image": "cPK_10_014930_00_MEGAGARURAex_RR.webp",
     "name": "Mega Kangaskhan ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21058,7 +23696,8 @@
     "rarity": "C",
     "image": "cPK_10_014940_00_OTACHI_C.webp",
     "name": "Sentret",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21066,7 +23705,8 @@
     "rarity": "C",
     "image": "cPK_10_014950_00_OOTACHI_C.webp",
     "name": "Furret",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21074,7 +23714,8 @@
     "rarity": "U",
     "image": "cPK_10_014960_00_DOBLE_U.webp",
     "name": "Smeargle",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21082,7 +23723,8 @@
     "rarity": "R",
     "image": "cPK_10_014970_00_LUGIA_R.webp",
     "name": "Lugia",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21090,7 +23732,8 @@
     "rarity": "C",
     "image": "cPK_10_014980_00_SUBAME_C.webp",
     "name": "Taillow",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21098,7 +23741,8 @@
     "rarity": "R",
     "image": "cPK_10_014990_00_OHSUBAME_R.webp",
     "name": "Swellow",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21106,7 +23750,8 @@
     "rarity": "C",
     "image": "cPK_10_015000_00_NAMAKERO_C.webp",
     "name": "Slakoth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21114,7 +23759,8 @@
     "rarity": "U",
     "image": "cPK_10_015010_00_YARUKIMONO_U.webp",
     "name": "Vigoroth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21122,7 +23768,8 @@
     "rarity": "R",
     "image": "cPK_10_015020_00_KEKKING_R.webp",
     "name": "Slaking",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21130,7 +23777,8 @@
     "rarity": "C",
     "image": "cPK_10_015030_00_PATCHEEL_C.webp",
     "name": "Spinda",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21138,7 +23786,8 @@
     "rarity": "R",
     "image": "cPK_10_015040_00_TORNELOS_R.webp",
     "name": "Tornadus",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21146,7 +23795,8 @@
     "rarity": "C",
     "image": "cPK_10_015050_00_HORUBEE_C.webp",
     "name": "Bunnelby",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21154,7 +23804,8 @@
     "rarity": "U",
     "image": "cPK_10_015060_00_HORUDO_U.webp",
     "name": "Diggersby",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21162,7 +23813,8 @@
     "rarity": "U",
     "image": "cPK_10_015070_00_TRIMMIEN_U.webp",
     "name": "Furfrou",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21170,7 +23822,8 @@
     "rarity": "C",
     "image": "cPK_10_015080_00_WAKKANEZUMI_C.webp",
     "name": "Tandemaus",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21178,7 +23831,8 @@
     "rarity": "U",
     "image": "cPK_10_015090_00_IKKANEZUMI_U.webp",
     "name": "Maushold",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21186,7 +23840,8 @@
     "rarity": "C",
     "image": "cTR_10_001050_00_AGONOKASEKI_C.webp",
     "name": "Jaw Fossil",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21194,7 +23849,8 @@
     "rarity": "U",
     "image": "cTR_10_001060_00_ATARITSUKIAISU_U.webp",
     "name": "Lucky Ice Pop",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21202,7 +23858,8 @@
     "rarity": "C",
     "image": "cTR_10_001070_00_HIRENOKASEKI_C.webp",
     "name": "Sail Fossil",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21210,7 +23867,8 @@
     "rarity": "U",
     "image": "cTR_10_001080_00_MAMORINOPONCHO_U.webp",
     "name": "Protective Poncho",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21218,7 +23876,8 @@
     "rarity": "U",
     "image": "cTR_10_001090_00_METARUKOABARIA_U.webp",
     "name": "Metal Core Barrier",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21226,7 +23885,8 @@
     "rarity": "U",
     "image": "cTR_10_001100_00_CARNE_U.webp",
     "name": "Diantha",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21234,7 +23894,8 @@
     "rarity": "U",
     "image": "cTR_10_001110_00_KANKOUKYAKU_U.webp",
     "name": "Sightseer",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21242,7 +23903,8 @@
     "rarity": "U",
     "image": "cTR_10_001120_00_JAGURA_U.webp",
     "name": "Juggler",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21250,7 +23912,8 @@
     "rarity": "U",
     "image": "cTR_10_001130_00_NEZU_U.webp",
     "name": "Piers",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21258,7 +23921,8 @@
     "rarity": "U",
     "image": "cTR_10_001140_00_TORENINGUERIA_U.webp",
     "name": "Training Area",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21266,7 +23930,8 @@
     "rarity": "U",
     "image": "cTR_10_001150_00_HAJIMARINOHEIGEN_U.webp",
     "name": "Starting Plains",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21274,7 +23939,8 @@
     "rarity": "U",
     "image": "cTR_10_001160_00_FUSHIGINAHIROBA_U.webp",
     "name": "Peculiar Plaza",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21282,7 +23948,8 @@
     "rarity": "AR",
     "image": "cPK_20_013720_00_SABONEA_AR.webp",
     "name": "Cacnea",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21290,7 +23957,8 @@
     "rarity": "AR",
     "image": "cPK_20_013710_00_ROSERADE_AR.webp",
     "name": "Roserade",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21298,7 +23966,8 @@
     "rarity": "AR",
     "image": "cPK_20_013790_00_VIVIYON_AR.webp",
     "name": "Vivillon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21306,7 +23975,8 @@
     "rarity": "AR",
     "image": "cPK_20_013800_00_MASSIVOON_AR.webp",
     "name": "Buzzwole",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21314,7 +23984,8 @@
     "rarity": "AR",
     "image": "cPK_20_013850_00_RESHIRAM_AR.webp",
     "name": "Reshiram",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21322,7 +23993,8 @@
     "rarity": "AR",
     "image": "cPK_20_013880_00_ODORIDORI_AR.webp",
     "name": "Oricorio",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21330,7 +24002,8 @@
     "rarity": "AR",
     "image": "cPK_20_013900_00_HIBANNY_AR.webp",
     "name": "Scorbunny",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21338,7 +24011,8 @@
     "rarity": "AR",
     "image": "cPK_20_014080_00_AMARURUGA_AR.webp",
     "name": "Aurorus",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21346,7 +24020,8 @@
     "rarity": "AR",
     "image": "cPK_20_014110_00_UU_AR.webp",
     "name": "Cramorant",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21354,7 +24029,8 @@
     "rarity": "AR",
     "image": "cPK_20_014190_00_MINUN_AR.webp",
     "name": "Minun",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21362,7 +24038,8 @@
     "rarity": "AR",
     "image": "cPK_20_014200_00_ELESON_AR.webp",
     "name": "Toxel",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21370,7 +24047,8 @@
     "rarity": "AR",
     "image": "cPK_20_014240_00_GALARPONYTA_AR.webp",
     "name": "Galarian Ponyta",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21378,7 +24056,8 @@
     "rarity": "AR",
     "image": "cPK_20_014270_00_BULU_AR.webp",
     "name": "Snubbull",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21386,7 +24065,8 @@
     "rarity": "AR",
     "image": "cPK_20_014420_00_YESSAN_AR.webp",
     "name": "Indeedee",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21394,7 +24074,8 @@
     "rarity": "AR",
     "image": "cPK_20_014430_00_SAND_AR.webp",
     "name": "Sandshrew",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21402,7 +24083,8 @@
     "rarity": "AR",
     "image": "cPK_20_014560_00_GACHIGORAS_AR.webp",
     "name": "Tyrantrum",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21410,7 +24092,8 @@
     "rarity": "AR",
     "image": "cPK_20_014580_00_TAIRETSU_AR.webp",
     "name": "Falinks",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21418,7 +24101,8 @@
     "rarity": "AR",
     "image": "cPK_20_014630_00_ALOLABETBETON_AR.webp",
     "name": "Alolan Muk",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21426,7 +24110,8 @@
     "rarity": "AR",
     "image": "cPK_20_014700_00_CHORONEKO_AR.webp",
     "name": "Purrloin",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21434,7 +24119,8 @@
     "rarity": "AR",
     "image": "cPK_20_014740_00_YVELTAL_AR.webp",
     "name": "Yveltal",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21442,7 +24128,8 @@
     "rarity": "AR",
     "image": "cPK_20_014660_00_GALARTACHIFUSAGUMA_AR.webp",
     "name": "Galarian Obstagoon",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21450,7 +24137,8 @@
     "rarity": "AR",
     "image": "cPK_20_014770_00_GALARNYAIKING_AR.webp",
     "name": "Galarian Perrserker",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21458,7 +24146,8 @@
     "rarity": "AR",
     "image": "cPK_20_014890_00_BOHMANDER_AR.webp",
     "name": "Salamence",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21466,7 +24155,8 @@
     "rarity": "AR",
     "image": "cPK_20_015000_00_NAMAKERO_AR.webp",
     "name": "Slakoth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21474,7 +24164,8 @@
     "rarity": "SR",
     "image": "cPK_20_013830_00_OGERPONMIDORINOMENex_SR.webp",
     "name": "Teal Mask Ogerpon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21482,7 +24173,8 @@
     "rarity": "SR",
     "image": "cPK_20_013890_00_ZUGADOONex_SR.webp",
     "name": "Blacephalon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21490,7 +24182,8 @@
     "rarity": "SR",
     "image": "cPK_20_013950_00_ALOLAKYUKONex_SR.webp",
     "name": "Alolan Ninetales ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21498,7 +24191,8 @@
     "rarity": "SR",
     "image": "cPK_20_014020_00_MEGALAGLARGEex_SR.webp",
     "name": "Mega Swampert ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21506,7 +24200,8 @@
     "rarity": "SR",
     "image": "cPK_20_014210_00_STRINDERex_SR.webp",
     "name": "Toxtricity ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21514,7 +24209,8 @@
     "rarity": "SR",
     "image": "cPK_20_014320_00_MEGASIRNIGHTex_SR.webp",
     "name": "Mega Gardevoir ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21522,7 +24218,8 @@
     "rarity": "SR",
     "image": "cPK_20_014390_00_MIMIKKYUex_SR.webp",
     "name": "Mimikyu ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21530,7 +24227,8 @@
     "rarity": "SR",
     "image": "cPK_20_014530_00_GIGAIATHex_SR.webp",
     "name": "Gigalith ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21538,7 +24236,8 @@
     "rarity": "SR",
     "image": "cPK_20_014790_00_MEGAKUCHEATex_SR.webp",
     "name": "Mega Mawile ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21546,7 +24245,8 @@
     "rarity": "SR",
     "image": "cPK_20_014930_00_MEGAGARURAex_SR.webp",
     "name": "Mega Kangaskhan ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21554,7 +24254,8 @@
     "rarity": "SR",
     "image": "cTR_20_001100_00_CARNE_SR.webp",
     "name": "Diantha",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21562,7 +24263,8 @@
     "rarity": "SR",
     "image": "cTR_20_001110_00_KANKOUKYAKU_SR.webp",
     "name": "Sightseer",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21570,7 +24272,8 @@
     "rarity": "SR",
     "image": "cTR_20_001120_00_JAGURA_SR.webp",
     "name": "Juggler",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21578,7 +24281,8 @@
     "rarity": "SR",
     "image": "cTR_20_001130_00_NEZU_SR.webp",
     "name": "Piers",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21586,7 +24290,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013830_01_OGERPONMIDORINOMENex_SAR.webp",
     "name": "Teal Mask Ogerpon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21594,7 +24299,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013890_01_ZUGADOONex_SAR.webp",
     "name": "Blacephalon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21602,7 +24308,8 @@
     "rarity": "SAR",
     "image": "cPK_20_013950_01_ALOLAKYUKONex_SAR.webp",
     "name": "Alolan Ninetales ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21610,7 +24317,8 @@
     "rarity": "SAR",
     "image": "cPK_20_014020_01_MEGALAGLARGEex_SAR.webp",
     "name": "Mega Swampert ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21618,7 +24326,8 @@
     "rarity": "SAR",
     "image": "cPK_20_014210_01_STRINDERex_SAR.webp",
     "name": "Toxtricity ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21626,7 +24335,8 @@
     "rarity": "SAR",
     "image": "cPK_20_014390_01_MIMIKKYUex_SAR.webp",
     "name": "Mimikyu ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21634,7 +24344,8 @@
     "rarity": "SAR",
     "image": "cPK_20_014530_01_GIGAIATHex_SAR.webp",
     "name": "Gigalith ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21642,7 +24353,8 @@
     "rarity": "SAR",
     "image": "cPK_20_014790_01_MEGAKUCHEATex_SAR.webp",
     "name": "Mega Mawile ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21650,7 +24362,8 @@
     "rarity": "SAR",
     "image": "cPK_20_014930_01_MEGAGARURAex_SAR.webp",
     "name": "Mega Kangaskhan ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21658,7 +24371,8 @@
     "rarity": "IM",
     "image": "cPK_20_014320_01_MEGASIRNIGHTex_IM.webp",
     "name": "Mega Gardevoir ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21666,7 +24380,8 @@
     "rarity": "IM",
     "image": "cPK_20_014900_00_NYARTH_IM.webp",
     "name": "Meowth",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21674,7 +24389,8 @@
     "rarity": "S",
     "image": "cPK_20_008600_00_MONJARA_S.webp",
     "name": "Tangela",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21682,7 +24398,8 @@
     "rarity": "S",
     "image": "cPK_20_008880_01_BUBY_S.webp",
     "name": "Magby",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21690,7 +24407,8 @@
     "rarity": "S",
     "image": "cPK_20_003040_00_BOOBER_S.webp",
     "name": "Magmar",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21698,7 +24416,8 @@
     "rarity": "S",
     "image": "cPK_20_008970_00_TATTU_S.webp",
     "name": "Horsea",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21706,7 +24425,8 @@
     "rarity": "S",
     "image": "cPK_20_008980_00_SEADRA_S.webp",
     "name": "Seadra",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21714,7 +24434,8 @@
     "rarity": "S",
     "image": "cPK_20_010420_01_TAMANTA_S.webp",
     "name": "Mantyke",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21722,7 +24443,8 @@
     "rarity": "S",
     "image": "cPK_20_000810_00_OMNITE_S.webp",
     "name": "Omanyte",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21730,7 +24452,8 @@
     "rarity": "S",
     "image": "cPK_20_000820_00_OMSTAR_S.webp",
     "name": "Omastar",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21738,7 +24461,8 @@
     "rarity": "S",
     "image": "cPK_20_009220_01_PICHU_S.webp",
     "name": "Pichu",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21746,7 +24470,8 @@
     "rarity": "S",
     "image": "cPK_20_001130_00_PIPPI_S.webp",
     "name": "Clefairy",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21754,7 +24479,8 @@
     "rarity": "S",
     "image": "cPK_20_001140_00_PIXY_S.webp",
     "name": "Clefable",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21762,7 +24488,8 @@
     "rarity": "S",
     "image": "cPK_20_010200_00_LATIAS_S.webp",
     "name": "Latias",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21770,7 +24497,8 @@
     "rarity": "S",
     "image": "cPK_20_010550_01_LATIOS_S.webp",
     "name": "Latios",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21778,7 +24506,8 @@
     "rarity": "S",
     "image": "cPK_20_001540_00_SAWAMULAR_S.webp",
     "name": "Hitmonlee",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21786,7 +24515,8 @@
     "rarity": "S",
     "image": "cPK_20_001550_00_EBIWALAR_S.webp",
     "name": "Hitmonchan",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21794,7 +24524,8 @@
     "rarity": "S",
     "image": "cPK_20_001580_00_KABUTO_S.webp",
     "name": "Kabuto",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21802,7 +24533,8 @@
     "rarity": "S",
     "image": "cPK_20_001590_00_KABUTOPS_S.webp",
     "name": "Kabutops",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21810,7 +24542,8 @@
     "rarity": "S",
     "image": "cPK_20_009550_00_GOMAZOU_S.webp",
     "name": "Phanpy",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21818,7 +24551,8 @@
     "rarity": "S",
     "image": "cPK_20_009570_00_BALKIE_S.webp",
     "name": "Tyrogue",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21826,7 +24560,8 @@
     "rarity": "S",
     "image": "cPK_20_002730_00_KENTAUROS_S.webp",
     "name": "Tauros",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21834,7 +24569,8 @@
     "rarity": "SSR",
     "image": "cPK_20_008050_02_BOOSTERex_SSR.webp",
     "name": "Flareon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21842,7 +24578,8 @@
     "rarity": "SSR",
     "image": "cPK_20_008900_04_HOUOUex_SSR.webp",
     "name": "Ho-Oh ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21850,7 +24587,8 @@
     "rarity": "SSR",
     "image": "cPK_20_008990_02_KINGDRAex_SSR.webp",
     "name": "Kingdra ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21858,7 +24596,8 @@
     "rarity": "SSR",
     "image": "cPK_20_009390_02_EIFIEex_SSR.webp",
     "name": "Espeon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21866,7 +24605,8 @@
     "rarity": "SSR",
     "image": "cPK_20_008280_02_NYMPHIAex_SSR.webp",
     "name": "Sylveon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21874,7 +24614,8 @@
     "rarity": "SSR",
     "image": "cPK_20_009560_02_DONFANex_SSR.webp",
     "name": "Donphan ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21882,7 +24623,8 @@
     "rarity": "SSR",
     "image": "cPK_20_009680_02_BRACKYex_SSR.webp",
     "name": "Umbreon ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21890,7 +24632,8 @@
     "rarity": "SSR",
     "image": "cPK_20_010050_04_LUGIAex_SSR.webp",
     "name": "Lugia ex",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21898,7 +24641,8 @@
     "rarity": "UR",
     "image": "cPK_20_014360_00_MELOETTA_UR.webp",
     "name": "Meloetta",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "B2",
@@ -21906,14 +24650,16 @@
     "rarity": "UR",
     "image": "cTR_20_001080_00_MAMORINOPONCHO_UR.webp",
     "name": "Protective Poncho",
-    "packs": ["Gardevoir"]
+    "packs": ["Gardevoir"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 1,
     "rarity": "AR",
     "name": "Pikachu",
-    "image": "cPK_90_004490_00_PIKACHU_AR.webp"
+    "image": "cPK_90_004490_00_PIKACHU_AR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -21921,7 +24667,8 @@
     "rarity": "C",
     "name": "Petilil",
     "image": "cPK_90_012930_00_CHURINE_C.webp",
-    "packs": ["B Series Vol. 1"]
+    "packs": ["B Series Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -21929,7 +24676,8 @@
     "rarity": "C",
     "name": "Froakie",
     "image": "cPK_90_012940_00_KEROMATSU_C.webp",
-    "packs": ["B Series Vol. 1"]
+    "packs": ["B Series Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -21937,7 +24685,8 @@
     "rarity": "R",
     "name": "Luxray",
     "image": "cPK_90_011700_00_RENTORAR_R.webp",
-    "packs": ["B Series Vol. 1"]
+    "packs": ["B Series Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -21945,7 +24694,8 @@
     "rarity": "C",
     "name": "Pidgey",
     "image": "cPK_90_012620_00_POPPO_C.webp",
-    "packs": ["B Series Vol. 1"]
+    "packs": ["B Series Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -21953,49 +24703,56 @@
     "rarity": "RR",
     "name": "Mega Pidgeot ex",
     "image": "cPK_90_012950_00_MEGAPIGEOTex_RR.webp",
-    "packs": ["B Series Vol. 1"]
+    "packs": ["B Series Vol. 1"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 7,
     "rarity": "R",
     "name": "Torchic",
-    "image": "cPK_90_011150_00_ACHAMO_R.webp"
+    "image": "cPK_90_011150_00_ACHAMO_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 8,
     "rarity": "R",
     "name": "Psyduck",
-    "image": "cPK_90_011300_00_KODUCK_R.webp"
+    "image": "cPK_90_011300_00_KODUCK_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 9,
     "rarity": "RR",
     "name": "Mega Absol ex",
-    "image": "cPK_90_012330_00_MEGAABSOLex_RR.webp"
+    "image": "cPK_90_012330_00_MEGAABSOLex_RR.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 10,
     "rarity": "R",
     "name": "Drifblim",
-    "image": "cPK_90_011900_00_FUWARIDE_R.webp"
+    "image": "cPK_90_011900_00_FUWARIDE_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 11,
     "rarity": "R",
     "name": "Eevee",
-    "image": "cPK_90_012660_00_EIEVUI_R.webp"
+    "image": "cPK_90_012660_00_EIEVUI_R.webp",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 12,
     "rarity": "AR",
     "image": "cPK_90_013060_00_METAMON_AR.webp",
-    "name": "Ditto"
+    "name": "Ditto",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22003,7 +24760,8 @@
     "rarity": "C",
     "image": "cPK_90_011110_00_WINDIE_C.webp",
     "name": "Arcanine",
-    "packs": ["B Series Vol. 2"]
+    "packs": ["B Series Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22011,7 +24769,8 @@
     "rarity": "C",
     "image": "cPK_90_012960_00_KOIKING_C.webp",
     "name": "Magikarp",
-    "packs": ["B Series Vol. 2"]
+    "packs": ["B Series Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22019,7 +24778,8 @@
     "rarity": "AR",
     "image": "cPK_90_011640_00_MERRIEP_AR.webp",
     "name": "Mareep",
-    "packs": ["B Series Vol. 2"]
+    "packs": ["B Series Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22027,7 +24787,8 @@
     "rarity": "R",
     "image": "cPK_90_012140_00_WARUVIAL_R.webp",
     "name": "Krookodile",
-    "packs": ["B Series Vol. 2"]
+    "packs": ["B Series Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22035,21 +24796,24 @@
     "rarity": "C",
     "image": "cPK_90_012970_00_TYLTTO_C.webp",
     "name": "Swablu",
-    "packs": ["B Series Vol. 2"]
+    "packs": ["B Series Vol. 2"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 18,
     "rarity": "R",
     "image": "cPK_90_013030_00_ELEZARD_R.webp",
-    "name": "Heliolisk"
+    "name": "Heliolisk",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 19,
     "rarity": "R",
     "image": "cPK_90_013040_00_MIMIROL_R.webp",
-    "name": "Buneary"
+    "name": "Buneary",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22057,7 +24821,8 @@
     "rarity": "C",
     "image": "cPK_90_012980_00_LIZARDO_C.webp",
     "name": "Charmeleon",
-    "packs": ["B Series Vol. 3"]
+    "packs": ["B Series Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22065,7 +24830,8 @@
     "rarity": "C",
     "image": "cPK_90_012990_00_IWARK_C.webp",
     "name": "Onix",
-    "packs": ["B Series Vol. 3"]
+    "packs": ["B Series Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22073,7 +24839,8 @@
     "rarity": "C",
     "image": "cPK_90_013000_00_LUCHABULL_C.webp",
     "name": "Hawlucha",
-    "packs": ["B Series Vol. 3"]
+    "packs": ["B Series Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22081,7 +24848,8 @@
     "rarity": "R",
     "image": "cPK_90_013010_00_GENESECT_R.webp",
     "name": "Genesect",
-    "packs": ["B Series Vol. 3"]
+    "packs": ["B Series Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22089,14 +24857,16 @@
     "rarity": "RR",
     "image": "cPK_90_013020_00_MEGALATIOSex_RR.webp",
     "name": "Mega Latios ex",
-    "packs": ["B Series Vol. 3"]
+    "packs": ["B Series Vol. 3"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 25,
     "rarity": "AR",
     "image": "cPK_90_011880_00_JIRACHI_AR.webp",
-    "name": "Jirachi"
+    "name": "Jirachi",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22104,7 +24874,8 @@
     "rarity": "C",
     "image": "cPK_90_015950_00_MIZUGOROU_C.webp",
     "name": "Mudkip",
-    "packs": ["B Series Vol. 4"]
+    "packs": ["B Series Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22112,7 +24883,8 @@
     "rarity": "C",
     "image": "cPK_90_014180_00_PRASLE_C.webp",
     "name": "Plusle",
-    "packs": ["B Series Vol. 4"]
+    "packs": ["B Series Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22120,7 +24892,8 @@
     "rarity": "C",
     "image": "cPK_90_015960_00_RALTS_C.webp",
     "name": "Ralts",
-    "packs": ["B Series Vol. 4"]
+    "packs": ["B Series Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22128,7 +24901,8 @@
     "rarity": "RR",
     "image": "cPK_90_015970_00_MEGACHAREMex_RR.webp",
     "name": "Mega Medicham ex",
-    "packs": ["B Series Vol. 4"]
+    "packs": ["B Series Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22136,28 +24910,32 @@
     "rarity": "R",
     "image": "cPK_90_015040_00_TORNELOS_R.webp",
     "name": "Tornadus",
-    "packs": ["B Series Vol. 4"]
+    "packs": ["B Series Vol. 4"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 31,
     "rarity": "R",
     "image": "cPK_90_013920_00_ACEBURN_R.webp",
-    "name": "Cinderace"
+    "name": "Cinderace",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 32,
     "rarity": "R",
     "image": "cPK_90_013940_00_ALOLAROKON_R.webp",
-    "name": "Alolan Vulpix"
+    "name": "Alolan Vulpix",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 33,
     "rarity": "AR",
     "image": "cPK_90_015310_00_KUWASSU_AR.webp",
-    "name": "Quaxly"
+    "name": "Quaxly",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22165,7 +24943,8 @@
     "rarity": "C",
     "image": "cPK_90_015980_00_MINIVE_C.webp",
     "name": "Smoliv",
-    "packs": ["B Series Vol. 5"]
+    "packs": ["B Series Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22173,7 +24952,8 @@
     "rarity": "AR",
     "image": "cPK_90_015280_00_CARBOU_AR.webp",
     "name": "Charcadet",
-    "packs": ["B Series Vol. 5"]
+    "packs": ["B Series Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22181,7 +24961,8 @@
     "rarity": "C",
     "image": "cPK_90_015420_00_SYARITATSU_C.webp",
     "name": "Tatsugiri",
-    "packs": ["B Series Vol. 5"]
+    "packs": ["B Series Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22189,7 +24970,8 @@
     "rarity": "C",
     "image": "cPK_90_015990_00_SEBIE_C.webp",
     "name": "Frigibax",
-    "packs": ["B Series Vol. 5"]
+    "packs": ["B Series Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22197,28 +24979,32 @@
     "rarity": "R",
     "image": "cPK_90_015830_00_DEKANUCHAN_R.webp",
     "name": "Tinkaton",
-    "packs": ["B Series Vol. 5"]
+    "packs": ["B Series Vol. 5"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 39,
     "rarity": "R",
     "image": "cPK_90_015470_00_PAMO_R.webp",
-    "name": "Pawmi"
+    "name": "Pawmi",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 40,
     "rarity": "R",
     "image": "cPK_90_015740_00_PALDEADOOH_R.webp",
-    "name": "Paldean Clodsire"
+    "name": "Paldean Clodsire",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 41,
     "rarity": "RR",
     "image": "cPK_90_015460_00_PAOJIANex_RR.webp",
-    "name": "Chien-Pao ex"
+    "name": "Chien-Pao ex",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22226,7 +25012,8 @@
     "rarity": "AR",
     "image": "cPK_90_016000_00_YADON_AR.webp",
     "name": "Slowpoke",
-    "packs": ["B Series Vol. 6"]
+    "packs": ["B Series Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22234,7 +25021,8 @@
     "rarity": "C",
     "image": "cPK_90_016010_00_RAKURAI_C.webp",
     "name": "Electrike",
-    "packs": ["B Series Vol. 6"]
+    "packs": ["B Series Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22242,7 +25030,8 @@
     "rarity": "C",
     "image": "cPK_90_016020_00_BURORON_C.webp",
     "name": "Varoom",
-    "packs": ["B Series Vol. 6"]
+    "packs": ["B Series Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22250,7 +25039,8 @@
     "rarity": "R",
     "image": "cPK_90_016030_00_ONONOKUS_R.webp",
     "name": "Haxorus",
-    "packs": ["B Series Vol. 6"]
+    "packs": ["B Series Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22258,28 +25048,32 @@
     "rarity": "C",
     "image": "cPK_90_016040_00_PERAP_C.webp",
     "name": "Chatot",
-    "packs": ["B Series Vol. 6"]
+    "packs": ["B Series Vol. 6"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 47,
     "rarity": "R",
     "image": "cPK_90_016050_00_GHOS_R.webp",
-    "name": "Gastly"
+    "name": "Gastly",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 48,
     "rarity": "R",
     "image": "cPK_90_016060_00_PUKURIN_R.webp",
-    "name": "Wigglytuff"
+    "name": "Wigglytuff",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 49,
     "rarity": "AR",
     "image": "cPK_90_016900_00_VICTINI_AR.webp",
-    "name": "Victini"
+    "name": "Victini",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22287,7 +25081,8 @@
     "rarity": "U",
     "image": "cPK_90_014360_00_MELOETTA_U.webp",
     "name": "Meloetta",
-    "packs": ["B Series Vol. 7"]
+    "packs": ["B Series Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22295,7 +25090,8 @@
     "rarity": "C",
     "image": "cPK_90_018860_00_ZYGARDE10%EF%BC%85FORME_C.webp",
     "name": "Zygarde",
-    "packs": ["B Series Vol. 7"]
+    "packs": ["B Series Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22303,7 +25099,8 @@
     "rarity": "R",
     "image": "cPK_90_018870_00_ZYGARDE50%EF%BC%85FORME_R.webp",
     "name": "Zygarde",
-    "packs": ["B Series Vol. 7"]
+    "packs": ["B Series Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22311,7 +25108,8 @@
     "rarity": "RR",
     "image": "cPK_90_018880_00_ZYGARDEPERFECTFORMEex_RR.webp",
     "name": "Zygarde ex",
-    "packs": ["B Series Vol. 7"]
+    "packs": ["B Series Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22319,14 +25117,16 @@
     "rarity": "C",
     "image": "cPK_90_012660_01_EIEVUI_C.webp",
     "name": "Eevee",
-    "packs": ["B Series Vol. 7"]
+    "packs": ["B Series Vol. 7"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 55,
     "rarity": "SR",
     "image": "cPK_90_018880_01_ZYGARDEPERFECTFORMEex_SR.webp",
-    "name": "Zygarde ex"
+    "name": "Zygarde ex",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22334,7 +25134,8 @@
     "rarity": "RR",
     "image": "cPK_90_018900_00_MEGAHERACROSex_RR.webp",
     "name": "Mega Heracross ex",
-    "packs": ["B Series Vol. 8"]
+    "packs": ["B Series Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22342,7 +25143,8 @@
     "rarity": "C",
     "image": "cPK_90_016890_00_POWALENTAIYOUNOSUGATA_C.webp",
     "name": "Castform Sunny Form",
-    "packs": ["B Series Vol. 8"]
+    "packs": ["B Series Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22350,7 +25152,8 @@
     "rarity": "C",
     "image": "cPK_90_018910_00_POKABU_C.webp",
     "name": "Tepig",
-    "packs": ["B Series Vol. 8"]
+    "packs": ["B Series Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22358,7 +25161,8 @@
     "rarity": "C",
     "image": "cPK_90_018920_00_ISHIZUMAI_C.webp",
     "name": "Dwebble",
-    "packs": ["B Series Vol. 8"]
+    "packs": ["B Series Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22366,28 +25170,32 @@
     "rarity": "R",
     "image": "cPK_90_017790_00_ZARUDE_R.webp",
     "name": "Zarude",
-    "packs": ["B Series Vol. 8"]
+    "packs": ["B Series Vol. 8"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 61,
     "rarity": "R",
     "image": "cPK_90_016700_00_KIMORI_R.webp",
-    "name": "Treecko"
+    "name": "Treecko",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 62,
     "rarity": "R",
     "image": "cPK_90_017490_00_ERUREIDO_R.webp",
-    "name": "Gallade"
+    "name": "Gallade",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 63,
     "rarity": "RR",
     "image": "cPK_90_015120_00_MASQUERNYAex_RR.webp",
-    "name": "Meowscarada ex"
+    "name": "Meowscarada ex",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22395,7 +25203,8 @@
     "rarity": "C",
     "image": "cPK_90_018930_00_CARBOU_C.webp",
     "name": "Charcadet",
-    "packs": ["B Series Vol. 9"]
+    "packs": ["B Series Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22403,7 +25212,8 @@
     "rarity": "C",
     "image": "cPK_90_018230_00_SHOWERS_C.webp",
     "name": "Vaporeon",
-    "packs": ["B Series Vol. 9"]
+    "packs": ["B Series Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22411,7 +25221,8 @@
     "rarity": "RR",
     "image": "cPK_90_018940_00_SOUBLADESex_RR.webp",
     "name": "Ceruledge ex",
-    "packs": ["B Series Vol. 9"]
+    "packs": ["B Series Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22419,7 +25230,8 @@
     "rarity": "C",
     "image": "cPK_90_018950_00_KOMATANA_C.webp",
     "name": "Pawniard",
-    "packs": ["B Series Vol. 9"]
+    "packs": ["B Series Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22427,28 +25239,32 @@
     "rarity": "R",
     "image": "cPK_90_018750_00_NOKOKOCCHI_R.webp",
     "name": "Dudunsparce",
-    "packs": ["B Series Vol. 9"]
+    "packs": ["B Series Vol. 9"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 69,
     "rarity": "R",
     "image": "cPK_90_015110_00_NYAROTE_R.webp",
-    "name": "Floragato"
+    "name": "Floragato",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 70,
     "rarity": "R",
     "image": "cPK_90_018550_00_YAMIRAMI_R.webp",
-    "name": "Sableye"
+    "name": "Sableye",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 71,
     "rarity": "AR",
     "image": "cPK_90_019030_00_KODUCK_AR.webp",
-    "name": "Psyduck"
+    "name": "Psyduck",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22456,7 +25272,8 @@
     "rarity": "C",
     "image": "cPK_90_018960_00_HINBASS_C.webp",
     "name": "Feebas",
-    "packs": ["B Series Vol. 10"]
+    "packs": ["B Series Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22464,7 +25281,8 @@
     "rarity": "R",
     "image": "cPK_90_018970_00_YUKIMENOKO_R.webp",
     "name": "Froslass",
-    "packs": ["B Series Vol. 10"]
+    "packs": ["B Series Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22472,7 +25290,8 @@
     "rarity": "U",
     "image": "cPK_90_018980_00_RAICHU_U.webp",
     "name": "Raichu",
-    "packs": ["B Series Vol. 10"]
+    "packs": ["B Series Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22480,7 +25299,8 @@
     "rarity": "C",
     "image": "cPK_90_018990_00_NUOH_C.webp",
     "name": "Quagsire",
-    "packs": ["B Series Vol. 10"]
+    "packs": ["B Series Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
@@ -22488,21 +25308,24 @@
     "rarity": "AR",
     "image": "cPK_90_019000_00_HISUIZORUA_AR.webp",
     "name": "Hisuian Zorua",
-    "packs": ["B Series Vol. 10"]
+    "packs": ["B Series Vol. 10"],
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 77,
     "rarity": "R",
     "image": "cPK_90_019010_00_GARDIE_R.webp",
-    "name": "Growlithe"
+    "name": "Growlithe",
+    "parallel": false
   },
   {
     "set": "PROMO-B",
     "number": 78,
     "rarity": "R",
     "image": "cPK_90_019020_00_EMOLGA_R.webp",
-    "name": "Emolga"
+    "name": "Emolga",
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22510,7 +25333,8 @@
     "rarity": "C",
     "image": "cPK_10_015100_00_NYAHOJA_C.webp",
     "name": "Sprigatito",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22518,7 +25342,8 @@
     "rarity": "C",
     "image": "cPK_10_015110_00_NYAROTE_C.webp",
     "name": "Floragato",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22526,7 +25351,8 @@
     "rarity": "RR",
     "image": "cPK_10_015120_00_MASQUERNYAex_RR.webp",
     "name": "Meowscarada ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22534,7 +25360,8 @@
     "rarity": "C",
     "image": "cPK_10_015130_00_TAMANTULA_C.webp",
     "name": "Tarountula",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22542,7 +25369,8 @@
     "rarity": "U",
     "image": "cPK_10_015140_00_WANAIDER_U.webp",
     "name": "Spidops",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22550,7 +25378,8 @@
     "rarity": "C",
     "image": "cPK_10_015150_00_MAMEBATTA_C.webp",
     "name": "Nymble",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22558,7 +25387,8 @@
     "rarity": "C",
     "image": "cPK_10_015160_00_MINIVE_C.webp",
     "name": "Smoliv",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22566,7 +25396,8 @@
     "rarity": "C",
     "image": "cPK_10_015170_00_OLINYO_C.webp",
     "name": "Dolliv",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22574,7 +25405,8 @@
     "rarity": "R",
     "image": "cPK_10_015180_00_OLIVA_R.webp",
     "name": "Arboliva",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22582,7 +25414,8 @@
     "rarity": "C",
     "image": "cPK_10_015190_00_ANOKUSA_C.webp",
     "name": "Bramblin",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22590,7 +25423,8 @@
     "rarity": "U",
     "image": "cPK_10_015200_00_ANOHORAGUSA_U.webp",
     "name": "Brambleghast",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22598,7 +25432,8 @@
     "rarity": "C",
     "image": "cPK_10_015210_00_CAPSAIJI_C.webp",
     "name": "Capsakid",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22606,7 +25441,8 @@
     "rarity": "U",
     "image": "cPK_10_015220_00_SCOVILLAIN_U.webp",
     "name": "Scovillain",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22614,7 +25450,8 @@
     "rarity": "C",
     "image": "cPK_10_015230_00_SHIGAROKO_C.webp",
     "name": "Rellor",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22622,7 +25459,8 @@
     "rarity": "R",
     "image": "cPK_10_015240_00_CHIONJEN_R.webp",
     "name": "Wo-Chien",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22630,7 +25468,8 @@
     "rarity": "C",
     "image": "cPK_10_015250_00_HOGATOR_C.webp",
     "name": "Fuecoco",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22638,7 +25477,8 @@
     "rarity": "C",
     "image": "cPK_10_015260_00_ACHIGATOR_C.webp",
     "name": "Crocalor",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22646,7 +25486,8 @@
     "rarity": "R",
     "image": "cPK_10_015270_00_LAUDBON_R.webp",
     "name": "Skeledirge",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22654,7 +25495,8 @@
     "rarity": "C",
     "image": "cPK_10_015280_00_CARBOU_C.webp",
     "name": "Charcadet",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22662,7 +25504,8 @@
     "rarity": "RR",
     "image": "cPK_10_015290_00_GURENARMAex_RR.webp",
     "name": "Armarouge ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22670,7 +25513,8 @@
     "rarity": "R",
     "image": "cPK_10_015300_00_YIYUI_R.webp",
     "name": "Chi-Yu",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22678,7 +25522,8 @@
     "rarity": "C",
     "image": "cPK_10_015310_00_KUWASSU_C.webp",
     "name": "Quaxly",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22686,7 +25531,8 @@
     "rarity": "C",
     "image": "cPK_10_015320_00_WELKAMO_C.webp",
     "name": "Quaxwell",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22694,7 +25540,8 @@
     "rarity": "R",
     "image": "cPK_10_015330_00_WANIVAL_R.webp",
     "name": "Quaquaval",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22702,7 +25549,8 @@
     "rarity": "C",
     "image": "cPK_10_015340_00_UMIDIGDA_C.webp",
     "name": "Wiglett",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22710,7 +25558,8 @@
     "rarity": "U",
     "image": "cPK_10_015350_00_UMITRIO_U.webp",
     "name": "Wugtrio",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22718,7 +25567,8 @@
     "rarity": "C",
     "image": "cPK_10_015360_00_NAMIIRUKA_C.webp",
     "name": "Finizen",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22726,7 +25576,8 @@
     "rarity": "R",
     "image": "cPK_10_015370_00_IRUKAMANMIGHTYFORME_R.webp",
     "name": "Palafin",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22734,7 +25585,8 @@
     "rarity": "C",
     "image": "cPK_10_015380_00_ARUKUJIRA_C.webp",
     "name": "Cetoddle",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22742,7 +25594,8 @@
     "rarity": "U",
     "image": "cPK_10_015390_00_HULKUJIRA_U.webp",
     "name": "Cetitan",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22750,7 +25603,8 @@
     "rarity": "U",
     "image": "cPK_10_015400_00_MIGALUSA_U.webp",
     "name": "Veluza",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22758,7 +25612,8 @@
     "rarity": "U",
     "image": "cPK_10_015410_00_HEYRUSHER_U.webp",
     "name": "Dondozo",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22766,7 +25621,8 @@
     "rarity": "U",
     "image": "cPK_10_015420_00_SYARITATSU_U.webp",
     "name": "Tatsugiri",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22774,7 +25630,8 @@
     "rarity": "C",
     "image": "cPK_10_015430_00_SEBIE_C.webp",
     "name": "Frigibax",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22782,7 +25639,8 @@
     "rarity": "C",
     "image": "cPK_10_015440_00_SEGOHRU_C.webp",
     "name": "Arctibax",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22790,7 +25648,8 @@
     "rarity": "R",
     "image": "cPK_10_015450_00_SEGLAIVE_R.webp",
     "name": "Baxcalibur",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22798,7 +25657,8 @@
     "rarity": "RR",
     "image": "cPK_10_015460_00_PAOJIANex_RR.webp",
     "name": "Chien-Pao ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22806,7 +25666,8 @@
     "rarity": "C",
     "image": "cPK_10_015470_00_PAMO_C.webp",
     "name": "Pawmi",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22814,7 +25675,8 @@
     "rarity": "C",
     "image": "cPK_10_015480_00_PAMOT_C.webp",
     "name": "Pawmo",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22822,7 +25684,8 @@
     "rarity": "U",
     "image": "cPK_10_015490_00_PARMOT_U.webp",
     "name": "Pawmot",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22830,7 +25693,8 @@
     "rarity": "C",
     "image": "cPK_10_015500_00_ZUPIKA_C.webp",
     "name": "Tadbulb",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22838,7 +25702,8 @@
     "rarity": "RR",
     "image": "cPK_10_015510_00_HARABARIEex_RR.webp",
     "name": "Bellibolt ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22846,7 +25711,8 @@
     "rarity": "C",
     "image": "cPK_10_015520_00_KAIDEN_C.webp",
     "name": "Wattrel",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22854,7 +25720,8 @@
     "rarity": "U",
     "image": "cPK_10_015530_00_TAIKAIDEN_U.webp",
     "name": "Kilowattrel",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22862,7 +25729,8 @@
     "rarity": "R",
     "image": "cPK_10_015540_00_MIRAIDONCOMPLETEMODE_R.webp",
     "name": "Miraidon",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22870,7 +25738,8 @@
     "rarity": "C",
     "image": "cPK_10_015550_00_PUPIMOCCHI_C.webp",
     "name": "Fidough",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22878,7 +25747,8 @@
     "rarity": "U",
     "image": "cPK_10_015560_00_BOWTZEL_U.webp",
     "name": "Dachsbun",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22886,7 +25756,8 @@
     "rarity": "R",
     "image": "cPK_10_015570_00_SOUBLADES_R.webp",
     "name": "Ceruledge",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22894,7 +25765,8 @@
     "rarity": "U",
     "image": "cPK_10_015580_00_BERACAS_U.webp",
     "name": "Rabsca",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22902,7 +25774,8 @@
     "rarity": "C",
     "image": "cPK_10_015590_00_HIRAHINA_C.webp",
     "name": "Flittle",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22910,7 +25783,8 @@
     "rarity": "U",
     "image": "cPK_10_015600_00_CUESPATRA_U.webp",
     "name": "Espathra",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22918,7 +25792,8 @@
     "rarity": "C",
     "image": "cPK_10_015610_00_BOCHI_C.webp",
     "name": "Greavard",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22926,7 +25801,8 @@
     "rarity": "U",
     "image": "cPK_10_015620_00_HAKADOG_U.webp",
     "name": "Houndstone",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22934,7 +25810,8 @@
     "rarity": "C",
     "image": "cPK_10_015630_00_COLLECUREI_C.webp",
     "name": "Gimmighoul",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22942,7 +25819,8 @@
     "rarity": "C",
     "image": "cPK_10_015640_00_MANKEY_C.webp",
     "name": "Mankey",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22950,7 +25828,8 @@
     "rarity": "C",
     "image": "cPK_10_015650_00_OKORIZARU_C.webp",
     "name": "Primeape",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22958,7 +25837,8 @@
     "rarity": "U",
     "image": "cPK_10_015660_00_KONOYOZARU_U.webp",
     "name": "Annihilape",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22966,7 +25846,8 @@
     "rarity": "U",
     "image": "cPK_10_015670_00_PALDEAKENTAUROS_U.webp",
     "name": "Paldean Tauros",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22974,7 +25855,8 @@
     "rarity": "C",
     "image": "cPK_10_015680_00_NONOKURAGE_C.webp",
     "name": "Toedscool",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22982,7 +25864,8 @@
     "rarity": "U",
     "image": "cPK_10_015690_00_RIKUKURAGE_U.webp",
     "name": "Toedscruel",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22990,7 +25873,8 @@
     "rarity": "C",
     "image": "cPK_10_015700_00_GAKEGANI_C.webp",
     "name": "Klawf",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -22998,7 +25882,8 @@
     "rarity": "R",
     "image": "cPK_10_015710_00_DINLU_R.webp",
     "name": "Ting-Lu",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23006,7 +25891,8 @@
     "rarity": "R",
     "image": "cPK_10_015720_00_KORAIDON_R.webp",
     "name": "Koraidon",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23014,7 +25900,8 @@
     "rarity": "C",
     "image": "cPK_10_015730_00_PALDEAUPAH_C.webp",
     "name": "Paldean Wooper",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23022,7 +25909,8 @@
     "rarity": "U",
     "image": "cPK_10_015740_00_PALDEADOOH_U.webp",
     "name": "Paldean Clodsire",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23030,7 +25918,8 @@
     "rarity": "U",
     "image": "cPK_10_015750_00_EXLEG_U.webp",
     "name": "Lokix",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23038,7 +25927,8 @@
     "rarity": "C",
     "image": "cPK_10_015760_00_ORACHIFU_C.webp",
     "name": "Maschiff",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23046,7 +25936,8 @@
     "rarity": "U",
     "image": "cPK_10_015770_00_MAFITIFF_U.webp",
     "name": "Mabosstiff",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23054,7 +25945,8 @@
     "rarity": "C",
     "image": "cPK_10_015780_00_SHIRUSHREW_C.webp",
     "name": "Shroodle",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23062,7 +25954,8 @@
     "rarity": "U",
     "image": "cPK_10_015790_00_TAGGINGRU_U.webp",
     "name": "Grafaiai",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23070,7 +25963,8 @@
     "rarity": "C",
     "image": "cPK_10_015800_00_OTOSHIDORI_C.webp",
     "name": "Bombirdier",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23078,7 +25972,8 @@
     "rarity": "C",
     "image": "cPK_10_015810_00_KANUCHAN_C.webp",
     "name": "Tinkatink",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23086,7 +25981,8 @@
     "rarity": "C",
     "image": "cPK_10_015820_00_NAKANUCHAN_C.webp",
     "name": "Tinkatuff",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23094,7 +25990,8 @@
     "rarity": "R",
     "image": "cPK_10_015830_00_DEKANUCHAN_R.webp",
     "name": "Tinkaton",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23102,7 +25999,8 @@
     "rarity": "C",
     "image": "cPK_10_015840_00_BURORON_C.webp",
     "name": "Varoom",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23110,7 +26008,8 @@
     "rarity": "U",
     "image": "cPK_10_015850_00_BUROROROOM_U.webp",
     "name": "Revavroom",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23118,7 +26017,8 @@
     "rarity": "U",
     "image": "cPK_10_015860_00_MIMIZUZU_U.webp",
     "name": "Orthworm",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23126,7 +26026,8 @@
     "rarity": "RR",
     "image": "cPK_10_015870_00_SURFUGOex_RR.webp",
     "name": "Gholdengo ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23134,7 +26035,8 @@
     "rarity": "C",
     "image": "cPK_10_015880_00_GOURTON_C.webp",
     "name": "Lechonk",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23142,7 +26044,8 @@
     "rarity": "C",
     "image": "cPK_10_015890_00_PERFUTONOSUNOSUGATA_C.webp",
     "name": "Oinkologne",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23150,7 +26053,8 @@
     "rarity": "C",
     "image": "cPK_10_015900_00_WAKKANEZUMI_C.webp",
     "name": "Tandemaus",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23158,7 +26062,8 @@
     "rarity": "U",
     "image": "cPK_10_015910_00_IKKANEZUMISANBIKIKAZOKU_U.webp",
     "name": "Maushold",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23166,7 +26071,8 @@
     "rarity": "C",
     "image": "cPK_10_015920_00_IKIRINKOGREENFEATHER_C.webp",
     "name": "Squawkabilly",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23174,7 +26080,8 @@
     "rarity": "U",
     "image": "cPK_10_015930_00_MOTOTOKAGE_U.webp",
     "name": "Cyclizar",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23182,7 +26089,8 @@
     "rarity": "C",
     "image": "cPK_10_015940_00_KARAMINGO_C.webp",
     "name": "Flamigo",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23190,7 +26098,8 @@
     "rarity": "U",
     "image": "cTR_10_001170_00_ELECTRICGENERATOR_U.webp",
     "name": "Electric Generator",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23198,7 +26107,8 @@
     "rarity": "U",
     "image": "cTR_10_001180_00_BIGAIRBALLOON_U.webp",
     "name": "Big Air Balloon",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23206,7 +26116,8 @@
     "rarity": "U",
     "image": "cTR_10_001190_00_TEAMSTARGRUNT_U.webp",
     "name": "Team Star Grunt",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23214,7 +26125,8 @@
     "rarity": "U",
     "image": "cTR_10_000420_02_NANJYAMO_U.webp",
     "name": "Iono",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23222,7 +26134,8 @@
     "rarity": "U",
     "image": "cTR_10_001200_00_NEMO_U.webp",
     "name": "Nemona",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23230,7 +26143,8 @@
     "rarity": "U",
     "image": "cTR_10_001210_00_PEPER_U.webp",
     "name": "Arven",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23238,7 +26152,8 @@
     "rarity": "U",
     "image": "cTR_10_000700_01_BOTAN_U.webp",
     "name": "Penny",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23246,7 +26161,8 @@
     "rarity": "U",
     "image": "cTR_10_001220_00_TABLECITY_U.webp",
     "name": "Mesagoza",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23254,7 +26170,8 @@
     "rarity": "AR",
     "image": "cPK_20_015250_00_HOGATOR_AR.webp",
     "name": "Fuecoco",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23262,7 +26179,8 @@
     "rarity": "AR",
     "image": "cPK_20_015610_00_BOCHI_AR.webp",
     "name": "Greavard",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23270,7 +26188,8 @@
     "rarity": "AR",
     "image": "cPK_20_015630_00_COLLECUREI_AR.webp",
     "name": "Gimmighoul",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23278,7 +26197,8 @@
     "rarity": "AR",
     "image": "cPK_20_015730_00_PALDEAUPAH_AR.webp",
     "name": "Paldean Wooper",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23286,7 +26206,8 @@
     "rarity": "AR",
     "image": "cPK_20_015860_00_MIMIZUZU_AR.webp",
     "name": "Orthworm",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23294,7 +26215,8 @@
     "rarity": "AR",
     "image": "cPK_20_015910_00_IKKANEZUMISANBIKIKAZOKU_AR.webp",
     "name": "Maushold",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23302,7 +26224,8 @@
     "rarity": "SR",
     "image": "cPK_20_015120_00_MASQUERNYAex_SR.webp",
     "name": "Meowscarada ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23310,7 +26233,8 @@
     "rarity": "SR",
     "image": "cPK_20_015290_00_GURENARMAex_SR.webp",
     "name": "Armarouge ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23318,7 +26242,8 @@
     "rarity": "SR",
     "image": "cPK_20_015460_00_PAOJIANex_SR.webp",
     "name": "Chien-Pao ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23326,7 +26251,8 @@
     "rarity": "SR",
     "image": "cPK_20_015510_00_HARABARIEex_SR.webp",
     "name": "Bellibolt ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23334,7 +26260,8 @@
     "rarity": "SR",
     "image": "cPK_20_015870_00_SURFUGOex_SR.webp",
     "name": "Gholdengo ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23342,7 +26269,8 @@
     "rarity": "SR",
     "image": "cTR_20_001190_00_TEAMSTARGRUNT_SR.webp",
     "name": "Team Star Grunt",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23350,7 +26278,8 @@
     "rarity": "SR",
     "image": "cTR_20_000420_01_NANJYAMO_SR.webp",
     "name": "Iono",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23358,7 +26287,8 @@
     "rarity": "SR",
     "image": "cTR_20_001200_00_NEMO_SR.webp",
     "name": "Nemona",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23366,7 +26296,8 @@
     "rarity": "SR",
     "image": "cTR_20_001210_00_PEPER_SR.webp",
     "name": "Arven",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23374,7 +26305,8 @@
     "rarity": "SR",
     "image": "cTR_20_000700_01_BOTAN_SR.webp",
     "name": "Penny",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23382,7 +26314,8 @@
     "rarity": "SAR",
     "image": "cPK_20_015120_01_MASQUERNYAex_SAR.webp",
     "name": "Meowscarada ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23390,7 +26323,8 @@
     "rarity": "SAR",
     "image": "cPK_20_015290_01_GURENARMAex_SAR.webp",
     "name": "Armarouge ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23398,7 +26332,8 @@
     "rarity": "SAR",
     "image": "cPK_20_015460_01_PAOJIANex_SAR.webp",
     "name": "Chien-Pao ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23406,7 +26341,8 @@
     "rarity": "SAR",
     "image": "cPK_20_015510_01_HARABARIEex_SAR.webp",
     "name": "Bellibolt ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23414,7 +26350,8 @@
     "rarity": "SAR",
     "image": "cPK_20_015870_01_SURFUGOex_SAR.webp",
     "name": "Gholdengo ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23422,7 +26359,8 @@
     "rarity": "IM",
     "image": "cTR_20_001210_01_PEPER_IM.webp",
     "name": "Arven",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23430,7 +26368,8 @@
     "rarity": "S",
     "image": "cPK_20_015100_00_NYAHOJA_S.webp",
     "name": "Sprigatito",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23438,7 +26377,8 @@
     "rarity": "S",
     "image": "cPK_20_015110_00_NYAROTE_S.webp",
     "name": "Floragato",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23446,7 +26386,8 @@
     "rarity": "S",
     "image": "cPK_20_005260_01_MASQUERNYA_S.webp",
     "name": "Meowscarada",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23454,7 +26395,8 @@
     "rarity": "S",
     "image": "cPK_20_015470_00_PAMO_S.webp",
     "name": "Pawmi",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23462,7 +26404,8 @@
     "rarity": "S",
     "image": "cPK_20_015480_00_PAMOT_S.webp",
     "name": "Pawmo",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23470,7 +26413,8 @@
     "rarity": "S",
     "image": "cPK_20_015490_00_PARMOT_S.webp",
     "name": "Pawmot",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23478,7 +26422,8 @@
     "rarity": "S",
     "image": "cPK_20_015630_01_COLLECUREI_S.webp",
     "name": "Gimmighoul",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23486,7 +26431,8 @@
     "rarity": "S",
     "image": "cPK_20_015810_00_KANUCHAN_S.webp",
     "name": "Tinkatink",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23494,7 +26440,8 @@
     "rarity": "S",
     "image": "cPK_20_015820_00_NAKANUCHAN_S.webp",
     "name": "Tinkatuff",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23502,7 +26449,8 @@
     "rarity": "S",
     "image": "cPK_20_005720_01_SURFUGO_S.webp",
     "name": "Gholdengo",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23510,7 +26458,8 @@
     "rarity": "SSR",
     "image": "cPK_20_010210_02_ENTEIex_SSR.webp",
     "name": "Entei ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23518,7 +26467,8 @@
     "rarity": "SSR",
     "image": "cPK_20_010400_02_SUICUNEex_SSR.webp",
     "name": "Suicune ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23526,7 +26476,8 @@
     "rarity": "SSR",
     "image": "cPK_20_010440_02_RAIKOUex_SSR.webp",
     "name": "Raikou ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23534,7 +26485,8 @@
     "rarity": "SSR",
     "image": "cPK_20_005690_02_DEKANUCHANex_SSR.webp",
     "name": "Tinkaton ex",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23542,7 +26494,8 @@
     "rarity": "UR",
     "image": "cPK_20_015450_00_SEGLAIVE_UR.webp",
     "name": "Baxcalibur",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2a",
@@ -23550,7 +26503,8 @@
     "rarity": "UR",
     "image": "cTR_20_001170_00_ELECTRICGENERATOR_UR.webp",
     "name": "Electric Generator",
-    "packs": ["Paldean"]
+    "packs": ["Paldean"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23558,7 +26512,8 @@
     "rarity": "C",
     "image": "cPK_10_016070_00_STRIKE_C.webp",
     "name": "Scyther",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23566,7 +26521,8 @@
     "rarity": "C",
     "image": "cPK_10_016080_00_KUNUGIDAMA_C.webp",
     "name": "Pineco",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23574,7 +26530,8 @@
     "rarity": "C",
     "image": "cPK_10_016090_00_BARUBEAT_C.webp",
     "name": "Volbeat",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23582,7 +26539,8 @@
     "rarity": "C",
     "image": "cPK_10_016100_00_ILLUMISE_C.webp",
     "name": "Illumise",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23590,7 +26548,8 @@
     "rarity": "C",
     "image": "cPK_10_016110_00_BOKUREI_C.webp",
     "name": "Phantump",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23598,7 +26557,8 @@
     "rarity": "U",
     "image": "cPK_10_016120_00_OHROT_U.webp",
     "name": "Trevenant",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23606,7 +26566,8 @@
     "rarity": "C",
     "image": "cPK_10_016130_00_HITOKAGE_C.webp",
     "name": "Charmander",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23614,7 +26575,8 @@
     "rarity": "U",
     "image": "cPK_10_016140_00_LIZARDO_U.webp",
     "name": "Charmeleon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23622,7 +26584,8 @@
     "rarity": "RR",
     "image": "cPK_10_016150_00_MEGALIZARDONXex_RR.webp",
     "name": "Mega Charizard X ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23630,7 +26593,8 @@
     "rarity": "C",
     "image": "cPK_10_016160_00_PONYTA_C.webp",
     "name": "Ponyta",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23638,7 +26602,8 @@
     "rarity": "C",
     "image": "cPK_10_016170_00_GALLOP_C.webp",
     "name": "Rapidash",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23646,7 +26611,8 @@
     "rarity": "C",
     "image": "cPK_10_016180_00_BOOBER_C.webp",
     "name": "Magmar",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23654,7 +26620,8 @@
     "rarity": "U",
     "image": "cPK_10_016190_00_BOOBURN_U.webp",
     "name": "Magmortar",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23662,7 +26629,8 @@
     "rarity": "C",
     "image": "cPK_10_016200_00_PALDEAKENTAUROS_C.webp",
     "name": "Paldean Tauros",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23670,7 +26638,8 @@
     "rarity": "C",
     "image": "cPK_10_016000_00_YADON_C.webp",
     "name": "Slowpoke",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23678,7 +26647,8 @@
     "rarity": "RR",
     "image": "cPK_10_016210_00_MEGAYADORANex_RR.webp",
     "name": "Mega Slowbro ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23686,7 +26656,8 @@
     "rarity": "U",
     "image": "cPK_10_016220_00_LAPLACE_U.webp",
     "name": "Lapras",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23694,7 +26665,8 @@
     "rarity": "C",
     "image": "cPK_10_016230_00_POCHAMA_C.webp",
     "name": "Piplup",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23702,7 +26674,8 @@
     "rarity": "U",
     "image": "cPK_10_016240_00_POTTAISHI_U.webp",
     "name": "Prinplup",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23710,7 +26683,8 @@
     "rarity": "R",
     "image": "cPK_10_016250_00_EMPERTE_R.webp",
     "name": "Empoleon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23718,7 +26692,8 @@
     "rarity": "U",
     "image": "cPK_10_016260_00_PHIONE_U.webp",
     "name": "Phione",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23726,7 +26701,8 @@
     "rarity": "C",
     "image": "cPK_10_016270_00_PIKACHU_C.webp",
     "name": "Pikachu",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23734,7 +26710,8 @@
     "rarity": "U",
     "image": "cPK_10_016280_00_RAICHU_U.webp",
     "name": "Raichu",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23742,7 +26719,8 @@
     "rarity": "C",
     "image": "cPK_10_016290_00_ELEBOO_C.webp",
     "name": "Electabuzz",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23750,7 +26728,8 @@
     "rarity": "U",
     "image": "cPK_10_016300_00_ELEKIBLE_U.webp",
     "name": "Electivire",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23758,7 +26737,8 @@
     "rarity": "C",
     "image": "cPK_10_016310_00_RAKURAI_C.webp",
     "name": "Electrike",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23766,7 +26746,8 @@
     "rarity": "RR",
     "image": "cPK_10_016320_00_MEGALIVOLTex_RR.webp",
     "name": "Mega Manectric ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23774,7 +26755,8 @@
     "rarity": "C",
     "image": "cPK_10_016330_00_SLEEPE_C.webp",
     "name": "Drowzee",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23782,7 +26764,8 @@
     "rarity": "U",
     "image": "cPK_10_016340_00_SLEEPER_U.webp",
     "name": "Hypno",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23790,7 +26773,8 @@
     "rarity": "R",
     "image": "cPK_10_016350_00_MEW_R.webp",
     "name": "Mew",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23798,7 +26782,8 @@
     "rarity": "C",
     "image": "cPK_10_016360_00_BANEBOO_C.webp",
     "name": "Spoink",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23806,7 +26791,8 @@
     "rarity": "U",
     "image": "cPK_10_016370_00_BOOPIG_U.webp",
     "name": "Grumpig",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23814,7 +26800,8 @@
     "rarity": "C",
     "image": "cPK_10_016380_00_DIGDA_C.webp",
     "name": "Diglett",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23822,7 +26809,8 @@
     "rarity": "U",
     "image": "cPK_10_016390_00_DUGTRIO_U.webp",
     "name": "Dugtrio",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23830,7 +26818,8 @@
     "rarity": "R",
     "image": "cPK_10_016400_00_GROUDON_R.webp",
     "name": "Groudon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23838,7 +26827,8 @@
     "rarity": "C",
     "image": "cPK_10_016410_00_LUCHABULL_C.webp",
     "name": "Hawlucha",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23846,7 +26836,8 @@
     "rarity": "C",
     "image": "cPK_10_016050_00_GHOS_C.webp",
     "name": "Gastly",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23854,7 +26845,8 @@
     "rarity": "U",
     "image": "cPK_10_016420_00_GHOST_U.webp",
     "name": "Haunter",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23862,7 +26854,8 @@
     "rarity": "RR",
     "image": "cPK_10_016430_00_MEGAGANGARex_RR.webp",
     "name": "Mega Gengar ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23870,7 +26863,8 @@
     "rarity": "R",
     "image": "cPK_10_016440_00_DARKRAI_R.webp",
     "name": "Darkrai",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23878,7 +26872,8 @@
     "rarity": "C",
     "image": "cPK_10_016450_00_YABUKURON_C.webp",
     "name": "Trubbish",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23886,7 +26881,8 @@
     "rarity": "C",
     "image": "cPK_10_016460_00_DUSTDAS_C.webp",
     "name": "Garbodor",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23894,7 +26890,8 @@
     "rarity": "C",
     "image": "cPK_10_016470_00_ZORUA_C.webp",
     "name": "Zorua",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23902,7 +26899,8 @@
     "rarity": "R",
     "image": "cPK_10_016480_00_ZOROARK_R.webp",
     "name": "Zoroark",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23910,7 +26908,8 @@
     "rarity": "C",
     "image": "cPK_10_016490_00_MORPEKO_C.webp",
     "name": "Morpeko",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23918,7 +26917,8 @@
     "rarity": "U",
     "image": "cPK_10_016500_00_FORETOS_U.webp",
     "name": "Forretress",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23926,7 +26926,8 @@
     "rarity": "RR",
     "image": "cPK_10_016510_00_MEGAHASSAMex_RR.webp",
     "name": "Mega Scizor ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23934,7 +26935,8 @@
     "rarity": "U",
     "image": "cPK_10_016520_00_KAMITURUGI_U.webp",
     "name": "Kartana",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23942,7 +26944,8 @@
     "rarity": "C",
     "image": "cPK_10_016530_00_BURORON_C.webp",
     "name": "Varoom",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23950,7 +26953,8 @@
     "rarity": "R",
     "image": "cPK_10_016540_00_BUROROROOM_R.webp",
     "name": "Revavroom",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23958,7 +26962,8 @@
     "rarity": "C",
     "image": "cPK_10_016550_00_MINIRYU_C.webp",
     "name": "Dratini",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23966,7 +26971,8 @@
     "rarity": "U",
     "image": "cPK_10_016560_00_HAKURYU_U.webp",
     "name": "Dragonair",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23974,7 +26980,8 @@
     "rarity": "R",
     "image": "cPK_10_016570_00_KAIRYU_R.webp",
     "name": "Dragonite",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23982,7 +26989,8 @@
     "rarity": "C",
     "image": "cPK_10_016580_00_KIBAGO_C.webp",
     "name": "Axew",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23990,7 +26998,8 @@
     "rarity": "U",
     "image": "cPK_10_016590_00_ONONDO_U.webp",
     "name": "Fraxure",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -23998,7 +27007,8 @@
     "rarity": "R",
     "image": "cPK_10_016030_00_ONONOKUS_R.webp",
     "name": "Haxorus",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24006,7 +27016,8 @@
     "rarity": "C",
     "image": "cPK_10_016600_00_CRIMGAN_C.webp",
     "name": "Druddigon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24014,7 +27025,8 @@
     "rarity": "C",
     "image": "cPK_10_016610_00_PURIN_C.webp",
     "name": "Jigglypuff",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24022,7 +27034,8 @@
     "rarity": "C",
     "image": "cPK_10_016060_00_PUKURIN_C.webp",
     "name": "Wigglytuff",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24030,7 +27043,8 @@
     "rarity": "U",
     "image": "cPK_10_016620_00_MILTANK_U.webp",
     "name": "Miltank",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24038,7 +27052,8 @@
     "rarity": "C",
     "image": "cPK_10_016040_00_PERAP_C.webp",
     "name": "Chatot",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24046,7 +27061,8 @@
     "rarity": "C",
     "image": "cPK_10_016630_00_CHILLARMY_C.webp",
     "name": "Minccino",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24054,7 +27070,8 @@
     "rarity": "C",
     "image": "cPK_10_016640_00_CHILLACCINO_C.webp",
     "name": "Cinccino",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24062,7 +27079,8 @@
     "rarity": "U",
     "image": "cPK_10_016650_00_TRIMMIEN_U.webp",
     "name": "Furfrou",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24070,7 +27088,8 @@
     "rarity": "U",
     "image": "cTR_10_001230_00_IJIWARULETTER_U.webp",
     "name": "Nasty Notice",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24078,7 +27097,8 @@
     "rarity": "U",
     "image": "cTR_10_001240_00_MAINTENANCE_U.webp",
     "name": "Maintenance",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24086,7 +27106,8 @@
     "rarity": "U",
     "image": "cTR_10_001250_00_IRIS_U.webp",
     "name": "Iris",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24094,7 +27115,8 @@
     "rarity": "U",
     "image": "cTR_10_001260_00_CALME_U.webp",
     "name": "Calem",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24102,7 +27124,8 @@
     "rarity": "U",
     "image": "cTR_10_001270_00_HAIKINGUCOURSE_U.webp",
     "name": "Hiking Trail",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24110,7 +27133,8 @@
     "rarity": "AR",
     "image": "cPK_20_016220_00_LAPLACE_AR.webp",
     "name": "Lapras",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24118,7 +27142,8 @@
     "rarity": "AR",
     "image": "cPK_20_016250_00_EMPERTE_AR.webp",
     "name": "Empoleon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24126,7 +27151,8 @@
     "rarity": "AR",
     "image": "cPK_20_016400_00_GROUDON_AR.webp",
     "name": "Groudon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24134,7 +27160,8 @@
     "rarity": "AR",
     "image": "cPK_20_016490_00_MORPEKO_AR.webp",
     "name": "Morpeko",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24142,7 +27169,8 @@
     "rarity": "AR",
     "image": "cPK_20_016540_00_BUROROROOM_AR.webp",
     "name": "Revavroom",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24150,7 +27178,8 @@
     "rarity": "AR",
     "image": "cPK_20_016620_00_MILTANK_AR.webp",
     "name": "Miltank",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24158,7 +27187,8 @@
     "rarity": "SR",
     "image": "cPK_20_016150_00_MEGALIZARDONXex_SR.webp",
     "name": "Mega Charizard X ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24166,7 +27196,8 @@
     "rarity": "SR",
     "image": "cPK_20_016210_00_MEGAYADORANex_SR.webp",
     "name": "Mega Slowbro ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24174,7 +27205,8 @@
     "rarity": "SR",
     "image": "cPK_20_016320_00_MEGALIVOLTex_SR.webp",
     "name": "Mega Manectric ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24182,7 +27214,8 @@
     "rarity": "SR",
     "image": "cPK_20_016430_00_MEGAGANGARex_SR.webp",
     "name": "Mega Gengar ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24190,7 +27223,8 @@
     "rarity": "SR",
     "image": "cPK_20_016510_00_MEGAHASSAMex_SR.webp",
     "name": "Mega Scizor ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24198,7 +27232,8 @@
     "rarity": "SR",
     "image": "cTR_20_001250_00_IRIS_SR.webp",
     "name": "Iris",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24206,7 +27241,8 @@
     "rarity": "SR",
     "image": "cTR_20_001260_00_CALME_SR.webp",
     "name": "Calem",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24214,7 +27250,8 @@
     "rarity": "SAR",
     "image": "cPK_20_016210_01_MEGAYADORANex_SAR.webp",
     "name": "Mega Slowbro ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24222,7 +27259,8 @@
     "rarity": "SAR",
     "image": "cPK_20_016320_01_MEGALIVOLTex_SAR.webp",
     "name": "Mega Manectric ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24230,7 +27268,8 @@
     "rarity": "IM",
     "image": "cPK_20_016350_00_MEW_IM.webp",
     "name": "Mew",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24238,7 +27277,8 @@
     "rarity": "IM",
     "image": "cPK_20_016350_01_MEW_IM.webp",
     "name": "Mew",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24246,7 +27286,8 @@
     "rarity": "S",
     "image": "cPK_20_016070_00_STRIKE_S.webp",
     "name": "Scyther",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24254,7 +27295,8 @@
     "rarity": "S",
     "image": "cPK_20_016080_00_KUNUGIDAMA_S.webp",
     "name": "Pineco",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24262,7 +27304,8 @@
     "rarity": "S",
     "image": "cPK_20_016110_00_BOKUREI_S.webp",
     "name": "Phantump",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24270,7 +27313,8 @@
     "rarity": "S",
     "image": "cPK_20_016120_00_OHROT_S.webp",
     "name": "Trevenant",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24278,7 +27322,8 @@
     "rarity": "S",
     "image": "cPK_20_016130_00_HITOKAGE_S.webp",
     "name": "Charmander",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24286,7 +27331,8 @@
     "rarity": "S",
     "image": "cPK_20_016140_00_LIZARDO_S.webp",
     "name": "Charmeleon",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24294,7 +27340,8 @@
     "rarity": "S",
     "image": "cPK_20_016160_00_PONYTA_S.webp",
     "name": "Ponyta",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24302,7 +27349,8 @@
     "rarity": "S",
     "image": "cPK_20_016170_00_GALLOP_S.webp",
     "name": "Rapidash",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24310,7 +27358,8 @@
     "rarity": "S",
     "image": "cPK_20_016000_00_YADON_S.webp",
     "name": "Slowpoke",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24318,7 +27367,8 @@
     "rarity": "S",
     "image": "cPK_20_016270_00_PIKACHU_S.webp",
     "name": "Pikachu",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24326,7 +27376,8 @@
     "rarity": "S",
     "image": "cPK_20_016280_00_RAICHU_S.webp",
     "name": "Raichu",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24334,7 +27385,8 @@
     "rarity": "S",
     "image": "cPK_20_016310_00_RAKURAI_S.webp",
     "name": "Electrike",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24342,7 +27394,8 @@
     "rarity": "S",
     "image": "cPK_20_016410_00_LUCHABULL_S.webp",
     "name": "Hawlucha",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24350,7 +27403,8 @@
     "rarity": "S",
     "image": "cPK_20_016050_00_GHOS_S.webp",
     "name": "Gastly",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24358,7 +27412,8 @@
     "rarity": "S",
     "image": "cPK_20_016420_00_GHOST_S.webp",
     "name": "Haunter",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24366,7 +27421,8 @@
     "rarity": "S",
     "image": "cPK_20_016470_00_ZORUA_S.webp",
     "name": "Zorua",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24374,7 +27430,8 @@
     "rarity": "S",
     "image": "cPK_20_016480_00_ZOROARK_S.webp",
     "name": "Zoroark",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24382,7 +27439,8 @@
     "rarity": "S",
     "image": "cPK_20_016500_00_FORETOS_S.webp",
     "name": "Forretress",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24390,7 +27448,8 @@
     "rarity": "S",
     "image": "cPK_20_016550_00_MINIRYU_S.webp",
     "name": "Dratini",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24398,7 +27457,8 @@
     "rarity": "S",
     "image": "cPK_20_016560_00_HAKURYU_S.webp",
     "name": "Dragonair",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24406,7 +27466,8 @@
     "rarity": "S",
     "image": "cPK_20_016570_00_KAIRYU_S.webp",
     "name": "Dragonite",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24414,7 +27475,8 @@
     "rarity": "S",
     "image": "cPK_20_016580_00_KIBAGO_S.webp",
     "name": "Axew",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24422,7 +27484,8 @@
     "rarity": "S",
     "image": "cPK_20_016590_00_ONONDO_S.webp",
     "name": "Fraxure",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24430,7 +27493,8 @@
     "rarity": "S",
     "image": "cPK_20_016030_00_ONONOKUS_S.webp",
     "name": "Haxorus",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24438,7 +27502,8 @@
     "rarity": "SSR",
     "image": "cPK_20_016150_01_MEGALIZARDONXex_SSR.webp",
     "name": "Mega Charizard X ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24446,7 +27511,8 @@
     "rarity": "SSR",
     "image": "cPK_20_016210_02_MEGAYADORANex_SSR.webp",
     "name": "Mega Slowbro ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24454,7 +27520,8 @@
     "rarity": "SSR",
     "image": "cPK_20_016320_02_MEGALIVOLTex_SSR.webp",
     "name": "Mega Manectric ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24462,7 +27529,8 @@
     "rarity": "SSR",
     "image": "cPK_20_016430_01_MEGAGANGARex_SSR.webp",
     "name": "Mega Gengar ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24470,7 +27538,8 @@
     "rarity": "SSR",
     "image": "cPK_20_016510_01_MEGAHASSAMex_SSR.webp",
     "name": "Mega Scizor ex",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24478,7 +27547,8 @@
     "rarity": "UR",
     "image": "cPK_20_015180_00_OLIVA_UR.webp",
     "name": "Arboliva",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B2b",
@@ -24486,7 +27556,8 @@
     "rarity": "UR",
     "image": "cTR_20_001090_00_METARUKOABARIA_UR.webp",
     "name": "Metal Core Barrier",
-    "packs": ["Mega Shine"]
+    "packs": ["Mega Shine"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24494,7 +27565,8 @@
     "rarity": "C",
     "image": "cPK_10_016660_00_MONJARA_C.webp",
     "name": "Tangela",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24502,7 +27574,8 @@
     "rarity": "U",
     "image": "cPK_10_016670_00_MOJUMBO_U.webp",
     "name": "Tangrowth",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24510,7 +27583,8 @@
     "rarity": "U",
     "image": "cPK_10_016680_00_HERACROS_U.webp",
     "name": "Heracross",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24518,7 +27592,8 @@
     "rarity": "R",
     "image": "cPK_10_016690_00_CELEBI_R.webp",
     "name": "Celebi",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24526,7 +27601,8 @@
     "rarity": "C",
     "image": "cPK_10_016700_00_KIMORI_C.webp",
     "name": "Treecko",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24534,7 +27610,8 @@
     "rarity": "U",
     "image": "cPK_10_016710_00_JUPTILE_U.webp",
     "name": "Grovyle",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24542,7 +27619,8 @@
     "rarity": "R",
     "image": "cPK_10_016720_00_JUKAIN_R.webp",
     "name": "Sceptile",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24550,7 +27628,8 @@
     "rarity": "RR",
     "image": "cPK_10_016730_00_MEGAJUKAINex_RR.webp",
     "name": "Mega Sceptile ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24558,7 +27637,8 @@
     "rarity": "C",
     "image": "cPK_10_016740_00_AMETAMA_C.webp",
     "name": "Surskit",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24566,7 +27646,8 @@
     "rarity": "C",
     "image": "cPK_10_016750_00_AMEMOTH_C.webp",
     "name": "Masquerain",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24574,7 +27655,8 @@
     "rarity": "C",
     "image": "cPK_10_016760_00_KINOCOCO_C.webp",
     "name": "Shroomish",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24582,7 +27664,8 @@
     "rarity": "U",
     "image": "cPK_10_016770_00_KINOGASSA_U.webp",
     "name": "Breloom",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24590,7 +27673,8 @@
     "rarity": "R",
     "image": "cPK_10_016780_00_SUBOMIE_R.webp",
     "name": "Budew",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24598,7 +27682,8 @@
     "rarity": "C",
     "image": "cPK_10_016790_00_MUSKIPPA_C.webp",
     "name": "Carnivine",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24606,7 +27691,8 @@
     "rarity": "C",
     "image": "cPK_10_016800_00_KURUMIRU_C.webp",
     "name": "Sewaddle",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24614,7 +27700,8 @@
     "rarity": "C",
     "image": "cPK_10_016810_00_KURUMAYU_C.webp",
     "name": "Swadloon",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24622,7 +27709,8 @@
     "rarity": "U",
     "image": "cPK_10_016820_00_HAHAKOMORI_U.webp",
     "name": "Leavanny",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24630,7 +27718,8 @@
     "rarity": "C",
     "image": "cPK_10_016830_00_AIANT_C.webp",
     "name": "Durant",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24638,7 +27727,8 @@
     "rarity": "C",
     "image": "cPK_10_016840_00_KAJICCHU_C.webp",
     "name": "Applin",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24646,7 +27736,8 @@
     "rarity": "R",
     "image": "cPK_10_016850_00_APPRYU_R.webp",
     "name": "Flapple",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24654,7 +27745,8 @@
     "rarity": "C",
     "image": "cPK_10_016860_00_DONMEL_C.webp",
     "name": "Numel",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24662,7 +27754,8 @@
     "rarity": "U",
     "image": "cPK_10_016870_00_BAKUUDA_U.webp",
     "name": "Camerupt",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24670,7 +27763,8 @@
     "rarity": "RR",
     "image": "cPK_10_016880_00_MEGABAKUUDAex_RR.webp",
     "name": "Mega Camerupt ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24678,7 +27772,8 @@
     "rarity": "C",
     "image": "cPK_10_016890_00_POWALENTAIYOUNOSUGATA_C.webp",
     "name": "Castform Sunny Form",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24686,7 +27781,8 @@
     "rarity": "R",
     "image": "cPK_10_016900_00_VICTINI_R.webp",
     "name": "Victini",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24694,7 +27790,8 @@
     "rarity": "C",
     "image": "cPK_10_016910_00_POKABU_C.webp",
     "name": "Tepig",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24702,7 +27799,8 @@
     "rarity": "U",
     "image": "cPK_10_016920_00_CHAOBOO_U.webp",
     "name": "Pignite",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24710,7 +27808,8 @@
     "rarity": "R",
     "image": "cPK_10_016930_00_ENBUOH_R.webp",
     "name": "Emboar",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24718,7 +27817,8 @@
     "rarity": "C",
     "image": "cPK_10_016940_00_DARUMAKKA_C.webp",
     "name": "Darumaka",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24726,7 +27826,8 @@
     "rarity": "U",
     "image": "cPK_10_016950_00_HIHIDARUMA_U.webp",
     "name": "Darmanitan",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24734,7 +27835,8 @@
     "rarity": "C",
     "image": "cPK_10_016960_00_MERLARVA_C.webp",
     "name": "Larvesta",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24742,7 +27844,8 @@
     "rarity": "U",
     "image": "cPK_10_016970_00_ULGAMOTH_U.webp",
     "name": "Volcarona",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24750,7 +27853,8 @@
     "rarity": "C",
     "image": "cPK_10_016980_00_NYOROMO_C.webp",
     "name": "Poliwag",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24758,7 +27862,8 @@
     "rarity": "U",
     "image": "cPK_10_016990_00_NYOROZO_U.webp",
     "name": "Poliwhirl",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24766,7 +27871,8 @@
     "rarity": "R",
     "image": "cPK_10_017000_00_NYOROTONO_R.webp",
     "name": "Politoed",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24774,7 +27880,8 @@
     "rarity": "U",
     "image": "cPK_10_017010_00_PALDEAKENTAUROS_U.webp",
     "name": "Paldean Tauros",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24782,7 +27889,8 @@
     "rarity": "RR",
     "image": "cPK_10_017020_00_SHOWERSex_RR.webp",
     "name": "Vaporeon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24790,7 +27898,8 @@
     "rarity": "C",
     "image": "cPK_10_017030_00_UPAH_C.webp",
     "name": "Wooper",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24798,7 +27907,8 @@
     "rarity": "U",
     "image": "cPK_10_017040_00_NUOH_U.webp",
     "name": "Quagsire",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24806,7 +27916,8 @@
     "rarity": "C",
     "image": "cPK_10_017050_00_POWALENAMAMIZUNOSUGATA_C.webp",
     "name": "Castform Rainy Form",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24814,7 +27925,8 @@
     "rarity": "C",
     "image": "cPK_10_017060_00_POWALENYUKIGUMONOSUGATA_C.webp",
     "name": "Castform Snowy Form",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24822,7 +27934,8 @@
     "rarity": "C",
     "image": "cPK_10_017070_00_PEARLULU_C.webp",
     "name": "Clamperl",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24830,7 +27943,8 @@
     "rarity": "U",
     "image": "cPK_10_017080_00_HUNTAIL_U.webp",
     "name": "Huntail",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24838,7 +27952,8 @@
     "rarity": "U",
     "image": "cPK_10_017090_00_SAKURABYSS_U.webp",
     "name": "Gorebyss",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24846,7 +27961,8 @@
     "rarity": "U",
     "image": "cPK_10_017100_00_REGICE_U.webp",
     "name": "Regice",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24854,7 +27970,8 @@
     "rarity": "C",
     "image": "cPK_10_017110_00_KUMASYUN_C.webp",
     "name": "Cubchoo",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24862,7 +27979,8 @@
     "rarity": "U",
     "image": "cPK_10_017120_00_TUNBEAR_U.webp",
     "name": "Beartic",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24870,7 +27988,8 @@
     "rarity": "C",
     "image": "cPK_10_017130_00_MESSON_C.webp",
     "name": "Sobble",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24878,7 +27997,8 @@
     "rarity": "U",
     "image": "cPK_10_017140_00_JIMEREON_U.webp",
     "name": "Drizzile",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24886,7 +28006,8 @@
     "rarity": "R",
     "image": "cPK_10_017150_00_INTEREON_R.webp",
     "name": "Inteleon",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24894,7 +28015,8 @@
     "rarity": "R",
     "image": "cPK_10_017160_00_WULAOSURENGEKINOKATA_R.webp",
     "name": "Rapid Strike Urshifu",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24902,7 +28024,8 @@
     "rarity": "C",
     "image": "cPK_10_017170_00_COIL_C.webp",
     "name": "Magnemite",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24910,7 +28033,8 @@
     "rarity": "U",
     "image": "cPK_10_017180_00_RARECOIL_U.webp",
     "name": "Magneton",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24918,7 +28042,8 @@
     "rarity": "RR",
     "image": "cPK_10_017190_00_JIBACOILex_RR.webp",
     "name": "Magnezone ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24926,7 +28051,8 @@
     "rarity": "C",
     "image": "cPK_10_017200_00_BIRIRIDAMA_C.webp",
     "name": "Voltorb",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24934,7 +28060,8 @@
     "rarity": "C",
     "image": "cPK_10_017210_00_MARUMINE_C.webp",
     "name": "Electrode",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24942,7 +28069,8 @@
     "rarity": "C",
     "image": "cPK_10_017220_00_CHONCHIE_C.webp",
     "name": "Chinchou",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24950,7 +28078,8 @@
     "rarity": "U",
     "image": "cPK_10_017230_00_LANTERN_U.webp",
     "name": "Lanturn",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24958,7 +28087,8 @@
     "rarity": "R",
     "image": "cPK_10_017240_00_ZEKROM_R.webp",
     "name": "Zekrom",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24966,7 +28096,8 @@
     "rarity": "C",
     "image": "cPK_10_017250_00_ELESON_C.webp",
     "name": "Toxel",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24974,7 +28105,8 @@
     "rarity": "R",
     "image": "cPK_10_017260_00_STRINDER_R.webp",
     "name": "Toxtricity",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24982,7 +28114,8 @@
     "rarity": "C",
     "image": "cPK_10_017270_00_MORPEKO_C.webp",
     "name": "Morpeko",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24990,7 +28123,8 @@
     "rarity": "C",
     "image": "cPK_10_017280_00_RALTS_C.webp",
     "name": "Ralts",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -24998,7 +28132,8 @@
     "rarity": "U",
     "image": "cPK_10_017290_00_KIRLIA_U.webp",
     "name": "Kirlia",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25006,7 +28141,8 @@
     "rarity": "C",
     "image": "cPK_10_017300_00_NYASPER_C.webp",
     "name": "Espurr",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25014,7 +28150,8 @@
     "rarity": "R",
     "image": "cPK_10_017310_00_NYAONIX_R.webp",
     "name": "Meowstic",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25022,7 +28159,8 @@
     "rarity": "R",
     "image": "cPK_10_017320_00_DIANCIE_R.webp",
     "name": "Diancie",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25030,7 +28168,8 @@
     "rarity": "C",
     "image": "cPK_10_017330_00_ODORIDORI_C.webp",
     "name": "Oricorio",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25038,7 +28177,8 @@
     "rarity": "C",
     "image": "cPK_10_017340_00_MIBRIM_C.webp",
     "name": "Hatenna",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25046,7 +28186,8 @@
     "rarity": "U",
     "image": "cPK_10_017350_00_TEBRIM_U.webp",
     "name": "Hattrem",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25054,7 +28195,8 @@
     "rarity": "R",
     "image": "cPK_10_017360_00_BRIMUON_R.webp",
     "name": "Hatterene",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25062,7 +28204,8 @@
     "rarity": "C",
     "image": "cPK_10_017370_00_ANOKUSA_C.webp",
     "name": "Bramblin",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25070,7 +28213,8 @@
     "rarity": "R",
     "image": "cPK_10_017380_00_ANOHORAGUSA_R.webp",
     "name": "Brambleghast",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25078,7 +28222,8 @@
     "rarity": "C",
     "image": "cPK_10_017390_00_GLIGER_C.webp",
     "name": "Gligar",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25086,7 +28231,8 @@
     "rarity": "U",
     "image": "cPK_10_017400_00_GLION_U.webp",
     "name": "Gliscor",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25094,7 +28240,8 @@
     "rarity": "C",
     "image": "cPK_10_017410_00_NUCKRAR_C.webp",
     "name": "Trapinch",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25102,7 +28249,8 @@
     "rarity": "U",
     "image": "cPK_10_017420_00_REGIROCK_U.webp",
     "name": "Regirock",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25110,7 +28258,8 @@
     "rarity": "R",
     "image": "cPK_10_017430_00_USOHACHI_R.webp",
     "name": "Bonsly",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25118,7 +28267,8 @@
     "rarity": "C",
     "image": "cPK_10_017440_00_RIOLU_C.webp",
     "name": "Riolu",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25126,7 +28276,8 @@
     "rarity": "R",
     "image": "cPK_10_017450_00_LUCARIO_R.webp",
     "name": "Lucario",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25134,7 +28285,8 @@
     "rarity": "RR",
     "image": "cPK_10_017460_00_MEGALUCARIOex_RR.webp",
     "name": "Mega Lucario ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25142,7 +28294,8 @@
     "rarity": "C",
     "image": "cPK_10_017470_00_GUREGGRU_C.webp",
     "name": "Croagunk",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25150,7 +28303,8 @@
     "rarity": "U",
     "image": "cPK_10_017480_00_DOKUROG_U.webp",
     "name": "Toxicroak",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25158,7 +28312,8 @@
     "rarity": "R",
     "image": "cPK_10_017490_00_ERUREIDO_R.webp",
     "name": "Gallade",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25166,7 +28321,8 @@
     "rarity": "C",
     "image": "cPK_10_017500_00_NAGEKI_C.webp",
     "name": "Throh",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25174,7 +28330,8 @@
     "rarity": "C",
     "image": "cPK_10_017510_00_DAGEKI_C.webp",
     "name": "Sawk",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25182,7 +28339,8 @@
     "rarity": "C",
     "image": "cPK_10_017520_00_ISHIZUMAI_C.webp",
     "name": "Dwebble",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25190,7 +28348,8 @@
     "rarity": "RR",
     "image": "cPK_10_017530_00_IWAPALACEex_RR.webp",
     "name": "Crustle ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25198,7 +28357,8 @@
     "rarity": "R",
     "image": "cPK_10_017540_00_MELOETTA_R.webp",
     "name": "Meloetta",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25206,7 +28366,8 @@
     "rarity": "C",
     "image": "cPK_10_017550_00_NUIKOGUMA_C.webp",
     "name": "Stufful",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25214,7 +28375,8 @@
     "rarity": "U",
     "image": "cPK_10_017560_00_KITERUGUMA_U.webp",
     "name": "Bewear",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25222,7 +28384,8 @@
     "rarity": "C",
     "image": "cPK_10_017570_00_TANDON_C.webp",
     "name": "Rolycoly",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25230,7 +28393,8 @@
     "rarity": "U",
     "image": "cPK_10_017580_00_TOROGGON_U.webp",
     "name": "Carkol",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25238,7 +28402,8 @@
     "rarity": "R",
     "image": "cPK_10_017590_00_SEKITANZAN_R.webp",
     "name": "Coalossal",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25246,7 +28411,8 @@
     "rarity": "C",
     "image": "cPK_10_017600_00_SUNAHEBI_C.webp",
     "name": "Silicobra",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25254,7 +28420,8 @@
     "rarity": "U",
     "image": "cPK_10_017610_00_SADAIJA_U.webp",
     "name": "Sandaconda",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25262,7 +28429,8 @@
     "rarity": "C",
     "image": "cPK_10_017620_00_DAKUMA_C.webp",
     "name": "Kubfu",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25270,7 +28438,8 @@
     "rarity": "C",
     "image": "cPK_10_017630_00_ZUBAT_C.webp",
     "name": "Zubat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25278,7 +28447,8 @@
     "rarity": "U",
     "image": "cPK_10_017640_00_GOLBAT_U.webp",
     "name": "Golbat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25286,7 +28456,8 @@
     "rarity": "R",
     "image": "cPK_10_017650_00_CROBAT_R.webp",
     "name": "Crobat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25294,7 +28465,8 @@
     "rarity": "C",
     "image": "cPK_10_017660_00_DOGARS_C.webp",
     "name": "Koffing",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25302,7 +28474,8 @@
     "rarity": "U",
     "image": "cPK_10_017670_00_MATADOGAS_U.webp",
     "name": "Weezing",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25310,7 +28483,8 @@
     "rarity": "C",
     "image": "cPK_10_017680_00_HARYSEN_C.webp",
     "name": "Qwilfish",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25318,7 +28492,8 @@
     "rarity": "C",
     "image": "cPK_10_017690_00_HABUNAKE_C.webp",
     "name": "Seviper",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25326,7 +28501,8 @@
     "rarity": "C",
     "image": "cPK_10_017700_00_ZORUA_C.webp",
     "name": "Zorua",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25334,7 +28510,8 @@
     "rarity": "RR",
     "image": "cPK_10_017710_00_ZOROARKex_RR.webp",
     "name": "Zoroark ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25342,7 +28519,8 @@
     "rarity": "C",
     "image": "cPK_10_017720_00_TAMAGETAKE_C.webp",
     "name": "Foongus",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25350,7 +28528,8 @@
     "rarity": "U",
     "image": "cPK_10_017730_00_MOROBARERU_U.webp",
     "name": "Amoonguss",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25358,7 +28537,8 @@
     "rarity": "C",
     "image": "cPK_10_017740_00_VALCHAI_C.webp",
     "name": "Vullaby",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25366,7 +28546,8 @@
     "rarity": "U",
     "image": "cPK_10_017750_00_VULGINA_U.webp",
     "name": "Mandibuzz",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25374,7 +28555,8 @@
     "rarity": "C",
     "image": "cPK_10_017760_00_MAAIIKA_C.webp",
     "name": "Inkay",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25382,7 +28564,8 @@
     "rarity": "U",
     "image": "cPK_10_017770_00_CALAMANERO_U.webp",
     "name": "Malamar",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25390,7 +28573,8 @@
     "rarity": "R",
     "image": "cPK_10_017780_00_WULAOSUICHIGEKINOKATA_R.webp",
     "name": "Single Strike Urshifu",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25398,7 +28582,8 @@
     "rarity": "R",
     "image": "cPK_10_017790_00_ZARUDE_R.webp",
     "name": "Zarude",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25406,7 +28591,8 @@
     "rarity": "R",
     "image": "cPK_10_017800_00_OTOSHIDORI_R.webp",
     "name": "Bombirdier",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25414,7 +28600,8 @@
     "rarity": "U",
     "image": "cPK_10_017810_00_REGISTEEL_U.webp",
     "name": "Registeel",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25422,7 +28609,8 @@
     "rarity": "C",
     "image": "cPK_10_017820_00_DOHMIRROR_C.webp",
     "name": "Bronzor",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25430,7 +28618,8 @@
     "rarity": "U",
     "image": "cPK_10_017830_00_DOHTAKUN_U.webp",
     "name": "Bronzong",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25438,7 +28627,8 @@
     "rarity": "C",
     "image": "cPK_10_017840_00_KOMATANA_C.webp",
     "name": "Pawniard",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25446,7 +28636,8 @@
     "rarity": "U",
     "image": "cPK_10_017850_00_KIRIKIZAN_U.webp",
     "name": "Bisharp",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25454,7 +28645,8 @@
     "rarity": "U",
     "image": "cPK_10_017860_00_MAGEARNA_U.webp",
     "name": "Magearna",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25462,7 +28654,8 @@
     "rarity": "C",
     "image": "cPK_10_017870_00_MELTAN_C.webp",
     "name": "Meltan",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25470,7 +28663,8 @@
     "rarity": "R",
     "image": "cPK_10_017880_00_MELMETAL_R.webp",
     "name": "Melmetal",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25478,7 +28672,8 @@
     "rarity": "RR",
     "image": "cPK_10_017890_00_ARMORGAex_RR.webp",
     "name": "Corviknight ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25486,7 +28681,8 @@
     "rarity": "U",
     "image": "cPK_10_017900_00_VIBRAVA_U.webp",
     "name": "Vibrava",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25494,7 +28690,8 @@
     "rarity": "RR",
     "image": "cPK_10_017910_00_FLYGONex_RR.webp",
     "name": "Flygon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25502,7 +28699,8 @@
     "rarity": "C",
     "image": "cPK_10_017920_00_LUCKY_C.webp",
     "name": "Chansey",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25510,7 +28708,8 @@
     "rarity": "R",
     "image": "cPK_10_017930_00_HAPPINAS_R.webp",
     "name": "Blissey",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25518,7 +28717,8 @@
     "rarity": "C",
     "image": "cPK_10_017940_00_EIEVUI_C.webp",
     "name": "Eevee",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25526,7 +28726,8 @@
     "rarity": "R",
     "image": "cPK_10_017950_00_NOKOCCHI_R.webp",
     "name": "Dunsparce",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25534,7 +28735,8 @@
     "rarity": "C",
     "image": "cPK_10_017960_00_HIMEGUMA_C.webp",
     "name": "Teddiursa",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25542,7 +28744,8 @@
     "rarity": "U",
     "image": "cPK_10_017970_00_RINGUMA_U.webp",
     "name": "Ursaring",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25550,7 +28753,8 @@
     "rarity": "C",
     "image": "cPK_10_017980_00_POWALEN_C.webp",
     "name": "Castform",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25558,7 +28762,8 @@
     "rarity": "R",
     "image": "cPK_10_017990_00_REGIGIGAS_R.webp",
     "name": "Regigigas",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25566,7 +28771,8 @@
     "rarity": "C",
     "image": "cPK_10_018000_00_MINEZUMI_C.webp",
     "name": "Patrat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25574,7 +28780,8 @@
     "rarity": "C",
     "image": "cPK_10_018010_00_MIRUHOG_C.webp",
     "name": "Watchog",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25582,7 +28789,8 @@
     "rarity": "C",
     "image": "cPK_10_018020_00_YORTERRIE_C.webp",
     "name": "Lillipup",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25590,7 +28798,8 @@
     "rarity": "U",
     "image": "cPK_10_018030_00_HERDERRIE_U.webp",
     "name": "Herdier",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25598,7 +28807,8 @@
     "rarity": "R",
     "image": "cPK_10_018040_00_MOOLAND_R.webp",
     "name": "Stoutland",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25606,7 +28816,8 @@
     "rarity": "U",
     "image": "cPK_10_018050_00_TABUNNE_U.webp",
     "name": "Audino",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25614,7 +28825,8 @@
     "rarity": "RR",
     "image": "cPK_10_018060_00_MEGATABUNNEex_RR.webp",
     "name": "Mega Audino ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25622,7 +28834,8 @@
     "rarity": "C",
     "image": "cPK_10_018070_00_CHILLARMY_C.webp",
     "name": "Minccino",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25630,7 +28843,8 @@
     "rarity": "C",
     "image": "cPK_10_018080_00_CHILLACCINO_C.webp",
     "name": "Cinccino",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25638,7 +28852,8 @@
     "rarity": "U",
     "image": "cPK_10_018090_00_TRIMMIEN_U.webp",
     "name": "Furfrou",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25646,7 +28861,8 @@
     "rarity": "C",
     "image": "cPK_10_018100_00_KOKOGARA_C.webp",
     "name": "Rookidee",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25654,7 +28870,8 @@
     "rarity": "U",
     "image": "cPK_10_018110_00_AOGARASU_U.webp",
     "name": "Corvisquire",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25662,7 +28879,8 @@
     "rarity": "U",
     "image": "cTR_10_001280_00_FIELDBLOWER_U.webp",
     "name": "Field Blower",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25670,7 +28888,8 @@
     "rarity": "U",
     "image": "cTR_10_001290_00_HAPPINESSEGG_U.webp",
     "name": "Lucky Egg",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25678,7 +28897,8 @@
     "rarity": "U",
     "image": "cTR_10_001300_00_CORNI_U.webp",
     "name": "Korrina",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25686,7 +28906,8 @@
     "rarity": "U",
     "image": "cTR_10_001310_00_TAXIDRIVER_U.webp",
     "name": "Cabbie",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25694,7 +28915,8 @@
     "rarity": "U",
     "image": "cTR_10_001320_00_CHEREN_U.webp",
     "name": "Cheren",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25702,7 +28924,8 @@
     "rarity": "U",
     "image": "cTR_10_001330_00_PARASOLGIRL_U.webp",
     "name": "Parasol Lady",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25710,7 +28933,8 @@
     "rarity": "U",
     "image": "cTR_10_001340_00_AMAKUKAORUMORI_U.webp",
     "name": "Fragrant Forest",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25718,7 +28942,8 @@
     "rarity": "U",
     "image": "cTR_10_001350_00_INISHIENOTOUGIJYOU_U.webp",
     "name": "Arena of Antiquity",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25726,7 +28951,8 @@
     "rarity": "U",
     "image": "cTR_10_001360_00_KEKKAINOFIELD_U.webp",
     "name": "Bounded Field",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25734,7 +28960,8 @@
     "rarity": "AR",
     "image": "cPK_20_016700_00_KIMORI_AR.webp",
     "name": "Treecko",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25742,7 +28969,8 @@
     "rarity": "AR",
     "image": "cPK_20_016710_00_JUPTILE_AR.webp",
     "name": "Grovyle",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25750,7 +28978,8 @@
     "rarity": "AR",
     "image": "cPK_20_016760_00_KINOCOCO_AR.webp",
     "name": "Shroomish",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25758,7 +28987,8 @@
     "rarity": "AR",
     "image": "cPK_20_016780_00_SUBOMIE_AR.webp",
     "name": "Budew",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25766,7 +28996,8 @@
     "rarity": "AR",
     "image": "cPK_20_016850_00_APPRYU_AR.webp",
     "name": "Flapple",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25774,7 +29005,8 @@
     "rarity": "AR",
     "image": "cPK_20_016910_00_POKABU_AR.webp",
     "name": "Tepig",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25782,7 +29014,8 @@
     "rarity": "AR",
     "image": "cPK_20_017040_00_NUOH_AR.webp",
     "name": "Quagsire",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25790,7 +29023,8 @@
     "rarity": "AR",
     "image": "cPK_20_017240_00_ZEKROM_AR.webp",
     "name": "Zekrom",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25798,7 +29032,8 @@
     "rarity": "AR",
     "image": "cPK_20_017270_00_MORPEKO_AR.webp",
     "name": "Morpeko",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25806,7 +29041,8 @@
     "rarity": "AR",
     "image": "cPK_20_017310_00_NYAONIX_AR.webp",
     "name": "Meowstic",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25814,7 +29050,8 @@
     "rarity": "AR",
     "image": "cPK_20_017330_00_ODORIDORI_AR.webp",
     "name": "Oricorio",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25822,7 +29059,8 @@
     "rarity": "AR",
     "image": "cPK_20_017380_00_ANOHORAGUSA_AR.webp",
     "name": "Brambleghast",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25830,7 +29068,8 @@
     "rarity": "AR",
     "image": "cPK_20_017430_00_USOHACHI_AR.webp",
     "name": "Bonsly",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25838,7 +29077,8 @@
     "rarity": "AR",
     "image": "cPK_20_017440_00_RIOLU_AR.webp",
     "name": "Riolu",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25846,7 +29086,8 @@
     "rarity": "AR",
     "image": "cPK_20_017540_00_MELOETTA_AR.webp",
     "name": "Meloetta",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25854,7 +29095,8 @@
     "rarity": "AR",
     "image": "cPK_20_017580_00_TOROGGON_AR.webp",
     "name": "Carkol",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25862,7 +29104,8 @@
     "rarity": "AR",
     "image": "cPK_20_017620_00_DAKUMA_AR.webp",
     "name": "Kubfu",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25870,7 +29113,8 @@
     "rarity": "AR",
     "image": "cPK_20_017690_00_HABUNAKE_AR.webp",
     "name": "Seviper",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25878,7 +29122,8 @@
     "rarity": "AR",
     "image": "cPK_20_017700_00_ZORUA_AR.webp",
     "name": "Zorua",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25886,7 +29131,8 @@
     "rarity": "AR",
     "image": "cPK_20_017770_00_CALAMANERO_AR.webp",
     "name": "Malamar",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25894,7 +29140,8 @@
     "rarity": "AR",
     "image": "cPK_20_017850_00_KIRIKIZAN_AR.webp",
     "name": "Bisharp",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25902,7 +29149,8 @@
     "rarity": "AR",
     "image": "cPK_20_017870_00_MELTAN_AR.webp",
     "name": "Meltan",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25910,7 +29158,8 @@
     "rarity": "AR",
     "image": "cPK_20_017980_00_POWALEN_AR.webp",
     "name": "Castform",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25918,7 +29167,8 @@
     "rarity": "AR",
     "image": "cPK_20_018080_00_CHILLACCINO_AR.webp",
     "name": "Cinccino",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25926,7 +29176,8 @@
     "rarity": "SR",
     "image": "cPK_20_016730_00_MEGAJUKAINex_SR.webp",
     "name": "Mega Sceptile ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25934,7 +29185,8 @@
     "rarity": "SR",
     "image": "cPK_20_016880_00_MEGABAKUUDAex_SR.webp",
     "name": "Mega Camerupt ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25942,7 +29194,8 @@
     "rarity": "SR",
     "image": "cPK_20_017020_00_SHOWERSex_SR.webp",
     "name": "Vaporeon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25950,7 +29203,8 @@
     "rarity": "SR",
     "image": "cPK_20_017190_00_JIBACOILex_SR.webp",
     "name": "Magnezone ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25958,7 +29212,8 @@
     "rarity": "SR",
     "image": "cPK_20_017460_00_MEGALUCARIOex_SR.webp",
     "name": "Mega Lucario ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25966,7 +29221,8 @@
     "rarity": "SR",
     "image": "cPK_20_017530_00_IWAPALACEex_SR.webp",
     "name": "Crustle ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25974,7 +29230,8 @@
     "rarity": "SR",
     "image": "cPK_20_017710_00_ZOROARKex_SR.webp",
     "name": "Zoroark ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25982,7 +29239,8 @@
     "rarity": "SR",
     "image": "cPK_20_017890_00_ARMORGAex_SR.webp",
     "name": "Corviknight ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25990,7 +29248,8 @@
     "rarity": "SR",
     "image": "cPK_20_017910_00_FLYGONex_SR.webp",
     "name": "Flygon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -25998,7 +29257,8 @@
     "rarity": "SR",
     "image": "cPK_20_018060_00_MEGATABUNNEex_SR.webp",
     "name": "Mega Audino ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26006,7 +29266,8 @@
     "rarity": "SR",
     "image": "cTR_20_001300_00_CORNI_SR.webp",
     "name": "Korrina",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26014,7 +29275,8 @@
     "rarity": "SR",
     "image": "cTR_20_001310_00_TAXIDRIVER_SR.webp",
     "name": "Cabbie",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26022,7 +29284,8 @@
     "rarity": "SR",
     "image": "cTR_20_001320_00_CHEREN_SR.webp",
     "name": "Cheren",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26030,7 +29293,8 @@
     "rarity": "SR",
     "image": "cTR_20_001330_00_PARASOLGIRL_SR.webp",
     "name": "Parasol Lady",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26038,7 +29302,8 @@
     "rarity": "SAR",
     "image": "cPK_20_016730_01_MEGAJUKAINex_SAR.webp",
     "name": "Mega Sceptile ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26046,7 +29311,8 @@
     "rarity": "SAR",
     "image": "cPK_20_016880_01_MEGABAKUUDAex_SAR.webp",
     "name": "Mega Camerupt ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26054,7 +29320,8 @@
     "rarity": "SAR",
     "image": "cPK_20_017020_01_SHOWERSex_SAR.webp",
     "name": "Vaporeon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26062,7 +29329,8 @@
     "rarity": "SAR",
     "image": "cPK_20_017190_01_JIBACOILex_SAR.webp",
     "name": "Magnezone ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26070,7 +29338,8 @@
     "rarity": "SAR",
     "image": "cPK_20_017530_01_IWAPALACEex_SAR.webp",
     "name": "Crustle ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26078,7 +29347,8 @@
     "rarity": "SAR",
     "image": "cPK_20_017710_01_ZOROARKex_SAR.webp",
     "name": "Zoroark ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26086,7 +29356,8 @@
     "rarity": "SAR",
     "image": "cPK_20_017890_01_ARMORGAex_SAR.webp",
     "name": "Corviknight ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26094,7 +29365,8 @@
     "rarity": "SAR",
     "image": "cPK_20_017910_01_FLYGONex_SAR.webp",
     "name": "Flygon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26102,7 +29374,8 @@
     "rarity": "SAR",
     "image": "cPK_20_018060_01_MEGATABUNNEex_SAR.webp",
     "name": "Mega Audino ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26110,7 +29383,8 @@
     "rarity": "IM",
     "image": "cPK_20_017130_00_MESSON_IM.webp",
     "name": "Sobble",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26118,7 +29392,8 @@
     "rarity": "IM",
     "image": "cPK_20_017460_01_MEGALUCARIOex_IM.webp",
     "name": "Mega Lucario ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26126,7 +29401,8 @@
     "rarity": "S",
     "image": "cPK_20_010970_00_MONMEN_S.webp",
     "name": "Cottonee",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26134,7 +29410,8 @@
     "rarity": "S",
     "image": "cPK_20_011150_00_ACHAMO_S.webp",
     "name": "Torchic",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26142,7 +29419,8 @@
     "rarity": "S",
     "image": "cPK_20_011160_00_WAKASYAMO_S.webp",
     "name": "Combusken",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26150,7 +29428,8 @@
     "rarity": "S",
     "image": "cPK_20_011170_00_BURSYAMO_S.webp",
     "name": "Blaziken",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26158,7 +29437,8 @@
     "rarity": "S",
     "image": "cPK_20_011500_00_PURURILL_S.webp",
     "name": "Frillish",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26166,7 +29446,8 @@
     "rarity": "S",
     "image": "cPK_20_011510_01_BURUNGEL_S.webp",
     "name": "Jellicent",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26174,7 +29455,8 @@
     "rarity": "S",
     "image": "cPK_20_013420_00_IWARK_S.webp",
     "name": "Onix",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26182,7 +29464,8 @@
     "rarity": "S",
     "image": "cPK_20_017630_00_ZUBAT_S.webp",
     "name": "Zubat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26190,7 +29473,8 @@
     "rarity": "S",
     "image": "cPK_20_017640_00_GOLBAT_S.webp",
     "name": "Golbat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26198,7 +29482,8 @@
     "rarity": "S",
     "image": "cPK_20_017650_00_CROBAT_S.webp",
     "name": "Crobat",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26206,7 +29491,8 @@
     "rarity": "S",
     "image": "cPK_20_013490_00_BETBETER_S.webp",
     "name": "Grimer",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26214,7 +29500,8 @@
     "rarity": "S",
     "image": "cPK_20_013500_00_BETBETON_S.webp",
     "name": "Muk",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26222,7 +29509,8 @@
     "rarity": "S",
     "image": "cPK_20_012320_00_ABSOL_S.webp",
     "name": "Absol",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26230,7 +29518,8 @@
     "rarity": "S",
     "image": "cPK_20_012410_00_KUZUMO_S.webp",
     "name": "Skrelp",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26238,7 +29527,8 @@
     "rarity": "S",
     "image": "cPK_20_013550_00_HAGANEIL_S.webp",
     "name": "Steelix",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26246,7 +29536,8 @@
     "rarity": "S",
     "image": "cPK_20_017920_00_LUCKY_S.webp",
     "name": "Chansey",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26254,7 +29545,8 @@
     "rarity": "S",
     "image": "cPK_20_017930_00_HAPPINAS_S.webp",
     "name": "Blissey",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26262,7 +29554,8 @@
     "rarity": "S",
     "image": "cPK_20_013580_00_PORYGON_S.webp",
     "name": "Porygon",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26270,7 +29563,8 @@
     "rarity": "S",
     "image": "cPK_20_013590_00_PORYGON2_S.webp",
     "name": "Porygon2",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26278,7 +29572,8 @@
     "rarity": "S",
     "image": "cPK_20_013600_00_PORYGON-Z_S.webp",
     "name": "Porygon-Z",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26286,7 +29581,8 @@
     "rarity": "SSR",
     "image": "cPK_20_010980_02_ELFUUNex_SSR.webp",
     "name": "Whimsicott ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26294,7 +29590,8 @@
     "rarity": "SSR",
     "image": "cPK_20_011180_02_MEGABURSYAMOex_SSR.webp",
     "name": "Mega Blaziken ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26302,7 +29599,8 @@
     "rarity": "SSR",
     "image": "cPK_20_011550_02_GEKKOUGAex_SSR.webp",
     "name": "Greninja ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26310,7 +29608,8 @@
     "rarity": "SSR",
     "image": "cPK_20_011630_02_THUNDERSex_SSR.webp",
     "name": "Jolteon ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26318,7 +29617,8 @@
     "rarity": "SSR",
     "image": "cPK_20_012060_02_EBIWALARex_SSR.webp",
     "name": "Hitmonchan ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26326,7 +29626,8 @@
     "rarity": "SSR",
     "image": "cPK_20_012330_02_MEGAABSOLex_SSR.webp",
     "name": "Mega Absol ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26334,7 +29635,8 @@
     "rarity": "SSR",
     "image": "cPK_20_012420_02_DRAMIDOROex_SSR.webp",
     "name": "Dragalge ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26342,7 +29644,8 @@
     "rarity": "SSR",
     "image": "cPK_20_013560_02_MEGAHAGANEILex_SSR.webp",
     "name": "Mega Steelix ex",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26350,7 +29653,8 @@
     "rarity": "UR",
     "image": "cPK_20_016690_00_CELEBI_UR.webp",
     "name": "Celebi",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3",
@@ -26358,7 +29662,8 @@
     "rarity": "UR",
     "image": "cPK_20_017800_00_OTOSHIDORI_UR.webp",
     "name": "Bombirdier",
-    "packs": ["Pulsing Aura"]
+    "packs": ["Pulsing Aura"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26366,7 +29671,8 @@
     "rarity": "C",
     "image": "cPK_10_018160_00_AMETAMA_C.webp",
     "name": "Surskit",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26374,7 +29680,8 @@
     "rarity": "C",
     "image": "cPK_10_018170_00_AMEMOTH_C.webp",
     "name": "Masquerain",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26382,7 +29689,8 @@
     "rarity": "C",
     "image": "cPK_10_018180_00_ARABURUTAKE_C.webp",
     "name": "Brute Bonnet",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26390,7 +29698,8 @@
     "rarity": "U",
     "image": "cPK_10_018190_00_CHIWOHAUHANE_U.webp",
     "name": "Slither Wing",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26398,7 +29707,8 @@
     "rarity": "U",
     "image": "cPK_10_018200_00_TETSUNODOKUGA_U.webp",
     "name": "Iron Moth",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26406,7 +29716,8 @@
     "rarity": "C",
     "image": "cPK_10_018210_00_KODUCK_C.webp",
     "name": "Psyduck",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26414,7 +29725,8 @@
     "rarity": "C",
     "image": "cPK_10_018220_00_GOLDUCK_C.webp",
     "name": "Golduck",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26422,7 +29734,8 @@
     "rarity": "U",
     "image": "cPK_10_018230_00_SHOWERS_U.webp",
     "name": "Vaporeon",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26430,7 +29743,8 @@
     "rarity": "C",
     "image": "cPK_10_018240_00_BUOYSEL_C.webp",
     "name": "Buizel",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26438,7 +29752,8 @@
     "rarity": "C",
     "image": "cPK_10_018250_00_FLOAZEL_C.webp",
     "name": "Floatzel",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26446,7 +29761,8 @@
     "rarity": "C",
     "image": "cPK_10_018260_00_YUKIHAMI_C.webp",
     "name": "Snom",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26454,7 +29770,8 @@
     "rarity": "C",
     "image": "cPK_10_018270_00_MOTHNOW_C.webp",
     "name": "Frosmoth",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26462,7 +29779,8 @@
     "rarity": "RR",
     "image": "cPK_10_018280_00_TETSUNOTSUTSUMIex_RR.webp",
     "name": "Iron Bundle ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26470,7 +29788,8 @@
     "rarity": "C",
     "image": "cPK_10_018290_00_PAMO_C.webp",
     "name": "Pawmi",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26478,7 +29797,8 @@
     "rarity": "C",
     "image": "cPK_10_018300_00_PAMOT_C.webp",
     "name": "Pawmo",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26486,7 +29806,8 @@
     "rarity": "U",
     "image": "cPK_10_018310_00_PARMOT_U.webp",
     "name": "Pawmot",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26494,7 +29815,8 @@
     "rarity": "C",
     "image": "cPK_10_018320_00_TETSUNOKAINA_C.webp",
     "name": "Iron Hands",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26502,7 +29824,8 @@
     "rarity": "U",
     "image": "cPK_10_018330_00_TETSUNOIBARA_U.webp",
     "name": "Iron Thorns",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26510,7 +29833,8 @@
     "rarity": "RR",
     "image": "cPK_10_018340_00_MIRAIDONex_RR.webp",
     "name": "Miraidon ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26518,7 +29842,8 @@
     "rarity": "U",
     "image": "cPK_10_018350_00_EIFIE_U.webp",
     "name": "Espeon",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26526,7 +29851,8 @@
     "rarity": "C",
     "image": "cPK_10_018360_00_HIRAHINA_C.webp",
     "name": "Flittle",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26534,7 +29860,8 @@
     "rarity": "U",
     "image": "cPK_10_018370_00_CUESPATRA_U.webp",
     "name": "Espathra",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26542,7 +29869,8 @@
     "rarity": "C",
     "image": "cPK_10_018380_00_BOCHI_C.webp",
     "name": "Greavard",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26550,7 +29878,8 @@
     "rarity": "U",
     "image": "cPK_10_018390_00_HAKADOG_U.webp",
     "name": "Houndstone",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26558,7 +29887,8 @@
     "rarity": "C",
     "image": "cPK_10_018400_00_SAKEBUSHIPPO_C.webp",
     "name": "Scream Tail",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26566,7 +29896,8 @@
     "rarity": "RR",
     "image": "cPK_10_018410_00_HABATAKUKAMIex_RR.webp",
     "name": "Flutter Mane ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26574,7 +29905,8 @@
     "rarity": "R",
     "image": "cPK_10_018420_00_TETSUNOBUJIN_R.webp",
     "name": "Iron Valiant",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26582,7 +29914,8 @@
     "rarity": "R",
     "image": "cPK_10_018430_00_TETSUNOISAHA_R.webp",
     "name": "Iron Leaves",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26590,7 +29923,8 @@
     "rarity": "R",
     "image": "cPK_10_018440_00_TETSUNOIWAO_R.webp",
     "name": "Iron Boulder",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26598,7 +29932,8 @@
     "rarity": "R",
     "image": "cPK_10_018450_00_TETSUNOKASHIRA_R.webp",
     "name": "Iron Crown",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26606,7 +29941,8 @@
     "rarity": "C",
     "image": "cPK_10_018460_00_KOJIO_C.webp",
     "name": "Nacli",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26614,7 +29950,8 @@
     "rarity": "C",
     "image": "cPK_10_018470_00_JIODUMU_C.webp",
     "name": "Naclstack",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26622,7 +29959,8 @@
     "rarity": "R",
     "image": "cPK_10_018480_00_KYOJIOHN_R.webp",
     "name": "Garganacl",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26630,7 +29968,8 @@
     "rarity": "U",
     "image": "cPK_10_018490_00_IDAINAKIBA_U.webp",
     "name": "Great Tusk",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26638,7 +29977,8 @@
     "rarity": "U",
     "image": "cPK_10_018500_00_SUNANOKEGAWA_U.webp",
     "name": "Sandy Shocks",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26646,7 +29986,8 @@
     "rarity": "RR",
     "image": "cPK_10_018510_00_KORAIDONex_RR.webp",
     "name": "Koraidon ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26654,7 +29995,8 @@
     "rarity": "U",
     "image": "cPK_10_018520_00_BRACKY_U.webp",
     "name": "Umbreon",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26662,7 +30004,8 @@
     "rarity": "C",
     "image": "cPK_10_018530_00_NYULA_C.webp",
     "name": "Sneasel",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26670,7 +30013,8 @@
     "rarity": "U",
     "image": "cPK_10_018540_00_MANYULA_U.webp",
     "name": "Weavile",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26678,7 +30022,8 @@
     "rarity": "U",
     "image": "cPK_10_018550_00_YAMIRAMI_U.webp",
     "name": "Sableye",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26686,7 +30031,8 @@
     "rarity": "C",
     "image": "cPK_10_018560_00_KOMATANA_C.webp",
     "name": "Pawniard",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26694,7 +30040,8 @@
     "rarity": "C",
     "image": "cPK_10_018570_00_KIRIKIZAN_C.webp",
     "name": "Bisharp",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26702,7 +30049,8 @@
     "rarity": "R",
     "image": "cPK_10_018580_00_DODOGEZAN_R.webp",
     "name": "Kingambit",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26710,7 +30058,8 @@
     "rarity": "C",
     "image": "cPK_10_018590_00_KIRAME_C.webp",
     "name": "Glimmet",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26718,7 +30067,8 @@
     "rarity": "R",
     "image": "cPK_10_018600_00_KIRAFLOR_R.webp",
     "name": "Glimmora",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26726,7 +30076,8 @@
     "rarity": "U",
     "image": "cPK_10_018610_00_TETSUNOKOUBE_U.webp",
     "name": "Iron Jugulis",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26734,7 +30085,8 @@
     "rarity": "R",
     "image": "cPK_10_018620_00_TODOROKUTSUKI_R.webp",
     "name": "Roaring Moon",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26742,7 +30094,8 @@
     "rarity": "U",
     "image": "cPK_10_018630_00_ARMORGA_U.webp",
     "name": "Corviknight",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26750,7 +30103,8 @@
     "rarity": "C",
     "image": "cPK_10_018640_00_ZOUDOU_C.webp",
     "name": "Cufant",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26758,7 +30112,8 @@
     "rarity": "U",
     "image": "cPK_10_018650_00_DAIOUDOU_U.webp",
     "name": "Copperajah",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26766,7 +30121,8 @@
     "rarity": "U",
     "image": "cPK_10_018660_00_TETSUNOWADACHI_U.webp",
     "name": "Iron Treads",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26774,7 +30130,8 @@
     "rarity": "U",
     "image": "cPK_10_018670_00_TYLTALIS_U.webp",
     "name": "Altaria",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26782,7 +30139,8 @@
     "rarity": "R",
     "image": "cPK_10_018680_00_UNERUMINAMO_R.webp",
     "name": "Walking Wake",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26790,7 +30148,8 @@
     "rarity": "R",
     "image": "cPK_10_018690_00_UGATSUHOMURA_R.webp",
     "name": "Gouging Fire",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26798,7 +30157,8 @@
     "rarity": "R",
     "image": "cPK_10_018700_00_TAKERURAIKO_R.webp",
     "name": "Raging Bolt",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26806,7 +30166,8 @@
     "rarity": "C",
     "image": "cPK_10_018710_00_EIEVUI_C.webp",
     "name": "Eevee",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26814,7 +30175,8 @@
     "rarity": "C",
     "image": "cPK_10_018720_00_KIRINRIKI_C.webp",
     "name": "Girafarig",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26822,7 +30184,8 @@
     "rarity": "C",
     "image": "cPK_10_018730_00_RIKIKIRIN_C.webp",
     "name": "Farigiraf",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26830,7 +30193,8 @@
     "rarity": "U",
     "image": "cPK_10_018740_00_NOKOCCHI_U.webp",
     "name": "Dunsparce",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26838,7 +30202,8 @@
     "rarity": "R",
     "image": "cPK_10_018750_00_NOKOKOCCHI_R.webp",
     "name": "Dudunsparce",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26846,7 +30211,8 @@
     "rarity": "C",
     "image": "cPK_10_018760_00_TYLTTO_C.webp",
     "name": "Swablu",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26854,7 +30220,8 @@
     "rarity": "C",
     "image": "cPK_10_018770_00_WASHIBON_C.webp",
     "name": "Rufflet",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26862,7 +30229,8 @@
     "rarity": "C",
     "image": "cPK_10_018780_00_WARRGLE_C.webp",
     "name": "Braviary",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26870,7 +30238,8 @@
     "rarity": "C",
     "image": "cPK_10_018790_00_LUCHABULL_C.webp",
     "name": "Hawlucha",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26878,7 +30247,8 @@
     "rarity": "C",
     "image": "cPK_10_018800_00_KOKOGARA_C.webp",
     "name": "Rookidee",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26886,7 +30256,8 @@
     "rarity": "C",
     "image": "cPK_10_018810_00_AOGARASU_C.webp",
     "name": "Corvisquire",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26894,7 +30265,8 @@
     "rarity": "C",
     "image": "cPK_10_018820_00_KARAMINGO_C.webp",
     "name": "Flamigo",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26902,7 +30274,8 @@
     "rarity": "RR",
     "image": "cPK_10_018830_00_TERAPAGOSex_RR.webp",
     "name": "Terapagos ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26910,7 +30283,8 @@
     "rarity": "U",
     "image": "cTR_10_001370_00_BUSUTOENAJIKODAI_U.webp",
     "name": "Ancient Booster Energy Capsule",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26918,7 +30292,8 @@
     "rarity": "U",
     "image": "cTR_10_001380_00_BUSUTOENAJIMIRAI_U.webp",
     "name": "Future Booster Energy Capsule",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26926,7 +30301,8 @@
     "rarity": "U",
     "image": "cTR_10_001390_00_AOI_U.webp",
     "name": "Juliana",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26934,7 +30310,8 @@
     "rarity": "U",
     "image": "cTR_10_001400_00_OLIMHAKASE_U.webp",
     "name": "Professor Sada",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26942,7 +30319,8 @@
     "rarity": "U",
     "image": "cTR_10_001410_00_FUTUHAKASE_U.webp",
     "name": "Professor Turo",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26950,7 +30328,8 @@
     "rarity": "U",
     "image": "cTR_10_001420_00_ERIAZERO_U.webp",
     "name": "Area Zero",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26958,7 +30337,8 @@
     "rarity": "AR",
     "image": "cPK_20_018260_00_YUKIHAMI_AR.webp",
     "name": "Snom",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26966,7 +30346,8 @@
     "rarity": "AR",
     "image": "cPK_20_018360_00_HIRAHINA_AR.webp",
     "name": "Flittle",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26974,7 +30355,8 @@
     "rarity": "AR",
     "image": "cPK_20_018440_00_TETSUNOIWAO_AR.webp",
     "name": "Iron Boulder",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26982,7 +30364,8 @@
     "rarity": "AR",
     "image": "cPK_20_018600_00_KIRAFLOR_AR.webp",
     "name": "Glimmora",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26990,7 +30373,8 @@
     "rarity": "AR",
     "image": "cPK_20_018700_00_TAKERURAIKO_AR.webp",
     "name": "Raging Bolt",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -26998,7 +30382,8 @@
     "rarity": "AR",
     "image": "cPK_20_018790_00_LUCHABULL_AR.webp",
     "name": "Hawlucha",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27006,7 +30391,8 @@
     "rarity": "SR",
     "image": "cPK_20_018280_00_TETSUNOTSUTSUMIex_SR.webp",
     "name": "Iron Bundle ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27014,7 +30400,8 @@
     "rarity": "SR",
     "image": "cPK_20_018340_00_MIRAIDONex_SR.webp",
     "name": "Miraidon ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27022,7 +30409,8 @@
     "rarity": "SR",
     "image": "cPK_20_018410_00_HABATAKUKAMIex_SR.webp",
     "name": "Flutter Mane ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27030,7 +30418,8 @@
     "rarity": "SR",
     "image": "cPK_20_018510_00_KORAIDONex_SR.webp",
     "name": "Koraidon ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27038,7 +30427,8 @@
     "rarity": "SR",
     "image": "cPK_20_018830_00_TERAPAGOSex_SR.webp",
     "name": "Terapagos ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27046,7 +30436,8 @@
     "rarity": "SR",
     "image": "cTR_20_001390_00_AOI_SR.webp",
     "name": "Juliana",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27054,7 +30445,8 @@
     "rarity": "SR",
     "image": "cTR_20_001400_00_OLIMHAKASE_SR.webp",
     "name": "Professor Sada",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27062,7 +30454,8 @@
     "rarity": "SR",
     "image": "cTR_20_001410_00_FUTUHAKASE_SR.webp",
     "name": "Professor Turo",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27070,7 +30463,8 @@
     "rarity": "SAR",
     "image": "cPK_20_018280_01_TETSUNOTSUTSUMIex_SAR.webp",
     "name": "Iron Bundle ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27078,7 +30472,8 @@
     "rarity": "SAR",
     "image": "cPK_20_018340_01_MIRAIDONex_SAR.webp",
     "name": "Miraidon ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27086,7 +30481,8 @@
     "rarity": "SAR",
     "image": "cPK_20_018410_01_HABATAKUKAMIex_SAR.webp",
     "name": "Flutter Mane ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27094,7 +30490,8 @@
     "rarity": "SAR",
     "image": "cPK_20_018510_01_KORAIDONex_SAR.webp",
     "name": "Koraidon ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27102,7 +30499,8 @@
     "rarity": "IM",
     "image": "cPK_20_018830_01_TERAPAGOSex_IM.webp",
     "name": "Terapagos ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27110,7 +30508,8 @@
     "rarity": "S",
     "image": "cPK_20_015230_00_SHIGAROKO_S.webp",
     "name": "Rellor",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27118,7 +30517,8 @@
     "rarity": "S",
     "image": "cPK_20_015280_00_CARBOU_S.webp",
     "name": "Charcadet",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27126,7 +30526,8 @@
     "rarity": "S",
     "image": "cPK_20_014220_00_ZUPIKA_S.webp",
     "name": "Tadbulb",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27134,7 +30535,8 @@
     "rarity": "S",
     "image": "cPK_20_015580_00_BERACAS_S.webp",
     "name": "Rabsca",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27142,7 +30544,8 @@
     "rarity": "S",
     "image": "cPK_20_016380_00_DIGDA_S.webp",
     "name": "Diglett",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27150,7 +30553,8 @@
     "rarity": "S",
     "image": "cPK_20_016390_00_DUGTRIO_S.webp",
     "name": "Dugtrio",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27158,7 +30562,8 @@
     "rarity": "S",
     "image": "cPK_20_015700_00_GAKEGANI_S.webp",
     "name": "Klawf",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27166,7 +30571,8 @@
     "rarity": "S",
     "image": "cPK_20_015860_01_MIMIZUZU_S.webp",
     "name": "Orthworm",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27174,7 +30580,8 @@
     "rarity": "S",
     "image": "cPK_20_012780_00_TYLTTO_S.webp",
     "name": "Swablu",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27182,7 +30589,8 @@
     "rarity": "S",
     "image": "cPK_20_012790_00_TYLTALIS_S.webp",
     "name": "Altaria",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27190,7 +30598,8 @@
     "rarity": "SSR",
     "image": "cPK_20_015120_02_MASQUERNYAex_SSR.webp",
     "name": "Meowscarada ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27198,7 +30607,8 @@
     "rarity": "SSR",
     "image": "cPK_20_015290_02_GURENARMAex_SSR.webp",
     "name": "Armarouge ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27206,7 +30616,8 @@
     "rarity": "SSR",
     "image": "cPK_20_015510_02_HARABARIEex_SSR.webp",
     "name": "Bellibolt ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27214,7 +30625,8 @@
     "rarity": "SSR",
     "image": "cPK_20_011840_02_MEGATYLTALISex_SSR.webp",
     "name": "Mega Altaria ex",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27222,7 +30634,8 @@
     "rarity": "UR",
     "image": "cPK_20_018420_00_TETSUNOBUJIN_UR.webp",
     "name": "Iron Valiant",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3a",
@@ -27230,7 +30643,8 @@
     "rarity": "UR",
     "image": "cPK_20_018620_00_TODOROKUTSUKI_UR.webp",
     "name": "Roaring Moon",
-    "packs": ["Paradox Drive"]
+    "packs": ["Paradox Drive"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27238,7 +30652,8 @@
     "rarity": "C",
     "image": "cPK_10_019040_00_CATERPIE_C.webp",
     "name": "Caterpie",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27246,7 +30661,8 @@
     "rarity": "U",
     "image": "cPK_10_019050_00_TRANSEL_U.webp",
     "name": "Metapod",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27254,7 +30670,8 @@
     "rarity": "R",
     "image": "cPK_10_019060_00_BUTTERFREE_R.webp",
     "name": "Butterfree",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27262,7 +30679,8 @@
     "rarity": "C",
     "image": "cPK_10_019070_00_SABONEA_C.webp",
     "name": "Cacnea",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27270,7 +30688,8 @@
     "rarity": "U",
     "image": "cPK_10_019080_00_TROPIUS_U.webp",
     "name": "Tropius",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27278,7 +30697,8 @@
     "rarity": "C",
     "image": "cPK_10_019090_00_CHURINE_C.webp",
     "name": "Petilil",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27286,7 +30706,8 @@
     "rarity": "U",
     "image": "cPK_10_019100_00_HISUIDREDEAR_U.webp",
     "name": "Hisuian Lilligant",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27294,7 +30715,8 @@
     "rarity": "C",
     "image": "cPK_10_019110_00_ROKON_C.webp",
     "name": "Vulpix",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27302,7 +30724,8 @@
     "rarity": "U",
     "image": "cPK_10_019120_00_KYUKON_U.webp",
     "name": "Ninetales",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27310,7 +30733,8 @@
     "rarity": "C",
     "image": "cPK_10_019010_00_GARDIE_C.webp",
     "name": "Growlithe",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27318,7 +30742,8 @@
     "rarity": "C",
     "image": "cPK_10_019030_00_KODUCK_C.webp",
     "name": "Psyduck",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27326,7 +30751,8 @@
     "rarity": "C",
     "image": "cPK_10_019130_00_TOSAKINTO_C.webp",
     "name": "Goldeen",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27334,7 +30760,8 @@
     "rarity": "U",
     "image": "cPK_10_019140_00_AZUMAO_U.webp",
     "name": "Seaking",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27342,7 +30769,8 @@
     "rarity": "C",
     "image": "cPK_10_019150_00_HINBASS_C.webp",
     "name": "Feebas",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27350,7 +30778,8 @@
     "rarity": "RR",
     "image": "cPK_10_019160_00_MILOKAROSSex_RR.webp",
     "name": "Milotic ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27358,7 +30787,8 @@
     "rarity": "C",
     "image": "cPK_10_019170_00_YUKIWARASHI_C.webp",
     "name": "Snorunt",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27366,7 +30796,8 @@
     "rarity": "R",
     "image": "cPK_10_018970_00_YUKIMENOKO_R.webp",
     "name": "Froslass",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27374,7 +30805,8 @@
     "rarity": "C",
     "image": "cPK_10_019180_00_LOVECUS_C.webp",
     "name": "Luvdisc",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27382,7 +30814,8 @@
     "rarity": "C",
     "image": "cPK_10_019190_00_POCHAMA_C.webp",
     "name": "Piplup",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27390,7 +30823,8 @@
     "rarity": "U",
     "image": "cPK_10_019200_00_TETSUNOTSUTSUMI_U.webp",
     "name": "Iron Bundle",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27398,7 +30832,8 @@
     "rarity": "C",
     "image": "cPK_10_019210_00_PIKACHU_C.webp",
     "name": "Pikachu",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27406,7 +30841,8 @@
     "rarity": "U",
     "image": "cPK_10_018980_00_RAICHU_U.webp",
     "name": "Raichu",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27414,7 +30850,8 @@
     "rarity": "C",
     "image": "cPK_10_019020_00_EMOLGA_C.webp",
     "name": "Emolga",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27422,7 +30859,8 @@
     "rarity": "RR",
     "image": "cPK_10_019220_00_DEDENNEex_RR.webp",
     "name": "Dedenne ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27430,7 +30868,8 @@
     "rarity": "C",
     "image": "cPK_10_019230_00_WANPACHI_C.webp",
     "name": "Yamper",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27438,7 +30877,8 @@
     "rarity": "C",
     "image": "cPK_10_019240_00_YADON_C.webp",
     "name": "Slowpoke",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27446,7 +30886,8 @@
     "rarity": "U",
     "image": "cPK_10_019250_00_YADORAN_U.webp",
     "name": "Slowbro",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27454,7 +30895,8 @@
     "rarity": "C",
     "image": "cPK_10_019260_00_MUNNA_C.webp",
     "name": "Munna",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27462,7 +30904,8 @@
     "rarity": "U",
     "image": "cPK_10_019270_00_MUSHARNA_U.webp",
     "name": "Musharna",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27470,7 +30913,8 @@
     "rarity": "R",
     "image": "cPK_10_019280_00_NYMPHIA_R.webp",
     "name": "Sylveon",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27478,7 +30922,8 @@
     "rarity": "U",
     "image": "cPK_10_019290_00_MELECIE_U.webp",
     "name": "Carbink",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27486,7 +30931,8 @@
     "rarity": "RR",
     "image": "cPK_10_019300_00_MEGADIANCIEex_RR.webp",
     "name": "Mega Diancie ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27494,7 +30940,8 @@
     "rarity": "R",
     "image": "cPK_10_019310_00_LOVETOLOS_R.webp",
     "name": "Enamorus",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27502,7 +30949,8 @@
     "rarity": "C",
     "image": "cPK_10_019320_00_PUPIMOCCHI_C.webp",
     "name": "Fidough",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27510,7 +30958,8 @@
     "rarity": "U",
     "image": "cPK_10_019330_00_HABATAKUKAMI_U.webp",
     "name": "Flutter Mane",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27518,7 +30967,8 @@
     "rarity": "C",
     "image": "cPK_10_019340_00_UPAH_C.webp",
     "name": "Wooper",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27526,7 +30976,8 @@
     "rarity": "U",
     "image": "cPK_10_019350_00_NUOH_U.webp",
     "name": "Quagsire",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27534,7 +30985,8 @@
     "rarity": "C",
     "image": "cPK_10_019360_00_IWANKO_C.webp",
     "name": "Rockruff",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27542,7 +30994,8 @@
     "rarity": "C",
     "image": "cPK_10_019370_00_SUNABA_C.webp",
     "name": "Sandygast",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27550,7 +31003,8 @@
     "rarity": "U",
     "image": "cPK_10_019380_00_SIRODETHNA_U.webp",
     "name": "Palossand",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27558,7 +31012,8 @@
     "rarity": "RR",
     "image": "cPK_10_019390_00_MEGAYAMIRAMIex_RR.webp",
     "name": "Mega Sableye ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27566,7 +31021,8 @@
     "rarity": "U",
     "image": "cPK_10_019400_00_NOCTUS_U.webp",
     "name": "Cacturne",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27574,7 +31030,8 @@
     "rarity": "U",
     "image": "cPK_10_019410_00_MIKARUGE_U.webp",
     "name": "Spiritomb",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27582,7 +31039,8 @@
     "rarity": "C",
     "image": "cPK_10_019420_00_ZURUGGU_C.webp",
     "name": "Scraggy",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27590,7 +31048,8 @@
     "rarity": "U",
     "image": "cPK_10_019430_00_ZURUZUKIN_U.webp",
     "name": "Scrafty",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27598,7 +31057,8 @@
     "rarity": "C",
     "image": "cPK_10_019440_00_HIDOIDE_C.webp",
     "name": "Mareanie",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27606,7 +31066,8 @@
     "rarity": "U",
     "image": "cPK_10_019450_00_DOHIDOIDE_U.webp",
     "name": "Toxapex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27614,7 +31075,8 @@
     "rarity": "C",
     "image": "cPK_10_019460_00_NUMERA_C.webp",
     "name": "Goomy",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27622,7 +31084,8 @@
     "rarity": "U",
     "image": "cPK_10_019470_00_HISUINUMEIL_U.webp",
     "name": "Hisuian Sliggoo",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27630,7 +31093,8 @@
     "rarity": "R",
     "image": "cPK_10_019480_00_HISUINUMELGON_R.webp",
     "name": "Hisuian Goodra",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27638,7 +31102,8 @@
     "rarity": "C",
     "image": "cPK_10_019490_00_PURIN_C.webp",
     "name": "Jigglypuff",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27646,7 +31111,8 @@
     "rarity": "U",
     "image": "cPK_10_019500_00_PUKURIN_U.webp",
     "name": "Wigglytuff",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27654,7 +31120,8 @@
     "rarity": "C",
     "image": "cPK_10_019510_00_EIEVUI_C.webp",
     "name": "Eevee",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27662,7 +31129,8 @@
     "rarity": "R",
     "image": "cPK_10_019520_00_GONBE_R.webp",
     "name": "Munchlax",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27670,7 +31138,8 @@
     "rarity": "R",
     "image": "cPK_10_019530_00_KABIGON_R.webp",
     "name": "Snorlax",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27678,7 +31147,8 @@
     "rarity": "C",
     "image": "cPK_10_019540_00_HIMEGUMA_C.webp",
     "name": "Teddiursa",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27686,7 +31156,8 @@
     "rarity": "U",
     "image": "cPK_10_019550_00_RINGUMA_U.webp",
     "name": "Ursaring",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27694,7 +31165,8 @@
     "rarity": "R",
     "image": "cPK_10_019560_00_GACHIGUMA_R.webp",
     "name": "Ursaluna",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27702,7 +31174,8 @@
     "rarity": "C",
     "image": "cPK_10_019000_00_HISUIZORUA_C.webp",
     "name": "Hisuian Zorua",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27710,7 +31183,8 @@
     "rarity": "RR",
     "image": "cPK_10_019570_00_HISUIZOROARKex_RR.webp",
     "name": "Hisuian Zoroark ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27718,7 +31192,8 @@
     "rarity": "C",
     "image": "cPK_10_019580_00_TRIMMIEN_C.webp",
     "name": "Furfrou",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27726,7 +31201,8 @@
     "rarity": "C",
     "image": "cPK_10_019590_00_HOSHIGARISU_C.webp",
     "name": "Skwovet",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27734,7 +31210,8 @@
     "rarity": "U",
     "image": "cPK_10_019600_00_YOKUBARISU_U.webp",
     "name": "Greedent",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27742,7 +31219,8 @@
     "rarity": "U",
     "image": "cTR_10_001430_00_CHIISANAFUUSEN_U.webp",
     "name": "Small Balloon",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27750,7 +31228,8 @@
     "rarity": "U",
     "image": "cTR_10_001440_00_YUUGANAMANTO_U.webp",
     "name": "Elegant Cape",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27758,7 +31237,8 @@
     "rarity": "U",
     "image": "cTR_10_001450_00_KAMITSURE_U.webp",
     "name": "Elesa",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27766,7 +31246,8 @@
     "rarity": "U",
     "image": "cTR_10_001460_00_KOINUDAISUKIGARL_U.webp",
     "name": "Puppy-Loving Girl",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27774,15 +31255,17 @@
     "rarity": "U",
     "image": "cTR_10_001470_00_MIKURI_U.webp",
     "name": "Wallace",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
     "number": 69,
     "rarity": "U",
     "image": "cTR_10_001480_00_KODOMOBEYA_U.webp",
-    "name": "Kid’s Room",
-    "packs": ["Everyday Wonders"]
+    "name": "Kid\u2019s Room",
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27790,7 +31273,8 @@
     "rarity": "AR",
     "image": "cPK_20_019110_00_ROKON_AR.webp",
     "name": "Vulpix",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27798,7 +31282,8 @@
     "rarity": "AR",
     "image": "cPK_20_019190_00_POCHAMA_AR.webp",
     "name": "Piplup",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27806,7 +31291,8 @@
     "rarity": "AR",
     "image": "cPK_20_019210_00_PIKACHU_AR.webp",
     "name": "Pikachu",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27814,7 +31300,8 @@
     "rarity": "AR",
     "image": "cPK_20_019280_00_NYMPHIA_AR.webp",
     "name": "Sylveon",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27822,7 +31309,8 @@
     "rarity": "AR",
     "image": "cPK_20_019440_00_HIDOIDE_AR.webp",
     "name": "Mareanie",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27830,7 +31318,8 @@
     "rarity": "AR",
     "image": "cPK_20_019490_00_PURIN_AR.webp",
     "name": "Jigglypuff",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27838,7 +31327,8 @@
     "rarity": "AR",
     "image": "cPK_20_019530_00_KABIGON_AR.webp",
     "name": "Snorlax",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27846,7 +31336,8 @@
     "rarity": "AR",
     "image": "cPK_20_019600_00_YOKUBARISU_AR.webp",
     "name": "Greedent",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27854,7 +31345,8 @@
     "rarity": "SR",
     "image": "cPK_20_019160_00_MILOKAROSSex_SR.webp",
     "name": "Milotic ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27862,7 +31354,8 @@
     "rarity": "SR",
     "image": "cPK_20_019220_00_DEDENNEex_SR.webp",
     "name": "Dedenne ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27870,7 +31363,8 @@
     "rarity": "SR",
     "image": "cPK_20_019300_00_MEGADIANCIEex_SR.webp",
     "name": "Mega Diancie ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27878,7 +31372,8 @@
     "rarity": "SR",
     "image": "cPK_20_019390_00_MEGAYAMIRAMIex_SR.webp",
     "name": "Mega Sableye ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27886,7 +31381,8 @@
     "rarity": "SR",
     "image": "cPK_20_019570_00_HISUIZOROARKex_SR.webp",
     "name": "Hisuian Zoroark ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27894,7 +31390,8 @@
     "rarity": "SR",
     "image": "cTR_20_001450_00_KAMITSURE_SR.webp",
     "name": "Elesa",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27902,7 +31399,8 @@
     "rarity": "SR",
     "image": "cTR_20_001460_00_KOINUDAISUKIGARL_SR.webp",
     "name": "Puppy-Loving Girl",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27910,7 +31408,8 @@
     "rarity": "SR",
     "image": "cTR_20_001470_00_MIKURI_SR.webp",
     "name": "Wallace",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27918,7 +31417,8 @@
     "rarity": "SAR",
     "image": "cPK_20_019160_01_MILOKAROSSex_SAR.webp",
     "name": "Milotic ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27926,7 +31426,8 @@
     "rarity": "SAR",
     "image": "cPK_20_019300_01_MEGADIANCIEex_SAR.webp",
     "name": "Mega Diancie ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27934,7 +31435,8 @@
     "rarity": "SAR",
     "image": "cPK_20_019390_01_MEGAYAMIRAMIex_SAR.webp",
     "name": "Mega Sableye ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27942,7 +31444,8 @@
     "rarity": "SAR",
     "image": "cPK_20_019570_01_HISUIZOROARKex_SAR.webp",
     "name": "Hisuian Zoroark ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27950,7 +31453,8 @@
     "rarity": "IM",
     "image": "cPK_20_019220_01_DEDENNEex_IM.webp",
     "name": "Dedenne ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27958,7 +31462,8 @@
     "rarity": "S",
     "image": "cPK_20_019040_00_CATERPIE_S.webp",
     "name": "Caterpie",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27966,7 +31471,8 @@
     "rarity": "S",
     "image": "cPK_20_019050_00_TRANSEL_S.webp",
     "name": "Metapod",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27974,7 +31480,8 @@
     "rarity": "S",
     "image": "cPK_20_019060_00_BUTTERFREE_S.webp",
     "name": "Butterfree",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27982,7 +31489,8 @@
     "rarity": "S",
     "image": "cPK_20_011640_00_MERRIEP_S.webp",
     "name": "Mareep",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27990,7 +31498,8 @@
     "rarity": "S",
     "image": "cPK_20_011650_00_MOKOKO_S.webp",
     "name": "Flaaffy",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -27998,7 +31507,8 @@
     "rarity": "S",
     "image": "cPK_20_011660_00_DENRYU_S.webp",
     "name": "Ampharos",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28006,7 +31516,8 @@
     "rarity": "S",
     "image": "cPK_20_019250_00_YADORAN_S.webp",
     "name": "Slowbro",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28014,7 +31525,8 @@
     "rarity": "S",
     "image": "cPK_20_014920_00_GARURA_S.webp",
     "name": "Kangaskhan",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28022,7 +31534,8 @@
     "rarity": "S",
     "image": "cPK_20_013060_00_METAMON_S.webp",
     "name": "Ditto",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28030,7 +31543,8 @@
     "rarity": "S",
     "image": "cPK_20_019530_01_KABIGON_S.webp",
     "name": "Snorlax",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28038,7 +31552,8 @@
     "rarity": "SSR",
     "image": "cPK_20_011340_02_MEGAGYARADOSex_SSR.webp",
     "name": "Mega Gyarados ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28046,7 +31561,8 @@
     "rarity": "SSR",
     "image": "cPK_20_017020_02_SHOWERSex_SSR.webp",
     "name": "Vaporeon ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28054,7 +31570,8 @@
     "rarity": "SSR",
     "image": "cPK_20_011670_02_MEGADENRYUex_SSR.webp",
     "name": "Mega Ampharos ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28062,7 +31579,8 @@
     "rarity": "SSR",
     "image": "cPK_20_012030_02_YESSANex_SSR.webp",
     "name": "Indeedee ex",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28070,7 +31588,8 @@
     "rarity": "UR",
     "image": "cPK_20_019520_00_GONBE_UR.webp",
     "name": "Munchlax",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   },
   {
     "set": "B3b",
@@ -28078,6 +31597,7 @@
     "rarity": "UR",
     "image": "cTR_20_001430_00_CHIISANAFUUSEN_UR.webp",
     "name": "Small Balloon",
-    "packs": ["Everyday Wonders"]
+    "packs": ["Everyday Wonders"],
+    "parallel": false
   }
 ]

--- a/dist/cards.json
+++ b/dist/cards.json
@@ -6,7 +6,8 @@
     "name": "Bulbasaur",
     "image": "cPK_10_000010_00_FUSHIGIDANE_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -15,7 +16,8 @@
     "name": "Ivysaur",
     "image": "cPK_10_000020_00_FUSHIGISOU_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -24,7 +26,8 @@
     "name": "Venusaur",
     "image": "cPK_10_000030_00_FUSHIGIBANA_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -33,7 +36,8 @@
     "name": "Venusaur ex",
     "image": "cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -42,7 +46,8 @@
     "name": "Caterpie",
     "image": "cPK_10_000050_00_CATERPIE_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -51,7 +56,8 @@
     "name": "Metapod",
     "image": "cPK_10_000060_00_TRANSEL_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -60,7 +66,8 @@
     "name": "Butterfree",
     "image": "cPK_10_000070_00_BUTTERFREE_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -69,7 +76,8 @@
     "name": "Weedle",
     "image": "cPK_10_000080_00_BEEDLE_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -78,7 +86,8 @@
     "name": "Kakuna",
     "image": "cPK_10_000090_00_COCOON_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -87,7 +96,8 @@
     "name": "Beedrill",
     "image": "cPK_10_000100_00_SPEAR_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -96,7 +106,8 @@
     "name": "Oddish",
     "image": "cPK_10_000110_00_NAZONOKUSA_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -105,7 +116,8 @@
     "name": "Gloom",
     "image": "cPK_10_000120_00_KUSAIHANA_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -114,7 +126,8 @@
     "name": "Vileplume",
     "image": "cPK_10_000130_00_RUFFRESIA_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -123,7 +136,8 @@
     "name": "Paras",
     "image": "cPK_10_000140_00_PARAS_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -132,7 +146,8 @@
     "name": "Parasect",
     "image": "cPK_10_000150_00_PARASECT_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -141,7 +156,8 @@
     "name": "Venonat",
     "image": "cPK_10_000160_00_KONGPANG_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -150,7 +166,8 @@
     "name": "Venomoth",
     "image": "cPK_10_000170_00_MORPHON_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -159,7 +176,8 @@
     "name": "Bellsprout",
     "image": "cPK_10_000180_00_MADATSUBOMI_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -168,7 +186,8 @@
     "name": "Weepinbell",
     "image": "cPK_10_000190_00_UTSUDON_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -177,7 +196,8 @@
     "name": "Victreebel",
     "image": "cPK_10_000200_00_UTSUBOT_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -186,7 +206,8 @@
     "name": "Exeggcute",
     "image": "cPK_10_000210_00_TAMATAMA_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -195,7 +216,8 @@
     "name": "Exeggutor",
     "image": "cPK_10_000220_00_NASSY_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -204,7 +226,8 @@
     "name": "Exeggutor ex",
     "image": "cPK_10_000230_00_NASSYex_RR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -213,7 +236,8 @@
     "name": "Tangela",
     "image": "cPK_10_000240_00_MONJARA_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -222,7 +246,8 @@
     "name": "Scyther",
     "image": "cPK_10_000250_00_STRIKE_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -231,7 +256,8 @@
     "name": "Pinsir",
     "image": "cPK_10_000260_00_KAILIOS_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -240,7 +266,8 @@
     "name": "Cottonee",
     "image": "cPK_10_000270_00_MONMEN_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -249,7 +276,8 @@
     "name": "Whimsicott",
     "image": "cPK_10_000280_00_ELFUUN_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -258,7 +286,8 @@
     "name": "Petilil",
     "image": "cPK_10_000290_00_CHURINE_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -267,7 +296,8 @@
     "name": "Lilligant",
     "image": "cPK_10_000300_00_DREDEAR_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -276,7 +306,8 @@
     "name": "Skiddo",
     "image": "cPK_10_000310_00_MEECLE_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -285,7 +316,8 @@
     "name": "Gogoat",
     "image": "cPK_10_000320_00_GOGOAT_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -294,7 +326,8 @@
     "name": "Charmander",
     "image": "cPK_10_000330_00_HITOKAGE_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -303,7 +336,8 @@
     "name": "Charmeleon",
     "image": "cPK_10_000340_00_LIZARDO_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -312,7 +346,8 @@
     "name": "Charizard",
     "image": "cPK_10_000350_00_LIZARDON_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -321,7 +356,8 @@
     "name": "Charizard ex",
     "image": "cPK_10_000360_00_LIZARDONex_RR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -330,7 +366,8 @@
     "name": "Vulpix",
     "image": "cPK_10_000370_00_ROKON_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -339,7 +376,8 @@
     "name": "Ninetales",
     "image": "cPK_10_000380_00_KYUKON_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -348,7 +386,8 @@
     "name": "Growlithe",
     "image": "cPK_10_000390_00_GARDIE_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -357,7 +396,8 @@
     "name": "Arcanine",
     "image": "cPK_10_000400_00_WINDIE_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -366,7 +406,8 @@
     "name": "Arcanine ex",
     "image": "cPK_10_000410_00_WINDIEex_RR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -375,7 +416,8 @@
     "name": "Ponyta",
     "image": "cPK_10_000420_00_PONYTA_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -384,7 +426,8 @@
     "name": "Rapidash",
     "image": "cPK_10_000430_00_GALLOP_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -393,7 +436,8 @@
     "name": "Magmar",
     "image": "cPK_10_000440_00_BOOBER_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -402,7 +446,8 @@
     "name": "Flareon",
     "image": "cPK_10_000450_00_BOOSTER_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -411,7 +456,8 @@
     "name": "Moltres",
     "image": "cPK_10_000460_00_FIRE_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -420,7 +466,8 @@
     "name": "Moltres ex",
     "image": "cPK_10_000470_00_FIREex_RR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -429,7 +476,8 @@
     "name": "Heatmor",
     "image": "cPK_10_000480_00_KUITARAN_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -438,7 +486,8 @@
     "name": "Salandit",
     "image": "cPK_10_000490_00_YATOUMORI_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -447,7 +496,8 @@
     "name": "Salazzle",
     "image": "cPK_10_000500_00_ENNEWT_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -456,7 +506,8 @@
     "name": "Sizzlipede",
     "image": "cPK_10_000510_00_YAKUDE_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -465,7 +516,8 @@
     "name": "Centiskorch",
     "image": "cPK_10_000520_00_MARUYAKUDE_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -474,7 +526,8 @@
     "name": "Squirtle",
     "image": "cPK_10_000530_00_ZENIGAME_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -483,7 +536,8 @@
     "name": "Wartortle",
     "image": "cPK_10_000540_00_KAMEIL_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -492,7 +546,8 @@
     "name": "Blastoise",
     "image": "cPK_10_000550_00_KAMEX_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -501,7 +556,8 @@
     "name": "Blastoise ex",
     "image": "cPK_10_000560_00_KAMEXex_RR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -510,7 +566,8 @@
     "name": "Psyduck",
     "image": "cPK_10_000570_00_KODUCK_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -519,7 +576,8 @@
     "name": "Golduck",
     "image": "cPK_10_000580_00_GOLDUCK_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -528,7 +586,8 @@
     "name": "Poliwag",
     "image": "cPK_10_000590_00_NYOROMO_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -537,7 +596,8 @@
     "name": "Poliwhirl",
     "image": "cPK_10_000600_00_NYOROZO_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -546,7 +606,8 @@
     "name": "Poliwrath",
     "image": "cPK_10_000610_00_NYOROBON_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -555,7 +616,8 @@
     "name": "Tentacool",
     "image": "cPK_10_000620_00_MENOKURAGE_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -564,7 +626,8 @@
     "name": "Tentacruel",
     "image": "cPK_10_000630_00_DOKUKURAGE_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -573,7 +636,8 @@
     "name": "Seel",
     "image": "cPK_10_000640_00_PAWOU_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -582,7 +646,8 @@
     "name": "Dewgong",
     "image": "cPK_10_000650_00_JUGON_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -591,7 +656,8 @@
     "name": "Shellder",
     "image": "cPK_10_000660_00_SHELLDER_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -600,7 +666,8 @@
     "name": "Cloyster",
     "image": "cPK_10_000670_00_PARSHEN_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -609,7 +676,8 @@
     "name": "Krabby",
     "image": "cPK_10_000680_00_CRAB_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -618,7 +686,8 @@
     "name": "Kingler",
     "image": "cPK_10_000690_00_KINGLER_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -627,7 +696,8 @@
     "name": "Horsea",
     "image": "cPK_10_000700_00_TATTU_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -636,7 +706,8 @@
     "name": "Seadra",
     "image": "cPK_10_000710_00_SEADRA_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -645,7 +716,8 @@
     "name": "Goldeen",
     "image": "cPK_10_000720_00_TOSAKINTO_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -654,7 +726,8 @@
     "name": "Seaking",
     "image": "cPK_10_000730_00_AZUMAO_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -663,7 +736,8 @@
     "name": "Staryu",
     "image": "cPK_10_000740_00_HITODEMAN_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -672,7 +746,8 @@
     "name": "Starmie",
     "image": "cPK_10_000750_00_STARMIE_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -681,7 +756,8 @@
     "name": "Starmie ex",
     "image": "cPK_10_000760_00_STARMIEex_RR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -690,7 +766,8 @@
     "name": "Magikarp",
     "image": "cPK_10_000770_00_KOIKING_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -699,7 +776,8 @@
     "name": "Gyarados",
     "image": "cPK_10_000780_00_GYARADOS_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -708,7 +786,8 @@
     "name": "Lapras",
     "image": "cPK_10_000790_00_LAPLACE_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -717,7 +796,8 @@
     "name": "Vaporeon",
     "image": "cPK_10_000800_00_SHOWERS_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -726,7 +806,8 @@
     "name": "Omanyte",
     "image": "cPK_10_000810_00_OMNITE_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -735,7 +816,8 @@
     "name": "Omastar",
     "image": "cPK_10_000820_00_OMSTAR_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -744,7 +826,8 @@
     "name": "Articuno",
     "image": "cPK_10_000830_00_FREEZER_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -753,7 +836,8 @@
     "name": "Articuno ex",
     "image": "cPK_10_000840_00_FREEZERex_RR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -762,7 +846,8 @@
     "name": "Ducklett",
     "image": "cPK_10_000850_00_KOARUHIE_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -771,7 +856,8 @@
     "name": "Swanna",
     "image": "cPK_10_000860_00_SWANNA_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -780,7 +866,8 @@
     "name": "Froakie",
     "image": "cPK_10_000870_00_KEROMATSU_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -789,7 +876,8 @@
     "name": "Frogadier",
     "image": "cPK_10_000880_00_GEKOGASHIRA_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -798,7 +886,8 @@
     "name": "Greninja",
     "image": "cPK_10_000890_00_GEKKOUGA_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -807,7 +896,8 @@
     "name": "Pyukumuku",
     "image": "cPK_10_000900_00_NAMAKOBUSHI_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -816,7 +906,8 @@
     "name": "Bruxish",
     "image": "cPK_10_000910_00_HAGIGISHIRI_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -825,7 +916,8 @@
     "name": "Snom",
     "image": "cPK_10_000920_00_YUKIHAMI_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -834,7 +926,8 @@
     "name": "Frosmoth",
     "image": "cPK_10_000930_00_MOTHNOW_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -843,7 +936,8 @@
     "name": "Pikachu",
     "image": "cPK_10_000940_00_PIKACHU_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -852,7 +946,8 @@
     "name": "Raichu",
     "image": "cPK_10_000950_00_RAICHU_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -861,7 +956,8 @@
     "name": "Pikachu ex",
     "image": "cPK_10_000960_00_PIKACHUex_RR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -870,7 +966,8 @@
     "name": "Magnemite",
     "image": "cPK_10_000970_00_COIL_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -879,7 +976,8 @@
     "name": "Magneton",
     "image": "cPK_10_000980_00_RARECOIL_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -888,7 +986,8 @@
     "name": "Voltorb",
     "image": "cPK_10_000990_00_BIRIRIDAMA_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -897,7 +996,8 @@
     "name": "Electrode",
     "image": "cPK_10_001000_00_MARUMINE_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -906,7 +1006,8 @@
     "name": "Electabuzz",
     "image": "cPK_10_001010_00_ELEBOO_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -915,7 +1016,8 @@
     "name": "Jolteon",
     "image": "cPK_10_001020_00_THUNDERS_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -924,7 +1026,8 @@
     "name": "Zapdos",
     "image": "cPK_10_001030_00_THUNDER_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -933,7 +1036,8 @@
     "name": "Zapdos ex",
     "image": "cPK_10_001040_00_THUNDERex_RR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -942,7 +1046,8 @@
     "name": "Blitzle",
     "image": "cPK_10_001050_00_SHIMAMA_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -951,7 +1056,8 @@
     "name": "Zebstrika",
     "image": "cPK_10_001060_00_ZEBRAIKA_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -960,7 +1066,8 @@
     "name": "Tynamo",
     "image": "cPK_10_001070_00_SHIBISHIRASU_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -969,7 +1076,8 @@
     "name": "Eelektrik",
     "image": "cPK_10_001080_00_SHIBIBEEL_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -978,7 +1086,8 @@
     "name": "Eelektross",
     "image": "cPK_10_001090_00_SHIBIRUDON_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -987,7 +1096,8 @@
     "name": "Helioptile",
     "image": "cPK_10_001100_00_ERIKITERU_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -996,7 +1106,8 @@
     "name": "Heliolisk",
     "image": "cPK_10_001110_00_ELEZARD_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1005,7 +1116,8 @@
     "name": "Pincurchin",
     "image": "cPK_10_001120_00_BACHINUNI_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1014,7 +1126,8 @@
     "name": "Clefairy",
     "image": "cPK_10_001130_00_PIPPI_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1023,7 +1136,8 @@
     "name": "Clefable",
     "image": "cPK_10_001140_00_PIXY_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1032,7 +1146,8 @@
     "name": "Abra",
     "image": "cPK_10_001150_00_CASEY_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1041,7 +1156,8 @@
     "name": "Kadabra",
     "image": "cPK_10_001160_00_YUNGERER_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1050,7 +1166,8 @@
     "name": "Alakazam",
     "image": "cPK_10_001170_00_FOODIN_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1059,7 +1176,8 @@
     "name": "Slowpoke",
     "image": "cPK_10_001180_00_YADON_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1068,7 +1186,8 @@
     "name": "Slowbro",
     "image": "cPK_10_001190_00_YADORAN_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1077,7 +1196,8 @@
     "name": "Gastly",
     "image": "cPK_10_001200_00_GHOS_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1086,7 +1206,8 @@
     "name": "Haunter",
     "image": "cPK_10_001210_00_GHOST_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1095,7 +1216,8 @@
     "name": "Gengar",
     "image": "cPK_10_001220_00_GANGAR_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1104,7 +1226,8 @@
     "name": "Gengar ex",
     "image": "cPK_10_001230_00_GANGARex_RR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1113,7 +1236,8 @@
     "name": "Drowzee",
     "image": "cPK_10_001240_00_SLEEPE_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1122,7 +1246,8 @@
     "name": "Hypno",
     "image": "cPK_10_001250_00_SLEEPER_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1131,7 +1256,8 @@
     "name": "Mr. Mime",
     "image": "cPK_10_001260_00_BARRIERD_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1140,7 +1266,8 @@
     "name": "Jynx",
     "image": "cPK_10_001270_00_ROUGELA_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1149,7 +1276,8 @@
     "name": "Mewtwo",
     "image": "cPK_10_001280_00_MEWTWO_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1158,7 +1286,8 @@
     "name": "Mewtwo ex",
     "image": "cPK_10_001290_00_MEWTWOex_RR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1167,7 +1296,8 @@
     "name": "Ralts",
     "image": "cPK_10_001300_00_RALTS_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1176,7 +1306,8 @@
     "name": "Kirlia",
     "image": "cPK_10_001310_00_KIRLIA_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1185,7 +1316,8 @@
     "name": "Gardevoir",
     "image": "cPK_10_001320_00_SIRNIGHT_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1194,7 +1326,8 @@
     "name": "Woobat",
     "image": "cPK_10_001330_00_KOROMORI_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1203,7 +1336,8 @@
     "name": "Swoobat",
     "image": "cPK_10_001340_00_KOKOROMORI_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1212,7 +1346,8 @@
     "name": "Golett",
     "image": "cPK_10_001350_00_GOBIT_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1221,7 +1356,8 @@
     "name": "Golurk",
     "image": "cPK_10_001360_00_GOLOOG_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1230,7 +1366,8 @@
     "name": "Sandshrew",
     "image": "cPK_10_001370_00_SAND_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1239,7 +1376,8 @@
     "name": "Sandslash",
     "image": "cPK_10_001380_00_SANDPAN_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1248,7 +1386,8 @@
     "name": "Diglett",
     "image": "cPK_10_001390_00_DIGDA_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1257,7 +1396,8 @@
     "name": "Dugtrio",
     "image": "cPK_10_001400_00_DUGTRIO_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1266,7 +1406,8 @@
     "name": "Mankey",
     "image": "cPK_10_001410_00_MANKEY_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1275,7 +1416,8 @@
     "name": "Primeape",
     "image": "cPK_10_001420_00_OKORIZARU_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1284,7 +1426,8 @@
     "name": "Machop",
     "image": "cPK_10_001430_00_WANRIKY_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1293,7 +1436,8 @@
     "name": "Machoke",
     "image": "cPK_10_001440_00_GORIKY_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1302,7 +1446,8 @@
     "name": "Machamp",
     "image": "cPK_10_001450_00_KAIRIKY_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1311,7 +1456,8 @@
     "name": "Machamp ex",
     "image": "cPK_10_001460_00_KAIRIKYex_RR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1320,7 +1466,8 @@
     "name": "Geodude",
     "image": "cPK_10_001470_00_ISITSUBUTE_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1329,7 +1476,8 @@
     "name": "Graveler",
     "image": "cPK_10_001480_00_GOLONE_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1338,7 +1486,8 @@
     "name": "Golem",
     "image": "cPK_10_001490_00_GOLONYA_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1347,7 +1496,8 @@
     "name": "Onix",
     "image": "cPK_10_001500_00_IWARK_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1356,7 +1506,8 @@
     "name": "Cubone",
     "image": "cPK_10_001510_00_KARAKARA_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1365,7 +1516,8 @@
     "name": "Marowak",
     "image": "cPK_10_001520_00_GARAGARA_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1374,7 +1526,8 @@
     "name": "Marowak ex",
     "image": "cPK_10_001530_00_GARAGARAex_RR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1383,7 +1536,8 @@
     "name": "Hitmonlee",
     "image": "cPK_10_001540_00_SAWAMULAR_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1392,7 +1546,8 @@
     "name": "Hitmonchan",
     "image": "cPK_10_001550_00_EBIWALAR_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1401,7 +1556,8 @@
     "name": "Rhyhorn",
     "image": "cPK_10_001560_00_SIHORN_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1410,7 +1566,8 @@
     "name": "Rhydon",
     "image": "cPK_10_001570_00_SIDON_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1419,7 +1576,8 @@
     "name": "Kabuto",
     "image": "cPK_10_001580_00_KABUTO_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1428,7 +1586,8 @@
     "name": "Kabutops",
     "image": "cPK_10_001590_00_KABUTOPS_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1437,7 +1596,8 @@
     "name": "Mienfoo",
     "image": "cPK_10_001600_00_KOJOFU_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1446,7 +1606,8 @@
     "name": "Mienshao",
     "image": "cPK_10_001610_00_KOJONDO_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1455,7 +1616,8 @@
     "name": "Clobbopus",
     "image": "cPK_10_001620_00_TATAKKO_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1464,7 +1626,8 @@
     "name": "Grapploct",
     "image": "cPK_10_001630_00_OTOSUPUS_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1473,7 +1636,8 @@
     "name": "Ekans",
     "image": "cPK_10_001640_00_ARBO_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1482,16 +1646,18 @@
     "name": "Arbok",
     "image": "cPK_10_001650_00_ARBOK_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
     "number": 166,
     "rarity": "C",
-    "name": "Nidoran\u2640",
-    "image": "cPK_10_001660_00_NIDORAN\u2640_C.webp",
+    "name": "Nidoran♀",
+    "image": "cPK_10_001660_00_NIDORAN♀_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1500,7 +1666,8 @@
     "name": "Nidorina",
     "image": "cPK_10_001670_00_NIDORINA_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1509,16 +1676,18 @@
     "name": "Nidoqueen",
     "image": "cPK_10_001680_00_NIDOQUEEN_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
     "number": 169,
     "rarity": "C",
-    "name": "Nidoran\u2642",
-    "image": "cPK_10_001690_00_NIDORAN\u2642_C.webp",
+    "name": "Nidoran♂",
+    "image": "cPK_10_001690_00_NIDORAN♂_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1527,7 +1696,8 @@
     "name": "Nidorino",
     "image": "cPK_10_001700_00_NIDORINO_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1536,7 +1706,8 @@
     "name": "Nidoking",
     "image": "cPK_10_001710_00_NIDOKING_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1545,7 +1716,8 @@
     "name": "Zubat",
     "image": "cPK_10_001720_00_ZUBAT_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1554,7 +1726,8 @@
     "name": "Golbat",
     "image": "cPK_10_001730_00_GOLBAT_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1563,7 +1736,8 @@
     "name": "Grimer",
     "image": "cPK_10_001740_00_BETBETER_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1572,7 +1746,8 @@
     "name": "Muk",
     "image": "cPK_10_001750_00_BETBETON_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1581,7 +1756,8 @@
     "name": "Koffing",
     "image": "cPK_10_001760_00_DOGARS_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1590,7 +1766,8 @@
     "name": "Weezing",
     "image": "cPK_10_001770_00_MATADOGAS_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1599,7 +1776,8 @@
     "name": "Mawile",
     "image": "cPK_10_001780_00_KUCHEAT_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1608,7 +1786,8 @@
     "name": "Pawniard",
     "image": "cPK_10_001790_00_KOMATANA_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1617,7 +1796,8 @@
     "name": "Bisharp",
     "image": "cPK_10_001800_00_KIRIKIZAN_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1626,7 +1806,8 @@
     "name": "Meltan",
     "image": "cPK_10_001810_00_MELTAN_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1635,7 +1816,8 @@
     "name": "Melmetal",
     "image": "cPK_10_001820_00_MELMETAL_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1644,7 +1826,8 @@
     "name": "Dratini",
     "image": "cPK_10_001830_00_MINIRYU_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1653,7 +1836,8 @@
     "name": "Dragonair",
     "image": "cPK_10_001840_00_HAKURYU_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1662,7 +1846,8 @@
     "name": "Dragonite",
     "image": "cPK_10_001850_00_KAIRYU_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1671,7 +1856,8 @@
     "name": "Pidgey",
     "image": "cPK_10_001860_00_POPPO_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1680,7 +1866,8 @@
     "name": "Pidgeotto",
     "image": "cPK_10_001870_00_PIGEON_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1689,7 +1876,8 @@
     "name": "Pidgeot",
     "image": "cPK_10_001880_00_PIGEOT_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1698,7 +1886,8 @@
     "name": "Rattata",
     "image": "cPK_10_001890_00_KORATTA_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1707,7 +1896,8 @@
     "name": "Raticate",
     "image": "cPK_10_001900_00_RATTA_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1716,7 +1906,8 @@
     "name": "Spearow",
     "image": "cPK_10_001910_00_ONISUZUME_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1725,7 +1916,8 @@
     "name": "Fearow",
     "image": "cPK_10_001920_00_ONIDRILL_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1734,7 +1926,8 @@
     "name": "Jigglypuff",
     "image": "cPK_10_001930_00_PURIN_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1743,7 +1936,8 @@
     "name": "Wigglytuff",
     "image": "cPK_10_001940_00_PUKURIN_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1752,7 +1946,8 @@
     "name": "Wigglytuff ex",
     "image": "cPK_10_001950_00_PUKURINex_RR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1761,7 +1956,8 @@
     "name": "Meowth",
     "image": "cPK_10_001960_00_NYARTH_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1770,16 +1966,18 @@
     "name": "Persian",
     "image": "cPK_10_001970_00_PERSIAN_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
     "number": 198,
     "rarity": "C",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_10_001980_00_KAMONEGI_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1788,7 +1986,8 @@
     "name": "Doduo",
     "image": "cPK_10_001990_00_DODO_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1797,7 +1996,8 @@
     "name": "Dodrio",
     "image": "cPK_10_002000_00_DODORIO_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1806,7 +2006,8 @@
     "name": "Lickitung",
     "image": "cPK_10_002010_00_BERORINGA_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1815,7 +2016,8 @@
     "name": "Chansey",
     "image": "cPK_10_002020_00_LUCKY_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1824,7 +2026,8 @@
     "name": "Kangaskhan",
     "image": "cPK_10_002030_00_GARURA_R.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1833,7 +2036,8 @@
     "name": "Tauros",
     "image": "cPK_10_002040_00_KENTAUROS_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1842,7 +2046,8 @@
     "name": "Ditto",
     "image": "cPK_10_002050_00_METAMON_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1851,7 +2056,8 @@
     "name": "Eevee",
     "image": "cPK_10_002060_00_EIEVUI_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1860,7 +2066,8 @@
     "name": "Eevee",
     "image": "cPK_10_002060_01_EIEVUI_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1869,7 +2076,8 @@
     "name": "Eevee",
     "image": "cPK_10_002060_02_EIEVUI_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1878,7 +2086,8 @@
     "name": "Porygon",
     "image": "cPK_10_002070_00_PORYGON_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1887,7 +2096,8 @@
     "name": "Aerodactyl",
     "image": "cPK_10_002080_00_PTERA_R.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1896,7 +2106,8 @@
     "name": "Snorlax",
     "image": "cPK_10_002090_00_KABIGON_R.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1905,7 +2116,8 @@
     "name": "Minccino",
     "image": "cPK_10_002100_00_CHILLARMY_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1914,7 +2126,8 @@
     "name": "Cinccino",
     "image": "cPK_10_002110_00_CHILLACCINO_U.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1923,7 +2136,8 @@
     "name": "Wooloo",
     "image": "cPK_10_002120_00_WOOLUU_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1932,7 +2146,8 @@
     "name": "Dubwool",
     "image": "cPK_10_002130_00_BAIWOOLUU_C.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1941,7 +2156,8 @@
     "name": "Helix Fossil",
     "image": "cTR_10_000080_00_KAINOKASEKI_C.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1950,7 +2166,8 @@
     "name": "Dome Fossil",
     "image": "cTR_10_000090_00_KOURANOKASEKI_C.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1959,7 +2176,8 @@
     "name": "Old Amber",
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1968,7 +2186,8 @@
     "name": "Erika",
     "image": "cTR_10_000110_00_ERIKA_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1977,7 +2196,8 @@
     "name": "Misty",
     "image": "cTR_10_000120_00_KASUMI_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1986,7 +2206,8 @@
     "name": "Blaine",
     "image": "cTR_10_000130_00_KATSURA_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -1995,7 +2216,8 @@
     "name": "Koga",
     "image": "cTR_10_000140_00_KYOU_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2004,7 +2226,8 @@
     "name": "Giovanni",
     "image": "cTR_10_000150_00_SAKAKI_U.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2013,7 +2236,8 @@
     "name": "Brock",
     "image": "cTR_10_000160_00_TAKESHI_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2022,7 +2246,8 @@
     "name": "Sabrina",
     "image": "cTR_10_000170_00_NATSUME_U.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2031,7 +2256,8 @@
     "name": "Lt. Surge",
     "image": "cTR_10_000180_00_MATISSE_U.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2040,7 +2266,8 @@
     "name": "Bulbasaur",
     "image": "cPK_20_000010_00_FUSHIGIDANE_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2049,7 +2276,8 @@
     "name": "Gloom",
     "image": "cPK_20_000120_00_KUSAIHANA_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2058,7 +2286,8 @@
     "name": "Pinsir",
     "image": "cPK_20_000260_00_KAILIOS_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2067,7 +2296,8 @@
     "name": "Charmander",
     "image": "cPK_20_000330_00_HITOKAGE_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2076,7 +2306,8 @@
     "name": "Rapidash",
     "image": "cPK_20_000430_00_GALLOP_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2085,7 +2316,8 @@
     "name": "Squirtle",
     "image": "cPK_20_000530_00_ZENIGAME_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2094,7 +2326,8 @@
     "name": "Gyarados",
     "image": "cPK_20_000780_00_GYARADOS_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2103,7 +2336,8 @@
     "name": "Lapras",
     "image": "cPK_20_000790_00_LAPLACE_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2112,7 +2346,8 @@
     "name": "Electrode",
     "image": "cPK_20_001000_00_MARUMINE_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2121,7 +2356,8 @@
     "name": "Alakazam",
     "image": "cPK_20_001170_00_FOODIN_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2130,7 +2366,8 @@
     "name": "Slowpoke",
     "image": "cPK_20_001180_00_YADON_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2139,7 +2376,8 @@
     "name": "Diglett",
     "image": "cPK_20_001390_00_DIGDA_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2148,7 +2386,8 @@
     "name": "Cubone",
     "image": "cPK_20_001510_00_KARAKARA_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2157,7 +2396,8 @@
     "name": "Nidoqueen",
     "image": "cPK_20_001680_00_NIDOQUEEN_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2166,7 +2406,8 @@
     "name": "Nidoking",
     "image": "cPK_20_001710_00_NIDOKING_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2175,7 +2416,8 @@
     "name": "Golbat",
     "image": "cPK_20_001730_00_GOLBAT_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2184,7 +2426,8 @@
     "name": "Weezing",
     "image": "cPK_20_001770_00_MATADOGAS_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2193,7 +2436,8 @@
     "name": "Dragonite",
     "image": "cPK_20_001850_00_KAIRYU_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2202,7 +2446,8 @@
     "name": "Pidgeot",
     "image": "cPK_20_001880_00_PIGEOT_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2211,7 +2456,8 @@
     "name": "Meowth",
     "image": "cPK_20_001960_00_NYARTH_AR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2220,7 +2466,8 @@
     "name": "Ditto",
     "image": "cPK_20_002050_00_METAMON_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2229,7 +2476,8 @@
     "name": "Eevee",
     "image": "cPK_20_002060_00_EIEVUI_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2238,7 +2486,8 @@
     "name": "Porygon",
     "image": "cPK_20_002070_00_PORYGON_AR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2247,7 +2496,8 @@
     "name": "Snorlax",
     "image": "cPK_20_002090_00_KABIGON_AR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2256,7 +2506,8 @@
     "name": "Venusaur ex",
     "image": "cPK_20_000040_00_FUSHIGIBANAex_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2265,7 +2516,8 @@
     "name": "Exeggutor ex",
     "image": "cPK_20_000230_00_NASSYex_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2274,7 +2526,8 @@
     "name": "Charizard ex",
     "image": "cPK_20_000360_00_LIZARDONex_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2283,7 +2536,8 @@
     "name": "Arcanine ex",
     "image": "cPK_20_000410_00_WINDIEex_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2292,7 +2546,8 @@
     "name": "Moltres ex",
     "image": "cPK_20_000470_00_FIREex_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2301,7 +2556,8 @@
     "name": "Blastoise ex",
     "image": "cPK_20_000560_00_KAMEXex_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2310,7 +2566,8 @@
     "name": "Starmie ex",
     "image": "cPK_20_000760_00_STARMIEex_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2319,7 +2576,8 @@
     "name": "Articuno ex",
     "image": "cPK_20_000840_00_FREEZERex_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2328,7 +2586,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_000960_00_PIKACHUex_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2337,7 +2596,8 @@
     "name": "Zapdos ex",
     "image": "cPK_20_001040_00_THUNDERex_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2346,7 +2606,8 @@
     "name": "Gengar ex",
     "image": "cPK_20_001230_00_GANGARex_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2355,7 +2616,8 @@
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_00_MEWTWOex_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2364,7 +2626,8 @@
     "name": "Machamp ex",
     "image": "cPK_20_001460_00_KAIRIKYex_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2373,7 +2636,8 @@
     "name": "Marowak ex",
     "image": "cPK_20_001530_00_GARAGARAex_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2382,7 +2646,8 @@
     "name": "Wigglytuff ex",
     "image": "cPK_20_001950_00_PUKURINex_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2391,7 +2656,8 @@
     "name": "Erika",
     "image": "cTR_20_000110_00_ERIKA_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2400,7 +2666,8 @@
     "name": "Misty",
     "image": "cTR_20_000120_00_KASUMI_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2409,7 +2676,8 @@
     "name": "Blaine",
     "image": "cTR_20_000130_00_KATSURA_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2418,7 +2686,8 @@
     "name": "Koga",
     "image": "cTR_20_000140_00_KYOU_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2427,7 +2696,8 @@
     "name": "Giovanni",
     "image": "cTR_20_000150_00_SAKAKI_SR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2436,7 +2706,8 @@
     "name": "Brock",
     "image": "cTR_20_000160_00_TAKESHI_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2445,7 +2716,8 @@
     "name": "Sabrina",
     "image": "cTR_20_000170_00_NATSUME_SR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2454,7 +2726,8 @@
     "name": "Lt. Surge",
     "image": "cTR_20_000180_00_MATISSE_SR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2463,7 +2736,8 @@
     "name": "Moltres ex",
     "image": "cPK_20_000470_01_FIREex_SAR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2472,7 +2746,8 @@
     "name": "Articuno ex",
     "image": "cPK_20_000840_01_FREEZERex_SAR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2481,7 +2756,8 @@
     "name": "Zapdos ex",
     "image": "cPK_20_001040_01_THUNDERex_SAR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2490,7 +2766,8 @@
     "name": "Gengar ex",
     "image": "cPK_20_001230_01_GANGARex_SAR.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2499,7 +2776,8 @@
     "name": "Machamp ex",
     "image": "cPK_20_001460_01_KAIRIKYex_SAR.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2508,7 +2786,8 @@
     "name": "Wigglytuff ex",
     "image": "cPK_20_001950_01_PUKURINex_SAR.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2517,7 +2796,8 @@
     "name": "Charizard ex",
     "image": "cPK_20_000360_01_LIZARDONex_IM.webp",
     "packs": ["Charizard"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2526,7 +2806,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_000960_01_PIKACHUex_IM.webp",
     "packs": ["Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2535,7 +2816,8 @@
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_01_MEWTWOex_IM.webp",
     "packs": ["Mewtwo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2543,7 +2825,8 @@
     "rarity": "IM",
     "name": "Mew",
     "image": "cPK_20_002140_00_MEW_IM.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2552,7 +2835,8 @@
     "name": "Charizard ex",
     "image": "cPK_20_000360_02_LIZARDONex_UR.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2561,7 +2845,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_000960_02_PIKACHUex_UR.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1",
@@ -2570,7 +2855,8 @@
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_02_MEWTWOex_UR.webp",
     "packs": ["Charizard", "Mewtwo", "Pikachu"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2579,7 +2865,8 @@
     "name": "Exeggcute",
     "image": "cPK_10_002150_00_TAMATAMA_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2588,7 +2875,8 @@
     "name": "Exeggutor",
     "image": "cPK_10_002160_00_NASSY_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2597,7 +2885,8 @@
     "name": "Celebi ex",
     "image": "cPK_10_002170_00_CELEBIex_RR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2606,7 +2895,8 @@
     "name": "Snivy",
     "image": "cPK_10_002180_00_TSUTARJA_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2615,7 +2905,8 @@
     "name": "Servine",
     "image": "cPK_10_002190_00_JANOVY_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2624,7 +2915,8 @@
     "name": "Serperior",
     "image": "cPK_10_002200_00_JALORDA_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2633,7 +2925,8 @@
     "name": "Morelull",
     "image": "cPK_10_002210_00_NEMASYU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2642,7 +2935,8 @@
     "name": "Shiinotic",
     "image": "cPK_10_002220_00_MASHADE_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2651,7 +2945,8 @@
     "name": "Dhelmise",
     "image": "cPK_10_002230_00_DADARIN_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2660,7 +2955,8 @@
     "name": "Ponyta",
     "image": "cPK_10_002240_00_PONYTA_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2669,7 +2965,8 @@
     "name": "Rapidash",
     "image": "cPK_10_002250_00_GALLOP_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2678,7 +2975,8 @@
     "name": "Magmar",
     "image": "cPK_10_002260_00_BOOBER_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2687,7 +2985,8 @@
     "name": "Larvesta",
     "image": "cPK_10_002270_00_MERLARVA_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2696,7 +2995,8 @@
     "name": "Volcarona",
     "image": "cPK_10_002280_00_ULGAMOTH_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2705,7 +3005,8 @@
     "name": "Salandit",
     "image": "cPK_10_002290_00_YATOUMORI_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2714,7 +3015,8 @@
     "name": "Salazzle",
     "image": "cPK_10_002300_00_ENNEWT_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2723,7 +3025,8 @@
     "name": "Magikarp",
     "image": "cPK_10_002310_00_KOIKING_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2732,7 +3035,8 @@
     "name": "Gyarados ex",
     "image": "cPK_10_002320_00_GYARADOSex_RR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2741,7 +3045,8 @@
     "name": "Vaporeon",
     "image": "cPK_10_002330_00_SHOWERS_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2750,7 +3055,8 @@
     "name": "Finneon",
     "image": "cPK_10_002340_00_KEIKOUO_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2759,7 +3065,8 @@
     "name": "Lumineon",
     "image": "cPK_10_002350_00_NEOLANT_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2768,7 +3075,8 @@
     "name": "Chewtle",
     "image": "cPK_10_002360_00_KAMUKAME_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2777,7 +3085,8 @@
     "name": "Drednaw",
     "image": "cPK_10_002370_00_KAJIRIGAME_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2786,7 +3095,8 @@
     "name": "Cramorant",
     "image": "cPK_10_002380_00_UU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2795,7 +3105,8 @@
     "name": "Pikachu",
     "image": "cPK_10_002390_00_PIKACHU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2804,7 +3115,8 @@
     "name": "Raichu",
     "image": "cPK_10_002400_00_RAICHU_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2813,7 +3125,8 @@
     "name": "Electabuzz",
     "image": "cPK_10_002410_00_ELEBOO_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2822,7 +3135,8 @@
     "name": "Joltik",
     "image": "cPK_10_002420_00_BACHURU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2831,7 +3145,8 @@
     "name": "Galvantula",
     "image": "cPK_10_002430_00_DENTULA_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2840,7 +3155,8 @@
     "name": "Dedenne",
     "image": "cPK_10_002440_00_DEDENNE_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2849,7 +3165,8 @@
     "name": "Mew",
     "image": "cPK_10_002140_00_MEW_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2858,7 +3175,8 @@
     "name": "Mew ex",
     "image": "cPK_10_002450_00_MEWex_RR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2867,7 +3185,8 @@
     "name": "Sigilyph",
     "image": "cPK_10_002460_00_SYMBOLER_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2876,7 +3195,8 @@
     "name": "Elgyem",
     "image": "cPK_10_002470_00_LIGRAY_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2885,16 +3205,18 @@
     "name": "Beheeyem",
     "image": "cPK_10_002500_00_OHBEM_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
     "number": 36,
     "rarity": "C",
-    "name": "Flab\u00e9b\u00e9",
+    "name": "Flabébé",
     "image": "cPK_10_002510_00_FLABEBE_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2903,7 +3225,8 @@
     "name": "Floette",
     "image": "cPK_10_002520_00_FLOETTE_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2912,7 +3235,8 @@
     "name": "Florges",
     "image": "cPK_10_002480_00_FLORGES_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2921,7 +3245,8 @@
     "name": "Swirlix",
     "image": "cPK_10_002490_00_PEROPPAFU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2930,7 +3255,8 @@
     "name": "Slurpuff",
     "image": "cPK_10_002530_00_PEROREAM_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2939,7 +3265,8 @@
     "name": "Mankey",
     "image": "cPK_10_002540_00_MANKEY_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2948,7 +3275,8 @@
     "name": "Primeape",
     "image": "cPK_10_002550_00_OKORIZARU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2957,7 +3285,8 @@
     "name": "Geodude",
     "image": "cPK_10_002560_00_ISITSUBUTE_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2966,7 +3295,8 @@
     "name": "Graveler",
     "image": "cPK_10_002570_00_GOLONE_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2975,7 +3305,8 @@
     "name": "Golem",
     "image": "cPK_10_002580_00_GOLONYA_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2984,7 +3315,8 @@
     "name": "Aerodactyl ex",
     "image": "cPK_10_002590_00_PTERAex_RR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -2993,7 +3325,8 @@
     "name": "Marshadow",
     "image": "cPK_10_002600_00_MARSHADOW_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3002,7 +3335,8 @@
     "name": "Stonjourner",
     "image": "cPK_10_002610_00_ISHIHENGIN_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3011,7 +3345,8 @@
     "name": "Koffing",
     "image": "cPK_10_002620_00_DOGARS_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3020,7 +3355,8 @@
     "name": "Weezing",
     "image": "cPK_10_002630_00_MATADOGAS_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3029,7 +3365,8 @@
     "name": "Purrloin",
     "image": "cPK_10_002640_00_CHORONEKO_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3038,7 +3375,8 @@
     "name": "Liepard",
     "image": "cPK_10_002650_00_LEPARDAS_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3047,7 +3385,8 @@
     "name": "Venipede",
     "image": "cPK_10_002660_00_FUSHIDE_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3056,7 +3395,8 @@
     "name": "Whirlipede",
     "image": "cPK_10_002670_00_WHEEGA_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3065,7 +3405,8 @@
     "name": "Scolipede",
     "image": "cPK_10_002680_00_PENDROR_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3074,7 +3415,8 @@
     "name": "Druddigon",
     "image": "cPK_10_002690_00_CRIMGAN_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3083,7 +3425,8 @@
     "name": "Pidgey",
     "image": "cPK_10_002700_00_POPPO_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3092,7 +3435,8 @@
     "name": "Pidgeotto",
     "image": "cPK_10_002710_00_PIGEON_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3101,7 +3445,8 @@
     "name": "Pidgeot ex",
     "image": "cPK_10_002720_00_PIGEOTex_RR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3110,7 +3455,8 @@
     "name": "Tauros",
     "image": "cPK_10_002730_00_KENTAUROS_R.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3119,7 +3465,8 @@
     "name": "Eevee",
     "image": "cPK_10_002740_00_EIEVUI_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3128,7 +3475,8 @@
     "name": "Chatot",
     "image": "cPK_10_002750_00_PERAP_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3137,16 +3485,18 @@
     "name": "Old Amber",
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
     "number": 64,
     "rarity": "U",
-    "name": "Pok\u00e9mon Flute",
+    "name": "Pokémon Flute",
     "image": "cTR_10_000200_00_POKEMONNOFUE_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3155,7 +3505,8 @@
     "name": "Mythical Slab",
     "image": "cTR_10_000190_00_MABOROSHINOSEKIBAN_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3164,7 +3515,8 @@
     "name": "Budding Expeditioner",
     "image": "cTR_10_000220_00_KAKEDASHICHOSAIN_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3173,7 +3525,8 @@
     "name": "Blue",
     "image": "cTR_10_000210_00_GREEN_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3182,7 +3535,8 @@
     "name": "Leaf",
     "image": "cTR_10_000230_00_LEAF_U.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3191,7 +3545,8 @@
     "name": "Exeggutor",
     "image": "cPK_20_002160_00_NASSY_AR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3200,7 +3555,8 @@
     "name": "Serperior",
     "image": "cPK_20_002200_00_JALORDA_AR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3209,7 +3565,8 @@
     "name": "Salandit",
     "image": "cPK_20_002290_00_YATOUMORI_AR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3218,7 +3575,8 @@
     "name": "Vaporeon",
     "image": "cPK_20_002330_00_SHOWERS_AR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3227,7 +3585,8 @@
     "name": "Dedenne",
     "image": "cPK_20_002440_00_DEDENNE_AR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3236,7 +3595,8 @@
     "name": "Marshadow",
     "image": "cPK_20_002600_00_MARSHADOW_AR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3245,7 +3605,8 @@
     "name": "Celebi ex",
     "image": "cPK_20_002170_00_CELEBIex_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3254,7 +3615,8 @@
     "name": "Gyarados ex",
     "image": "cPK_20_002320_00_GYARADOSex_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3263,7 +3625,8 @@
     "name": "Mew ex",
     "image": "cPK_20_002450_00_MEWex_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3272,7 +3635,8 @@
     "name": "Aerodactyl ex",
     "image": "cPK_20_002590_00_PTERAex_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3281,7 +3645,8 @@
     "name": "Pidgeot ex",
     "image": "cPK_20_002720_00_PIGEOTex_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3290,7 +3655,8 @@
     "name": "Budding Expeditioner",
     "image": "cTR_20_000220_00_KAKEDASHICHOSAIN_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3299,7 +3665,8 @@
     "name": "Blue",
     "image": "cTR_20_000210_00_GREEN_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3308,7 +3675,8 @@
     "name": "Leaf",
     "image": "cTR_20_000230_00_LEAF_SR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3317,7 +3685,8 @@
     "name": "Mew ex",
     "image": "cPK_20_002450_01_MEWex_SAR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3326,7 +3695,8 @@
     "name": "Aerodactyl ex",
     "image": "cPK_20_002590_01_PTERAex_SAR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3335,7 +3705,8 @@
     "name": "Celebi ex",
     "image": "cPK_20_002170_01_CELEBIex_IM.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A1a",
@@ -3344,7 +3715,8 @@
     "name": "Mew ex",
     "image": "cPK_20_002450_02_MEWex_UR.webp",
     "packs": ["Mew"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3353,7 +3725,8 @@
     "name": "Oddish",
     "image": "cPK_10_002820_00_NAZONOKUSA_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3362,7 +3735,8 @@
     "name": "Gloom",
     "image": "cPK_10_002830_00_KUSAIHANA_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3371,7 +3745,8 @@
     "name": "Bellossom",
     "image": "cPK_10_002840_00_KIREIHANA_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3380,7 +3755,8 @@
     "name": "Tangela",
     "image": "cPK_10_002850_00_MONJARA_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3389,7 +3765,8 @@
     "name": "Tangrowth",
     "image": "cPK_10_002860_00_MOJUMBO_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3398,7 +3775,8 @@
     "name": "Yanma",
     "image": "cPK_10_002870_00_YANYANMA_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3407,7 +3785,8 @@
     "name": "Yanmega ex",
     "image": "cPK_10_002880_00_MEGAYANMAex_RR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3416,7 +3795,8 @@
     "name": "Roselia",
     "image": "cPK_10_002890_00_ROSELIA_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3425,7 +3805,8 @@
     "name": "Roserade",
     "image": "cPK_10_002900_00_ROSERADE_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3434,7 +3815,8 @@
     "name": "Turtwig",
     "image": "cPK_10_002910_00_NAETLE_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3443,7 +3825,8 @@
     "name": "Grotle",
     "image": "cPK_10_002920_00_HAYASHIGAME_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3452,7 +3835,8 @@
     "name": "Torterra",
     "image": "cPK_10_002930_00_DODAITOSE_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3461,7 +3845,8 @@
     "name": "Kricketot",
     "image": "cPK_10_002940_00_KOROBOHSHI_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3470,7 +3855,8 @@
     "name": "Kricketune",
     "image": "cPK_10_002950_00_KOROTOCK_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3479,7 +3865,8 @@
     "name": "Burmy",
     "image": "cPK_10_002960_00_MINOMUCCHI_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3488,7 +3875,8 @@
     "name": "Wormadam",
     "image": "cPK_10_002970_00_MINOMADAMKUSAKINOMINO_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3497,7 +3885,8 @@
     "name": "Combee",
     "image": "cPK_10_002980_00_MITSUHONEY_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3506,7 +3895,8 @@
     "name": "Vespiquen",
     "image": "cPK_10_002990_00_BEEQUEN_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3515,7 +3905,8 @@
     "name": "Carnivine",
     "image": "cPK_10_003000_00_MUSKIPPA_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3524,7 +3915,8 @@
     "name": "Leafeon",
     "image": "cPK_10_003010_00_LEAFIA_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3533,7 +3925,8 @@
     "name": "Mow Rotom",
     "image": "cPK_10_003020_00_CUT ROTOM_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3542,7 +3935,8 @@
     "name": "Shaymin",
     "image": "cPK_10_003030_00_SHAYMIN_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3551,7 +3945,8 @@
     "name": "Magmar",
     "image": "cPK_10_003040_00_BOOBER_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3560,7 +3955,8 @@
     "name": "Magmortar",
     "image": "cPK_10_003050_00_BOOBURN_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3569,7 +3965,8 @@
     "name": "Slugma",
     "image": "cPK_10_003060_00_MAGMAG_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3578,7 +3975,8 @@
     "name": "Magcargo",
     "image": "cPK_10_003070_00_MAGCARGOT_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3587,7 +3985,8 @@
     "name": "Chimchar",
     "image": "cPK_10_003080_00_HIKOZARU_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3596,7 +3995,8 @@
     "name": "Monferno",
     "image": "cPK_10_003090_00_MOUKAZARU_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3605,7 +4005,8 @@
     "name": "Infernape ex",
     "image": "cPK_10_003100_00_GOUKAZARUex_RR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3614,7 +4015,8 @@
     "name": "Heat Rotom",
     "image": "cPK_10_003110_00_HEAT ROTOM_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3623,7 +4025,8 @@
     "name": "Swinub",
     "image": "cPK_10_003120_00_URIMOO_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3632,7 +4035,8 @@
     "name": "Piloswine",
     "image": "cPK_10_003130_00_INOMOO_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3641,7 +4045,8 @@
     "name": "Mamoswine",
     "image": "cPK_10_003140_00_MAMMOO_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3650,7 +4055,8 @@
     "name": "Regice",
     "image": "cPK_10_003150_00_REGICE_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3659,7 +4065,8 @@
     "name": "Piplup",
     "image": "cPK_10_003160_00_POCHAMA_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3668,7 +4075,8 @@
     "name": "Prinplup",
     "image": "cPK_10_003170_00_POTTAISHI_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3677,7 +4085,8 @@
     "name": "Empoleon",
     "image": "cPK_10_003180_00_EMPERTE_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3686,7 +4095,8 @@
     "name": "Buizel",
     "image": "cPK_10_003190_00_BUOYSEL_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3695,7 +4105,8 @@
     "name": "Floatzel",
     "image": "cPK_10_003200_00_FLOAZEL_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3704,7 +4115,8 @@
     "name": "Shellos",
     "image": "cPK_10_003210_00_KARANAKUSHI_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3713,7 +4125,8 @@
     "name": "Gastrodon",
     "image": "cPK_10_003220_00_TRITODON_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3722,7 +4135,8 @@
     "name": "Finneon",
     "image": "cPK_10_003230_00_KEIKOUO_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3731,7 +4145,8 @@
     "name": "Lumineon",
     "image": "cPK_10_003240_00_NEOLANT_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3740,7 +4155,8 @@
     "name": "Snover",
     "image": "cPK_10_003250_00_YUKIKABURI_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3749,7 +4165,8 @@
     "name": "Abomasnow",
     "image": "cPK_10_003260_00_YUKINOOH_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3758,7 +4175,8 @@
     "name": "Glaceon",
     "image": "cPK_10_003270_00_GLACIA_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3767,7 +4185,8 @@
     "name": "Wash Rotom",
     "image": "cPK_10_003280_00_WASH ROTOM_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3776,7 +4195,8 @@
     "name": "Frost Rotom",
     "image": "cPK_10_003290_00_FROST ROTOM_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3785,7 +4205,8 @@
     "name": "Palkia ex",
     "image": "cPK_10_003300_00_PALKIAex_RR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3794,7 +4215,8 @@
     "name": "Manaphy",
     "image": "cPK_10_003310_00_MANAPHY_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3803,7 +4225,8 @@
     "name": "Magnemite",
     "image": "cPK_10_003320_00_COIL_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3812,7 +4235,8 @@
     "name": "Magneton",
     "image": "cPK_10_003330_00_RARECOIL_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3821,7 +4245,8 @@
     "name": "Magnezone",
     "image": "cPK_10_003340_00_JIBACOIL_R.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3830,7 +4255,8 @@
     "name": "Voltorb",
     "image": "cPK_10_003350_00_BIRIRIDAMA_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3839,7 +4265,8 @@
     "name": "Electrode",
     "image": "cPK_10_003360_00_MARUMINE_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3848,7 +4275,8 @@
     "name": "Electabuzz",
     "image": "cPK_10_003370_00_ELEBOO_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3857,7 +4285,8 @@
     "name": "Electivire",
     "image": "cPK_10_003380_00_ELEKIBLE_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3866,7 +4295,8 @@
     "name": "Shinx",
     "image": "cPK_10_003390_00_KOLINK_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3875,7 +4305,8 @@
     "name": "Luxio",
     "image": "cPK_10_003400_00_LUXIO_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3884,7 +4315,8 @@
     "name": "Luxray",
     "image": "cPK_10_003410_00_RENTORAR_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3893,7 +4325,8 @@
     "name": "Pachirisu ex",
     "image": "cPK_10_003420_00_PACHIRISUex_RR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3902,7 +4335,8 @@
     "name": "Rotom",
     "image": "cPK_10_003430_00_ROTOM_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3911,7 +4345,8 @@
     "name": "Togepi",
     "image": "cPK_10_003440_00_TOGEPY_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3920,7 +4355,8 @@
     "name": "Togetic",
     "image": "cPK_10_003450_00_TOGECHICK_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3929,7 +4365,8 @@
     "name": "Togekiss",
     "image": "cPK_10_003460_00_TOGEKISS_R.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3938,7 +4375,8 @@
     "name": "Misdreavus",
     "image": "cPK_10_003470_00_MUMA_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3947,7 +4385,8 @@
     "name": "Mismagius ex",
     "image": "cPK_10_003480_00_MUMARGIex_RR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3956,7 +4395,8 @@
     "name": "Ralts",
     "image": "cPK_10_003490_00_RALTS_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3965,7 +4405,8 @@
     "name": "Kirlia",
     "image": "cPK_10_003500_00_KIRLIA_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3974,7 +4415,8 @@
     "name": "Duskull",
     "image": "cPK_10_003510_00_YOMAWARU_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3983,7 +4425,8 @@
     "name": "Dusclops",
     "image": "cPK_10_003520_00_SAMAYOURU_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -3992,7 +4435,8 @@
     "name": "Dusknoir",
     "image": "cPK_10_003530_00_YONOIR_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4001,7 +4445,8 @@
     "name": "Drifloon",
     "image": "cPK_10_003540_00_FUWANTE_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4010,7 +4455,8 @@
     "name": "Drifblim",
     "image": "cPK_10_003550_00_FUWARIDE_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4019,7 +4465,8 @@
     "name": "Uxie",
     "image": "cPK_10_003560_00_YUXIE_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4028,7 +4475,8 @@
     "name": "Mesprit",
     "image": "cPK_10_003570_00_EMRIT_R.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4037,7 +4485,8 @@
     "name": "Azelf",
     "image": "cPK_10_003580_00_AGNOME_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4046,7 +4495,8 @@
     "name": "Giratina",
     "image": "cPK_10_003590_00_ORIGINGIRATINA_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4055,7 +4505,8 @@
     "name": "Cresselia",
     "image": "cPK_10_003600_00_CRESSELIA_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4064,7 +4515,8 @@
     "name": "Rhyhorn",
     "image": "cPK_10_003610_00_SIHORN_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4073,7 +4525,8 @@
     "name": "Rhydon",
     "image": "cPK_10_003620_00_SIDON_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4082,7 +4535,8 @@
     "name": "Rhyperior",
     "image": "cPK_10_003630_00_DOSIDON_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4091,7 +4545,8 @@
     "name": "Gligar",
     "image": "cPK_10_003640_00_GLIGER_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4100,7 +4555,8 @@
     "name": "Gliscor",
     "image": "cPK_10_003650_00_GLION_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4109,7 +4565,8 @@
     "name": "Hitmontop",
     "image": "cPK_10_003660_00_KAPOERER_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4118,7 +4575,8 @@
     "name": "Nosepass",
     "image": "cPK_10_003670_00_NOSEPASS_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4127,7 +4585,8 @@
     "name": "Regirock",
     "image": "cPK_10_003680_00_REGIROCK_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4136,7 +4595,8 @@
     "name": "Cranidos",
     "image": "cPK_10_003690_00_ZUGAIDOS_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4145,7 +4605,8 @@
     "name": "Rampardos",
     "image": "cPK_10_003700_00_RAMPALD_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4154,7 +4615,8 @@
     "name": "Wormadam",
     "image": "cPK_10_003710_00_MINOMADAMSUNACHINOMINO_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4163,7 +4625,8 @@
     "name": "Riolu",
     "image": "cPK_10_003720_00_RIOLU_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4172,7 +4635,8 @@
     "name": "Lucario",
     "image": "cPK_10_003730_00_LUCARIO_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4181,7 +4645,8 @@
     "name": "Hippopotas",
     "image": "cPK_10_003740_00_HIPPOPOTAS_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4190,7 +4655,8 @@
     "name": "Hippowdon",
     "image": "cPK_10_003750_00_KABALDON_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4199,7 +4665,8 @@
     "name": "Gallade ex",
     "image": "cPK_10_003760_00_ERUREIDOex_RR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4208,7 +4675,8 @@
     "name": "Murkrow",
     "image": "cPK_10_003770_00_YAMIKARASU_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4217,7 +4685,8 @@
     "name": "Honchkrow",
     "image": "cPK_10_003780_00_DONGKARASU_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4226,7 +4695,8 @@
     "name": "Sneasel",
     "image": "cPK_10_003790_00_NYULA_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4235,7 +4705,8 @@
     "name": "Weavile ex",
     "image": "cPK_10_003800_00_MANYULAex_RR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4244,7 +4715,8 @@
     "name": "Poochyena",
     "image": "cPK_10_003810_00_POCHIENA_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4253,7 +4725,8 @@
     "name": "Mightyena",
     "image": "cPK_10_003820_00_GRAENA_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4262,7 +4735,8 @@
     "name": "Stunky",
     "image": "cPK_10_003830_00_SKUNPUU_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4271,7 +4745,8 @@
     "name": "Skuntank",
     "image": "cPK_10_003840_00_SKUTANK_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4280,7 +4755,8 @@
     "name": "Spiritomb",
     "image": "cPK_10_003850_00_MIKARUGE_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4289,7 +4765,8 @@
     "name": "Skorupi",
     "image": "cPK_10_003860_00_SCORUPI_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4298,7 +4775,8 @@
     "name": "Drapion",
     "image": "cPK_10_003870_00_DORAPION_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4307,7 +4785,8 @@
     "name": "Croagunk",
     "image": "cPK_10_003880_00_GUREGGRU_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4316,7 +4795,8 @@
     "name": "Toxicroak",
     "image": "cPK_10_003890_00_DOKUROG_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4325,7 +4805,8 @@
     "name": "Darkrai",
     "image": "cPK_10_003900_00_DARKRAI_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4334,7 +4815,8 @@
     "name": "Darkrai ex",
     "image": "cPK_10_003910_00_DARKRAIex_RR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4343,7 +4825,8 @@
     "name": "Skarmory",
     "image": "cPK_10_003920_00_AIRMD_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4352,7 +4835,8 @@
     "name": "Registeel",
     "image": "cPK_10_003930_00_REGISTEEL_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4361,7 +4845,8 @@
     "name": "Shieldon",
     "image": "cPK_10_003940_00_TATETOPS_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4370,7 +4855,8 @@
     "name": "Bastiodon",
     "image": "cPK_10_003950_00_TORIDEPS_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4379,7 +4865,8 @@
     "name": "Wormadam",
     "image": "cPK_10_003960_00_MINOMADAMGOMINOMINO_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4388,7 +4875,8 @@
     "name": "Bronzor",
     "image": "cPK_10_003970_00_DOHMIRROR_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4397,7 +4885,8 @@
     "name": "Bronzong",
     "image": "cPK_10_003980_00_DOHTAKUN_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4406,7 +4895,8 @@
     "name": "Probopass",
     "image": "cPK_10_003990_00_DAINOSE_U.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4415,7 +4905,8 @@
     "name": "Dialga ex",
     "image": "cPK_10_004000_00_DIALGAex_RR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4424,7 +4915,8 @@
     "name": "Heatran",
     "image": "cPK_10_004010_00_HEATRAN_R.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4433,7 +4925,8 @@
     "name": "Gible",
     "image": "cPK_10_004020_00_FUKAMARU_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4442,7 +4935,8 @@
     "name": "Gabite",
     "image": "cPK_10_004030_00_GABITE_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4451,7 +4945,8 @@
     "name": "Garchomp",
     "image": "cPK_10_004040_00_GABURIAS_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4460,7 +4955,8 @@
     "name": "Lickitung",
     "image": "cPK_10_004050_00_BERORINGA_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4469,7 +4965,8 @@
     "name": "Lickilicky ex",
     "image": "cPK_10_004060_00_BEROBELTex_RR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4478,7 +4975,8 @@
     "name": "Eevee",
     "image": "cPK_10_004070_00_EIEVUI_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4487,7 +4985,8 @@
     "name": "Porygon",
     "image": "cPK_10_004080_00_PORYGON_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4496,7 +4995,8 @@
     "name": "Porygon2",
     "image": "cPK_10_004090_00_PORYGON2_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4505,7 +5005,8 @@
     "name": "Porygon-Z",
     "image": "cPK_10_004100_00_PORYGON-Z_R.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4514,7 +5015,8 @@
     "name": "Aipom",
     "image": "cPK_10_004110_00_EIPAM_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4523,7 +5025,8 @@
     "name": "Ambipom",
     "image": "cPK_10_004120_00_ETEBOTH_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4532,7 +5035,8 @@
     "name": "Starly",
     "image": "cPK_10_004130_00_MUKKURU_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4541,7 +5045,8 @@
     "name": "Staravia",
     "image": "cPK_10_004140_00_MUKUBIRD_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4550,7 +5055,8 @@
     "name": "Staraptor",
     "image": "cPK_10_004150_00_MUKUHAWK_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4559,7 +5065,8 @@
     "name": "Bidoof",
     "image": "cPK_10_004160_00_BIPPA_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4568,7 +5075,8 @@
     "name": "Bibarel",
     "image": "cPK_10_004170_00_BEADARU_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4577,7 +5085,8 @@
     "name": "Buneary",
     "image": "cPK_10_004180_00_MIMIROL_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4586,7 +5095,8 @@
     "name": "Lopunny",
     "image": "cPK_10_004190_00_MIMILOP_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4595,7 +5105,8 @@
     "name": "Glameow",
     "image": "cPK_10_004200_00_NYARMAR_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4604,7 +5115,8 @@
     "name": "Purugly",
     "image": "cPK_10_004210_00_BUNYATTO_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4613,7 +5125,8 @@
     "name": "Chatot",
     "image": "cPK_10_004220_00_PERAP_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4622,7 +5135,8 @@
     "name": "Fan Rotom",
     "image": "cPK_10_004230_00_SPIN ROTOM_C.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4631,7 +5145,8 @@
     "name": "Regigigas",
     "image": "cPK_10_004240_00_REGIGIGAS_R.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4640,7 +5155,8 @@
     "name": "Skull Fossil",
     "image": "cTR_10_000260_00_ZUGAINOKASEKI_C.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4649,16 +5165,18 @@
     "name": "Armor Fossil",
     "image": "cTR_10_000270_00_TATENOKASEKI_C.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
     "number": 146,
     "rarity": "U",
-    "name": "Pok\u00e9mon Communication",
+    "name": "Pokémon Communication",
     "image": "cTR_10_000280_00_POKEMONTSUUSHIN_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4667,7 +5185,8 @@
     "name": "Giant Cape",
     "image": "cTR_10_000290_00_OOKINAMANTO_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4676,7 +5195,8 @@
     "name": "Rocky Helmet",
     "image": "cTR_10_000300_00_GOTSUGOTSUMETTO_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4685,7 +5205,8 @@
     "name": "Lum Berry",
     "image": "cTR_10_000310_00_RAMUNOMI_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4694,7 +5215,8 @@
     "name": "Cyrus",
     "image": "cTR_10_000320_00_AKAGI_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4703,7 +5225,8 @@
     "name": "Team Galactic Grunt",
     "image": "cTR_10_000330_00_GINGADANNOSHITAPPA_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4712,7 +5235,8 @@
     "name": "Cynthia",
     "image": "cTR_10_000340_00_SHIRONA_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4721,7 +5245,8 @@
     "name": "Volkner",
     "image": "cTR_10_000350_00_DENZI_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4730,7 +5255,8 @@
     "name": "Dawn",
     "image": "cTR_10_000360_00_HIKARI_U.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4739,7 +5265,8 @@
     "name": "Mars",
     "image": "cTR_10_000370_00_MARS_U.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4748,7 +5275,8 @@
     "name": "Tangrowth",
     "image": "cPK_20_002860_00_MOJUMBO_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4757,7 +5285,8 @@
     "name": "Combee",
     "image": "cPK_20_002980_00_MITSUHONEY_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4766,7 +5295,8 @@
     "name": "Carnivine",
     "image": "cPK_20_003000_00_MUSKIPPA_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4775,7 +5305,8 @@
     "name": "Shaymin",
     "image": "cPK_20_003030_00_SHAYMIN_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4784,7 +5315,8 @@
     "name": "Mamoswine",
     "image": "cPK_20_003140_00_MAMMOO_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4793,7 +5325,8 @@
     "name": "Gastrodon",
     "image": "cPK_20_003220_00_TRITODON_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4802,7 +5335,8 @@
     "name": "Manaphy",
     "image": "cPK_20_003310_00_MANAPHY_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4811,7 +5345,8 @@
     "name": "Shinx",
     "image": "cPK_20_003390_00_KOLINK_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4820,7 +5355,8 @@
     "name": "Rotom",
     "image": "cPK_20_003430_00_ROTOM_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4829,7 +5365,8 @@
     "name": "Drifloon",
     "image": "cPK_20_003540_00_FUWANTE_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4838,7 +5375,8 @@
     "name": "Mesprit",
     "image": "cPK_20_003570_00_EMRIT_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4847,7 +5385,8 @@
     "name": "Giratina",
     "image": "cPK_20_003590_00_ORIGINGIRATINA_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4856,7 +5395,8 @@
     "name": "Cresselia",
     "image": "cPK_20_003600_00_CRESSELIA_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4865,7 +5405,8 @@
     "name": "Rhyperior",
     "image": "cPK_20_003630_00_DOSIDON_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4874,7 +5415,8 @@
     "name": "Lucario",
     "image": "cPK_20_003730_00_LUCARIO_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4883,7 +5425,8 @@
     "name": "Hippopotas",
     "image": "cPK_20_003740_00_HIPPOPOTAS_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4892,7 +5435,8 @@
     "name": "Spiritomb",
     "image": "cPK_20_003850_00_MIKARUGE_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4901,7 +5445,8 @@
     "name": "Croagunk",
     "image": "cPK_20_003880_00_GUREGGRU_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4910,7 +5455,8 @@
     "name": "Heatran",
     "image": "cPK_20_004010_00_HEATRAN_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4919,7 +5465,8 @@
     "name": "Garchomp",
     "image": "cPK_20_004040_00_GABURIAS_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4928,7 +5475,8 @@
     "name": "Staraptor",
     "image": "cPK_20_004150_00_MUKUHAWK_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4937,7 +5485,8 @@
     "name": "Bidoof",
     "image": "cPK_20_004160_00_BIPPA_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4946,7 +5495,8 @@
     "name": "Glameow",
     "image": "cPK_20_004200_00_NYARMAR_AR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4955,7 +5505,8 @@
     "name": "Regigigas",
     "image": "cPK_20_004240_00_REGIGIGAS_AR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4964,7 +5515,8 @@
     "name": "Yanmega ex",
     "image": "cPK_20_002880_00_MEGAYANMAex_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4973,7 +5525,8 @@
     "name": "Infernape ex",
     "image": "cPK_20_003100_00_GOUKAZARUex_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4982,7 +5535,8 @@
     "name": "Palkia ex",
     "image": "cPK_20_003300_00_PALKIAex_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -4991,7 +5545,8 @@
     "name": "Pachirisu ex",
     "image": "cPK_20_003420_00_PACHIRISUex_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5000,7 +5555,8 @@
     "name": "Mismagius ex",
     "image": "cPK_20_003480_00_MUMARGIex_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5009,7 +5565,8 @@
     "name": "Gallade ex",
     "image": "cPK_20_003760_00_ERUREIDOex_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5018,7 +5575,8 @@
     "name": "Weavile ex",
     "image": "cPK_20_003800_00_MANYULAex_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5027,7 +5585,8 @@
     "name": "Darkrai ex",
     "image": "cPK_20_003910_00_DARKRAIex_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5036,7 +5595,8 @@
     "name": "Dialga ex",
     "image": "cPK_20_004000_00_DIALGAex_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5045,7 +5605,8 @@
     "name": "Lickilicky ex",
     "image": "cPK_20_004060_00_BEROBELTex_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5054,7 +5615,8 @@
     "name": "Cyrus",
     "image": "cTR_20_000320_00_AKAGI_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5063,7 +5625,8 @@
     "name": "Team Galactic Grunt",
     "image": "cTR_20_000330_00_GINGADANNOSHITAPPA_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5072,7 +5635,8 @@
     "name": "Cynthia",
     "image": "cTR_20_000340_00_SHIRONA_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5081,7 +5645,8 @@
     "name": "Volkner",
     "image": "cTR_20_000350_00_DENZI_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5090,7 +5655,8 @@
     "name": "Dawn",
     "image": "cTR_20_000360_00_HIKARI_SR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5099,7 +5665,8 @@
     "name": "Mars",
     "image": "cTR_20_000370_00_MARS_SR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5108,7 +5675,8 @@
     "name": "Yanmega ex",
     "image": "cPK_20_002880_01_MEGAYANMAex_SAR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5117,7 +5685,8 @@
     "name": "Infernape ex",
     "image": "cPK_20_003100_01_GOUKAZARUex_SAR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5126,7 +5695,8 @@
     "name": "Pachirisu ex",
     "image": "cPK_20_003420_01_PACHIRISUex_SAR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5135,7 +5705,8 @@
     "name": "Mismagius ex",
     "image": "cPK_20_003480_01_MUMARGIex_SAR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5144,7 +5715,8 @@
     "name": "Gallade ex",
     "image": "cPK_20_003760_01_ERUREIDOex_SAR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5153,7 +5725,8 @@
     "name": "Weavile ex",
     "image": "cPK_20_003800_01_MANYULAex_SAR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5162,7 +5735,8 @@
     "name": "Darkrai ex",
     "image": "cPK_20_003910_01_DARKRAIex_SAR.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5171,7 +5745,8 @@
     "name": "Lickilicky ex",
     "image": "cPK_20_004060_01_BEROBELTex_SAR.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5180,7 +5755,8 @@
     "name": "Palkia ex",
     "image": "cPK_20_003300_01_PALKIAex_IM.webp",
     "packs": ["Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5189,7 +5765,8 @@
     "name": "Dialga ex",
     "image": "cPK_20_004000_01_DIALGAex_IM.webp",
     "packs": ["Dialga"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5198,7 +5775,8 @@
     "name": "Palkia ex",
     "image": "cPK_20_003300_02_PALKIAex_UR.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2",
@@ -5207,7 +5785,8 @@
     "name": "Dialga ex",
     "image": "cPK_20_004000_02_DIALGAex_UR.webp",
     "packs": ["Dialga", "Palkia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5216,7 +5795,8 @@
     "name": "Heracross",
     "image": "cPK_10_004250_00_HERACROS_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5225,7 +5805,8 @@
     "name": "Burmy",
     "image": "cPK_10_004260_00_MINOMUCCHI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5234,7 +5815,8 @@
     "name": "Mothim",
     "image": "cPK_10_004270_00_GAMALE_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5243,7 +5825,8 @@
     "name": "Combee",
     "image": "cPK_10_004280_00_MITSUHONEY_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5252,7 +5835,8 @@
     "name": "Vespiquen",
     "image": "cPK_10_004290_00_BEEQUEN_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5261,7 +5845,8 @@
     "name": "Cherubi",
     "image": "cPK_10_004300_00_CHERINBO_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5270,7 +5855,8 @@
     "name": "Cherrim",
     "image": "cPK_10_004310_00_CHERRIM_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5279,7 +5865,8 @@
     "name": "Cherrim",
     "image": "cPK_10_004320_00_CHERRIM_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5288,7 +5875,8 @@
     "name": "Carnivine",
     "image": "cPK_10_004330_00_MUSKIPPA_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5297,7 +5885,8 @@
     "name": "Leafeon ex",
     "image": "cPK_10_004340_00_LEAFIAex_RR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5306,7 +5895,8 @@
     "name": "Houndour",
     "image": "cPK_10_004350_00_DELVIL_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5315,7 +5905,8 @@
     "name": "Houndoom",
     "image": "cPK_10_004360_00_HELLGAR_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5324,7 +5915,8 @@
     "name": "Heatran",
     "image": "cPK_10_004370_00_HEATRAN_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5333,7 +5925,8 @@
     "name": "Marill",
     "image": "cPK_10_004380_00_MARIL_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5342,7 +5935,8 @@
     "name": "Azumarill",
     "image": "cPK_10_004390_00_MARILLI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5351,7 +5945,8 @@
     "name": "Barboach",
     "image": "cPK_10_004400_00_DOJOACH_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5360,7 +5955,8 @@
     "name": "Whiscash",
     "image": "cPK_10_004410_00_NAMAZUN_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5369,7 +5965,8 @@
     "name": "Snorunt",
     "image": "cPK_10_004420_00_YUKIWARASHI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5378,7 +5975,8 @@
     "name": "Froslass",
     "image": "cPK_10_004430_00_YUKIMENOKO_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5387,7 +5985,8 @@
     "name": "Snover",
     "image": "cPK_10_004440_00_YUKIKABURI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5396,7 +5995,8 @@
     "name": "Abomasnow",
     "image": "cPK_10_004450_00_YUKINOOH_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5405,7 +6005,8 @@
     "name": "Glaceon ex",
     "image": "cPK_10_004460_00_GLACIAex_RR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5414,7 +6015,8 @@
     "name": "Palkia",
     "image": "cPK_10_004470_00_ORIGINPALKIA_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5423,7 +6025,8 @@
     "name": "Phione",
     "image": "cPK_10_004480_00_PHIONE_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5432,7 +6035,8 @@
     "name": "Pikachu",
     "image": "cPK_10_004490_00_PIKACHU_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5441,7 +6045,8 @@
     "name": "Raichu",
     "image": "cPK_10_004500_00_RAICHU_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5450,7 +6055,8 @@
     "name": "Electrike",
     "image": "cPK_10_004510_00_RAKURAI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5459,7 +6065,8 @@
     "name": "Manectric",
     "image": "cPK_10_004520_00_LIVOLT_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5468,7 +6075,8 @@
     "name": "Clefairy",
     "image": "cPK_10_004530_00_PIPPI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5477,7 +6085,8 @@
     "name": "Clefable",
     "image": "cPK_10_004540_00_PIXY_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5486,7 +6095,8 @@
     "name": "Gastly",
     "image": "cPK_10_004550_00_GHOS_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5495,7 +6105,8 @@
     "name": "Haunter",
     "image": "cPK_10_004560_00_GHOST_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5504,7 +6115,8 @@
     "name": "Gengar",
     "image": "cPK_10_004570_00_GANGAR_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5513,7 +6125,8 @@
     "name": "Unown",
     "image": "cPK_10_004580_00_UNKNOWN_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5522,7 +6135,8 @@
     "name": "Rotom",
     "image": "cPK_10_004590_00_ROTOM_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5531,7 +6145,8 @@
     "name": "Sudowoodo",
     "image": "cPK_10_004600_00_USOKKIE_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5540,7 +6155,8 @@
     "name": "Phanpy",
     "image": "cPK_10_004610_00_GOMAZOU_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5549,7 +6165,8 @@
     "name": "Donphan",
     "image": "cPK_10_004620_00_DONFAN_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5558,7 +6175,8 @@
     "name": "Larvitar",
     "image": "cPK_10_004630_00_YOGIRAS_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5567,7 +6185,8 @@
     "name": "Pupitar",
     "image": "cPK_10_004640_00_SANAGIRAS_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5576,7 +6195,8 @@
     "name": "Tyranitar",
     "image": "cPK_10_004650_00_BANGIRAS_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5585,7 +6205,8 @@
     "name": "Nosepass",
     "image": "cPK_10_004660_00_NOSEPASS_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5594,7 +6215,8 @@
     "name": "Meditite",
     "image": "cPK_10_004670_00_ASANAN_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5603,7 +6225,8 @@
     "name": "Medicham",
     "image": "cPK_10_004680_00_CHAREM_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5612,7 +6235,8 @@
     "name": "Gible",
     "image": "cPK_10_004690_00_FUKAMARU_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5621,7 +6245,8 @@
     "name": "Gabite",
     "image": "cPK_10_004700_00_GABITE_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5630,7 +6255,8 @@
     "name": "Garchomp ex",
     "image": "cPK_10_004710_00_GABURIASex_RR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5639,7 +6265,8 @@
     "name": "Zubat",
     "image": "cPK_10_004720_00_ZUBAT_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5648,7 +6275,8 @@
     "name": "Golbat",
     "image": "cPK_10_004730_00_GOLBAT_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5657,7 +6285,8 @@
     "name": "Crobat",
     "image": "cPK_10_004740_00_CROBAT_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5666,7 +6295,8 @@
     "name": "Croagunk",
     "image": "cPK_10_004750_00_GUREGGRU_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5675,7 +6305,8 @@
     "name": "Toxicroak",
     "image": "cPK_10_004760_00_DOKUROG_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5684,7 +6315,8 @@
     "name": "Magnemite",
     "image": "cPK_10_004770_00_COIL_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5693,7 +6325,8 @@
     "name": "Magneton",
     "image": "cPK_10_004780_00_RARECOIL_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5702,7 +6335,8 @@
     "name": "Magnezone",
     "image": "cPK_10_004790_00_JIBACOIL_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5711,7 +6345,8 @@
     "name": "Mawile",
     "image": "cPK_10_004800_00_KUCHEAT_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5720,7 +6355,8 @@
     "name": "Probopass ex",
     "image": "cPK_10_004810_00_DAINOSEex_RR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5729,7 +6365,8 @@
     "name": "Bronzor",
     "image": "cPK_10_004820_00_DOHMIRROR_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5738,7 +6375,8 @@
     "name": "Bronzong",
     "image": "cPK_10_004830_00_DOHTAKUN_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5747,7 +6385,8 @@
     "name": "Dialga",
     "image": "cPK_10_004840_00_ORIGINDIALGA_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5756,7 +6395,8 @@
     "name": "Giratina",
     "image": "cPK_10_004850_00_GIRATINA_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5765,7 +6405,8 @@
     "name": "Eevee",
     "image": "cPK_10_004860_00_EIEVUI_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5774,7 +6415,8 @@
     "name": "Snorlax",
     "image": "cPK_10_004870_00_KABIGON_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5783,7 +6425,8 @@
     "name": "Hoothoot",
     "image": "cPK_10_004880_00_HOHO_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5792,7 +6435,8 @@
     "name": "Noctowl",
     "image": "cPK_10_004890_00_YORUNOZUKU_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5801,7 +6445,8 @@
     "name": "Starly",
     "image": "cPK_10_004900_00_MUKKURU_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5810,7 +6455,8 @@
     "name": "Staravia",
     "image": "cPK_10_004910_00_MUKUBIRD_C.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5819,7 +6465,8 @@
     "name": "Staraptor",
     "image": "cPK_10_004920_00_MUKUHAWK_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5828,7 +6475,8 @@
     "name": "Shaymin",
     "image": "cPK_10_004930_00_SHAYMIN_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5837,7 +6485,8 @@
     "name": "Arceus",
     "image": "cPK_10_004940_00_ARCEUS_R.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5846,7 +6495,8 @@
     "name": "Arceus ex",
     "image": "cPK_10_004950_00_ARCEUSex_RR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5855,7 +6505,8 @@
     "name": "Irida",
     "image": "cTR_10_000380_00_KAI_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5864,7 +6515,8 @@
     "name": "Celestic Town Elder",
     "image": "cTR_10_000390_00_KANNAGITOWNNOTYOUROU_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5873,7 +6525,8 @@
     "name": "Barry",
     "image": "cTR_10_000400_00_JUN_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5882,7 +6535,8 @@
     "name": "Adaman",
     "image": "cTR_10_000410_00_SEKI_U.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5891,7 +6545,8 @@
     "name": "Houndoom",
     "image": "cPK_20_004360_00_HELLGAR_AR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5900,7 +6555,8 @@
     "name": "Marill",
     "image": "cPK_20_004380_00_MARIL_AR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5909,7 +6565,8 @@
     "name": "Unown",
     "image": "cPK_20_004580_00_UNKNOWN_AR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5918,7 +6575,8 @@
     "name": "Sudowoodo",
     "image": "cPK_20_004600_00_USOKKIE_AR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5927,7 +6585,8 @@
     "name": "Magnemite",
     "image": "cPK_20_004770_00_COIL_AR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5936,7 +6595,8 @@
     "name": "Shaymin",
     "image": "cPK_20_004930_00_SHAYMIN_AR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5945,7 +6605,8 @@
     "name": "Leafeon ex",
     "image": "cPK_20_004340_00_LEAFIAex_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5954,7 +6615,8 @@
     "name": "Glaceon ex",
     "image": "cPK_20_004460_00_GLACIAex_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5963,7 +6625,8 @@
     "name": "Garchomp ex",
     "image": "cPK_20_004710_00_GABURIASex_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5972,7 +6635,8 @@
     "name": "Probopass ex",
     "image": "cPK_20_004810_00_DAINOSEex_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5981,7 +6645,8 @@
     "name": "Arceus ex",
     "image": "cPK_20_004950_00_ARCEUSex_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5990,7 +6655,8 @@
     "name": "Irida",
     "image": "cTR_20_000380_00_KAI_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -5999,7 +6665,8 @@
     "name": "Celestic Town Elder",
     "image": "cTR_20_000390_00_KANNAGITOWNNOTYOUROU_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6008,7 +6675,8 @@
     "name": "Barry",
     "image": "cTR_20_000400_00_JUN_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6017,7 +6685,8 @@
     "name": "Adaman",
     "image": "cTR_20_000410_00_SEKI_SR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6026,7 +6695,8 @@
     "name": "Leafeon ex",
     "image": "cPK_20_004340_01_LEAFIAex_SAR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6035,7 +6705,8 @@
     "name": "Glaceon ex",
     "image": "cPK_20_004460_01_GLACIAex_SAR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6044,7 +6715,8 @@
     "name": "Garchomp ex",
     "image": "cPK_20_004710_01_GABURIASex_SAR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6053,7 +6725,8 @@
     "name": "Probopass ex",
     "image": "cPK_20_004810_01_DAINOSEex_SAR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6062,7 +6735,8 @@
     "name": "Arceus ex",
     "image": "cPK_20_004950_01_ARCEUSex_IM.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2a",
@@ -6071,7 +6745,8 @@
     "name": "Arceus ex",
     "image": "cPK_20_004950_02_ARCEUSex_UR.webp",
     "packs": ["Arceus"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6080,7 +6755,8 @@
     "name": "Weedle",
     "image": "cPK_10_005210_00_BEEDLE_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6089,7 +6765,8 @@
     "name": "Kakuna",
     "image": "cPK_10_005220_00_COCOON_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6098,7 +6775,8 @@
     "name": "Beedrill ex",
     "image": "cPK_10_005230_00_SPEARex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6107,7 +6785,8 @@
     "name": "Pinsir",
     "image": "cPK_10_005240_00_KAILIOS_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6116,7 +6795,8 @@
     "name": "Sprigatito",
     "image": "cPK_10_005080_00_NYAHOJA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6125,7 +6805,8 @@
     "name": "Floragato",
     "image": "cPK_10_005250_00_NYAROTE_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6134,7 +6815,8 @@
     "name": "Meowscarada",
     "image": "cPK_10_005260_00_MASQUERNYA_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6143,7 +6825,8 @@
     "name": "Charmander",
     "image": "cPK_10_005270_00_HITOKAGE_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6152,7 +6835,8 @@
     "name": "Charmeleon",
     "image": "cPK_10_005280_00_LIZARDO_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6161,7 +6845,8 @@
     "name": "Charizard ex",
     "image": "cPK_10_005290_00_LIZARDONex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6170,7 +6855,8 @@
     "name": "Magmar",
     "image": "cPK_10_005300_00_BOOBER_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6179,7 +6865,8 @@
     "name": "Magmortar",
     "image": "cPK_10_005310_00_BOOBURN_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6188,7 +6875,8 @@
     "name": "Paldean Tauros",
     "image": "cPK_10_005320_00_PALDEAKENTAUROS_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6197,7 +6885,8 @@
     "name": "Tentacool",
     "image": "cPK_10_005330_00_MENOKURAGE_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6206,7 +6895,8 @@
     "name": "Tentacruel",
     "image": "cPK_10_005340_00_DOKUKURAGE_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6215,7 +6905,8 @@
     "name": "Buizel",
     "image": "cPK_10_005350_00_BUOYSEL_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6224,7 +6915,8 @@
     "name": "Floatzel",
     "image": "cPK_10_005360_00_FLOAZEL_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6233,7 +6925,8 @@
     "name": "Wiglett",
     "image": "cPK_10_005370_00_UMIDIGDA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6242,7 +6935,8 @@
     "name": "Wugtrio ex",
     "image": "cPK_10_005380_00_UMITRIOex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6251,7 +6945,8 @@
     "name": "Dondozo",
     "image": "cPK_10_005390_00_HEYRUSHER_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6260,7 +6955,8 @@
     "name": "Tatsugiri",
     "image": "cPK_10_005400_00_SYARITATSU_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6269,7 +6965,8 @@
     "name": "Pikachu ex",
     "image": "cPK_10_005410_00_PIKACHUex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6278,7 +6975,8 @@
     "name": "Voltorb",
     "image": "cPK_10_005420_00_BIRIRIDAMA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6287,7 +6985,8 @@
     "name": "Electrode",
     "image": "cPK_10_005430_00_MARUMINE_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6296,7 +6995,8 @@
     "name": "Pachirisu",
     "image": "cPK_10_005060_00_PACHIRISU_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6305,7 +7005,8 @@
     "name": "Pawmi",
     "image": "cPK_10_005440_00_PAMO_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6314,7 +7015,8 @@
     "name": "Pawmo",
     "image": "cPK_10_005450_00_PAMOT_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6323,7 +7025,8 @@
     "name": "Pawmot",
     "image": "cPK_10_005010_00_PARMOT_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6332,7 +7035,8 @@
     "name": "Abra",
     "image": "cPK_10_005460_00_CASEY_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6341,7 +7045,8 @@
     "name": "Kadabra",
     "image": "cPK_10_005470_00_YUNGERER_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6350,7 +7055,8 @@
     "name": "Alakazam",
     "image": "cPK_10_005480_00_FOODIN_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6359,7 +7065,8 @@
     "name": "Mr. Mime",
     "image": "cPK_10_005490_00_BARRIERD_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6368,7 +7075,8 @@
     "name": "Drifloon",
     "image": "cPK_10_005500_00_FUWANTE_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6377,7 +7085,8 @@
     "name": "Drifblim",
     "image": "cPK_10_005510_00_FUWARIDE_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6386,7 +7095,8 @@
     "name": "Giratina ex",
     "image": "cPK_10_005520_00_GIRATINAex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6395,7 +7105,8 @@
     "name": "Gimmighoul",
     "image": "cPK_10_005530_00_COLLECUREI_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6404,7 +7115,8 @@
     "name": "Machop",
     "image": "cPK_10_005540_00_WANRIKY_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6413,7 +7125,8 @@
     "name": "Machoke",
     "image": "cPK_10_005550_00_GORIKY_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6422,7 +7135,8 @@
     "name": "Machamp",
     "image": "cPK_10_005020_00_KAIRIKY_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6431,7 +7145,8 @@
     "name": "Hitmonlee",
     "image": "cPK_10_005560_00_SAWAMULAR_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6440,7 +7155,8 @@
     "name": "Hitmonchan",
     "image": "cPK_10_005570_00_EBIWALAR_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6449,7 +7165,8 @@
     "name": "Riolu",
     "image": "cPK_10_005070_00_RIOLU_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6458,7 +7175,8 @@
     "name": "Lucario ex",
     "image": "cPK_10_005580_00_LUCARIOex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6467,7 +7185,8 @@
     "name": "Flamigo",
     "image": "cPK_10_005590_00_KARAMINGO_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6476,7 +7195,8 @@
     "name": "Ekans",
     "image": "cPK_10_005600_00_ARBO_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6485,7 +7205,8 @@
     "name": "Arbok",
     "image": "cPK_10_005610_00_ARBOK_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6494,7 +7215,8 @@
     "name": "Paldean Wooper",
     "image": "cPK_10_005620_00_PALDEAUPAH_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6503,7 +7225,8 @@
     "name": "Paldean Clodsire ex",
     "image": "cPK_10_005630_00_PALDEADOOHex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6512,7 +7235,8 @@
     "name": "Spiritomb",
     "image": "cPK_10_005640_00_MIKARUGE_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6521,7 +7245,8 @@
     "name": "Shroodle",
     "image": "cPK_10_005650_00_SHIRUSHREW_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6530,7 +7255,8 @@
     "name": "Grafaiai",
     "image": "cPK_10_005660_00_TAGGINGRU_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6539,7 +7265,8 @@
     "name": "Tinkatink",
     "image": "cPK_10_005670_00_KANUCHAN_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6548,7 +7275,8 @@
     "name": "Tinkatuff",
     "image": "cPK_10_005680_00_NAKANUCHAN_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6557,7 +7285,8 @@
     "name": "Tinkaton ex",
     "image": "cPK_10_005690_00_DEKANUCHANex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6566,7 +7295,8 @@
     "name": "Varoom",
     "image": "cPK_10_005700_00_BURORON_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6575,7 +7305,8 @@
     "name": "Revavroom",
     "image": "cPK_10_005710_00_BUROROROOM_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6584,7 +7315,8 @@
     "name": "Gholdengo",
     "image": "cPK_10_005720_00_SURFUGO_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6593,7 +7325,8 @@
     "name": "Rattata",
     "image": "cPK_10_005730_00_KORATTA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6602,7 +7335,8 @@
     "name": "Raticate",
     "image": "cPK_10_005740_00_RATTA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6611,7 +7345,8 @@
     "name": "Jigglypuff",
     "image": "cPK_10_005750_00_PURIN_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6620,7 +7355,8 @@
     "name": "Wigglytuff",
     "image": "cPK_10_005760_00_PUKURIN_R.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6629,7 +7365,8 @@
     "name": "Lickitung",
     "image": "cPK_10_005770_00_BERORINGA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6638,7 +7375,8 @@
     "name": "Lickilicky",
     "image": "cPK_10_005780_00_BEROBELT_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6647,7 +7385,8 @@
     "name": "Bidoof",
     "image": "cPK_10_005040_00_BIPPA_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6656,7 +7395,8 @@
     "name": "Bibarel ex",
     "image": "cPK_10_005790_00_BEADARUex_RR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6665,7 +7405,8 @@
     "name": "Buneary",
     "image": "cPK_10_005800_00_MIMIROL_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6674,7 +7415,8 @@
     "name": "Lopunny",
     "image": "cPK_10_005810_00_MIMILOP_C.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6683,7 +7425,8 @@
     "name": "Cyclizar",
     "image": "cPK_10_005090_00_MOTOTOKAGE_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6692,16 +7435,18 @@
     "name": "Iono",
     "image": "cTR_10_000420_00_NANJYAMO_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
     "number": 70,
     "rarity": "U",
-    "name": "Pok\u00e9mon Center Lady",
+    "name": "Pokémon Center Lady",
     "image": "cTR_10_000430_00_POKEMONCENTERNOONEESAN_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6710,7 +7455,8 @@
     "name": "Red",
     "image": "cTR_10_000440_00_RED_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6719,7 +7465,8 @@
     "name": "Team Rocket Grunt",
     "image": "cTR_10_000450_00_ROCKETDANNOSHITAPPA_U.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6728,7 +7475,8 @@
     "name": "Meowscarada",
     "image": "cPK_20_005260_00_MASQUERNYA_AR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6737,7 +7485,8 @@
     "name": "Buizel",
     "image": "cPK_20_005350_00_BUOYSEL_AR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6746,7 +7495,8 @@
     "name": "Tatsugiri",
     "image": "cPK_20_005400_00_SYARITATSU_AR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6755,7 +7505,8 @@
     "name": "Grafaiai",
     "image": "cPK_20_005660_00_TAGGINGRU_AR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6764,7 +7515,8 @@
     "name": "Gholdengo",
     "image": "cPK_20_005720_00_SURFUGO_AR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6773,7 +7525,8 @@
     "name": "Wigglytuff",
     "image": "cPK_20_005760_00_PUKURIN_AR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6782,7 +7535,8 @@
     "name": "Beedrill ex",
     "image": "cPK_20_005230_00_SPEARex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6791,7 +7545,8 @@
     "name": "Charizard ex",
     "image": "cPK_20_005290_00_LIZARDONex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6800,7 +7555,8 @@
     "name": "Wugtrio ex",
     "image": "cPK_20_005380_00_UMITRIOex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6809,7 +7565,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_005410_00_PIKACHUex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6818,7 +7575,8 @@
     "name": "Giratina ex",
     "image": "cPK_20_005520_00_GIRATINAex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6827,7 +7585,8 @@
     "name": "Lucario ex",
     "image": "cPK_20_005580_00_LUCARIOex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6836,7 +7595,8 @@
     "name": "Paldean Clodsire ex",
     "image": "cPK_20_005630_00_PALDEADOOHex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6845,7 +7605,8 @@
     "name": "Tinkaton ex",
     "image": "cPK_20_005690_00_DEKANUCHANex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6854,7 +7615,8 @@
     "name": "Bibarel ex",
     "image": "cPK_20_005790_00_BEADARUex_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6863,16 +7625,18 @@
     "name": "Iono",
     "image": "cTR_20_000420_00_NANJYAMO_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
     "number": 89,
     "rarity": "SR",
-    "name": "Pok\u00e9mon Center Lady",
+    "name": "Pokémon Center Lady",
     "image": "cTR_20_000430_00_POKEMONCENTERNOONEESAN_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6881,7 +7645,8 @@
     "name": "Red",
     "image": "cTR_20_000440_00_RED_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6890,7 +7655,8 @@
     "name": "Team Rocket Grunt",
     "image": "cTR_20_000450_00_ROCKETDANNOSHITAPPA_SR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6899,7 +7665,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_005410_01_PIKACHUex_SAR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6908,7 +7675,8 @@
     "name": "Paldean Clodsire ex",
     "image": "cPK_20_005630_01_PALDEADOOHex_SAR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6917,7 +7685,8 @@
     "name": "Tinkaton ex",
     "image": "cPK_20_005690_01_DEKANUCHANex_SAR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6926,7 +7695,8 @@
     "name": "Bibarel ex",
     "image": "cPK_20_005790_01_BEADARUex_SAR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6935,7 +7705,8 @@
     "name": "Giratina ex",
     "image": "cPK_20_005520_01_GIRATINAex_IM.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A2b",
@@ -6944,7 +7715,8 @@
     "name": "Weedle",
     "image": "cPK_20_005210_00_BEEDLE_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -6953,7 +7725,8 @@
     "name": "Kakuna",
     "image": "cPK_20_005220_00_COCOON_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -6962,7 +7735,8 @@
     "name": "Charmander",
     "image": "cPK_20_005270_00_HITOKAGE_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -6971,7 +7745,8 @@
     "name": "Charmeleon",
     "image": "cPK_20_005280_00_LIZARDO_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -6980,7 +7755,8 @@
     "name": "Wiglett",
     "image": "cPK_20_005370_00_UMIDIGDA_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -6989,7 +7765,8 @@
     "name": "Dondozo",
     "image": "cPK_20_005390_00_HEYRUSHER_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -6998,7 +7775,8 @@
     "name": "Pachirisu",
     "image": "cPK_20_005060_00_PACHIRISU_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7007,7 +7785,8 @@
     "name": "Riolu",
     "image": "cPK_20_005070_00_RIOLU_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7016,7 +7795,8 @@
     "name": "Varoom",
     "image": "cPK_20_005700_00_BURORON_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7025,7 +7805,8 @@
     "name": "Revavroom",
     "image": "cPK_20_005710_00_BUROROROOM_S.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7034,7 +7815,8 @@
     "name": "Beedrill ex",
     "image": "cPK_20_005230_01_SPEARex_SSR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7043,7 +7825,8 @@
     "name": "Charizard ex",
     "image": "cPK_20_005290_01_LIZARDONex_SSR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7052,7 +7835,8 @@
     "name": "Wugtrio ex",
     "image": "cPK_20_005380_01_UMITRIOex_SSR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
@@ -7061,16 +7845,18 @@
     "name": "Lucario ex",
     "image": "cPK_20_005580_01_LUCARIOex_SSR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A2b",
     "number": 111,
     "rarity": "UR",
-    "name": "Pok\u00e9 Ball",
+    "name": "Poké Ball",
     "image": "cTR_20_000030_00_MONSTERBALL_UR.webp",
     "packs": ["Shining"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7079,7 +7865,8 @@
     "name": "Exeggcute",
     "image": "cPK_10_005820_00_TAMATAMA_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7088,7 +7875,8 @@
     "name": "Alolan Exeggutor",
     "image": "cPK_10_005830_00_ALOLANASSY_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7097,7 +7885,8 @@
     "name": "Surskit",
     "image": "cPK_10_005840_00_AMETAMA_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7106,7 +7895,8 @@
     "name": "Masquerain",
     "image": "cPK_10_005850_00_AMEMOTH_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7115,7 +7905,8 @@
     "name": "Maractus",
     "image": "cPK_10_005860_00_MARACACCHI_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7124,7 +7915,8 @@
     "name": "Karrablast",
     "image": "cPK_10_005870_00_KABURUMO_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7133,7 +7925,8 @@
     "name": "Phantump",
     "image": "cPK_10_005880_00_BOKUREI_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7142,7 +7935,8 @@
     "name": "Trevenant",
     "image": "cPK_10_005890_00_OHROT_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7151,7 +7945,8 @@
     "name": "Rowlet",
     "image": "cPK_10_005900_00_MOKUROH_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7160,7 +7955,8 @@
     "name": "Rowlet",
     "image": "cPK_10_005910_00_MOKUROH_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7169,7 +7965,8 @@
     "name": "Dartrix",
     "image": "cPK_10_005920_00_FUKUTHROW_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7178,7 +7975,8 @@
     "name": "Decidueye ex",
     "image": "cPK_10_005930_00_JUNAIPERex_RR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7187,7 +7985,8 @@
     "name": "Grubbin",
     "image": "cPK_10_005940_00_AGOJIMUSHI_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7196,7 +7995,8 @@
     "name": "Fomantis",
     "image": "cPK_10_005950_00_KARIKIRI_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7205,7 +8005,8 @@
     "name": "Lurantis",
     "image": "cPK_10_005960_00_LALANTES_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7214,7 +8015,8 @@
     "name": "Morelull",
     "image": "cPK_10_005970_00_NEMASYU_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7223,7 +8025,8 @@
     "name": "Shiinotic",
     "image": "cPK_10_005980_00_MASHADE_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7232,7 +8035,8 @@
     "name": "Bounsweet",
     "image": "cPK_10_005990_00_AMAKAJI_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7241,7 +8045,8 @@
     "name": "Steenee",
     "image": "cPK_10_006000_00_AMAMAIKO_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7250,7 +8055,8 @@
     "name": "Tsareena",
     "image": "cPK_10_006010_00_AMAJO_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7259,7 +8065,8 @@
     "name": "Wimpod",
     "image": "cPK_10_006020_00_KOSOKUMUSHI_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7268,7 +8075,8 @@
     "name": "Golisopod",
     "image": "cPK_10_006030_00_GUSOKUMUSHA_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7277,7 +8085,8 @@
     "name": "Dhelmise ex",
     "image": "cPK_10_006040_00_DADARINex_RR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7286,7 +8095,8 @@
     "name": "Tapu Bulu",
     "image": "cPK_10_006050_00_KAPU-BULUL_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7295,7 +8105,8 @@
     "name": "Growlithe",
     "image": "cPK_10_006060_00_GARDIE_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7304,7 +8115,8 @@
     "name": "Arcanine",
     "image": "cPK_10_006070_00_WINDIE_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7313,7 +8125,8 @@
     "name": "Alolan Marowak",
     "image": "cPK_10_006080_00_ALOLAGARAGARA_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7322,7 +8135,8 @@
     "name": "Fletchinder",
     "image": "cPK_10_006090_00_HINOYAKOMA_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7331,7 +8145,8 @@
     "name": "Talonflame",
     "image": "cPK_10_006100_00_FIARROW_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7340,7 +8155,8 @@
     "name": "Litten",
     "image": "cPK_10_006110_00_NYABBY_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7349,7 +8165,8 @@
     "name": "Litten",
     "image": "cPK_10_006120_00_NYABBY_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7358,7 +8175,8 @@
     "name": "Torracat",
     "image": "cPK_10_006130_00_NYAHEAT_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7367,7 +8185,8 @@
     "name": "Incineroar ex",
     "image": "cPK_10_006140_00_GAOGAENex_RR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7376,7 +8195,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006150_00_ODORIDORIMERAMERASTYLE_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7385,7 +8205,8 @@
     "name": "Salandit",
     "image": "cPK_10_006160_00_YATOUMORI_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7394,7 +8215,8 @@
     "name": "Salazzle",
     "image": "cPK_10_006170_00_ENNEWT_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7403,7 +8225,8 @@
     "name": "Turtonator",
     "image": "cPK_10_006180_00_BAKUGAMES_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7412,7 +8235,8 @@
     "name": "Alolan Sandshrew",
     "image": "cPK_10_006190_00_ALOLASAND_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7421,7 +8245,8 @@
     "name": "Alolan Sandslash",
     "image": "cPK_10_006200_00_ALOLASANDPAN_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7430,7 +8255,8 @@
     "name": "Alolan Vulpix",
     "image": "cPK_10_006210_00_ALOLAROKON_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7439,7 +8265,8 @@
     "name": "Alolan Ninetales",
     "image": "cPK_10_006220_00_ALOLAKYUKON_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7448,7 +8275,8 @@
     "name": "Shellder",
     "image": "cPK_10_006230_00_SHELLDER_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7457,7 +8285,8 @@
     "name": "Cloyster",
     "image": "cPK_10_006240_00_PARSHEN_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7466,7 +8295,8 @@
     "name": "Lapras",
     "image": "cPK_10_006250_00_LAPLACE_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7475,7 +8305,8 @@
     "name": "Popplio",
     "image": "cPK_10_006260_00_ASHIMARI_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7484,7 +8315,8 @@
     "name": "Popplio",
     "image": "cPK_10_006270_00_ASHIMARI_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7493,7 +8325,8 @@
     "name": "Brionne",
     "image": "cPK_10_006280_00_OSYAMARI_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7502,7 +8335,8 @@
     "name": "Primarina",
     "image": "cPK_10_006290_00_ASHIRENE_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7511,7 +8345,8 @@
     "name": "Crabominable ex",
     "image": "cPK_10_006300_00_KEKENKANIex_RR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7520,7 +8355,8 @@
     "name": "Wishiwashi",
     "image": "cPK_10_006310_00_YOWASHITANDOKUNOSUGATA_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7529,7 +8365,8 @@
     "name": "Wishiwashi ex",
     "image": "cPK_10_006320_00_YOWASHIMURETASUGATA_RR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7538,7 +8375,8 @@
     "name": "Dewpider",
     "image": "cPK_10_006330_00_SHIZUKUMO_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7547,7 +8385,8 @@
     "name": "Araquanid",
     "image": "cPK_10_006340_00_ONISHIZUKUMO_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7556,7 +8395,8 @@
     "name": "Pyukumuku",
     "image": "cPK_10_006350_00_NAMAKOBUSHI_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7565,7 +8405,8 @@
     "name": "Bruxish",
     "image": "cPK_10_006360_00_HAGIGISHIRI_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7574,7 +8415,8 @@
     "name": "Tapu Fini",
     "image": "cPK_10_006370_00_KAPU-REHIRE_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7583,7 +8425,8 @@
     "name": "Pikachu",
     "image": "cPK_10_006380_00_PIKACHU_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7592,7 +8435,8 @@
     "name": "Alolan Raichu ex",
     "image": "cPK_10_006390_00_ALOLARAICHUex_RR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7601,7 +8445,8 @@
     "name": "Alolan Geodude",
     "image": "cPK_10_006400_00_ALOLAISITSUBUTE_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7610,7 +8455,8 @@
     "name": "Alolan Graveler",
     "image": "cPK_10_006410_00_ALOLAGOLONE_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7619,7 +8465,8 @@
     "name": "Alolan Golem",
     "image": "cPK_10_006420_00_ALOLAGOLONYA_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7628,7 +8475,8 @@
     "name": "Helioptile",
     "image": "cPK_10_006430_00_ERIKITERU_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7637,7 +8485,8 @@
     "name": "Heliolisk",
     "image": "cPK_10_006440_00_ELEZARD_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7646,7 +8495,8 @@
     "name": "Charjabug",
     "image": "cPK_10_006450_00_DENDIMUSHI_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7655,7 +8505,8 @@
     "name": "Vikavolt",
     "image": "cPK_10_006460_00_KUWAGANNON_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7664,7 +8515,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006470_00_ODORIDORIPACHIPACHISTYLE_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7673,7 +8525,8 @@
     "name": "Togedemaru",
     "image": "cPK_10_006480_00_TOGEDEMARU_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7682,7 +8535,8 @@
     "name": "Tapu Koko",
     "image": "cPK_10_006490_00_KAPU-KOKEKO_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7691,7 +8545,8 @@
     "name": "Mr. Mime",
     "image": "cPK_10_006500_00_BARRIERD_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7700,7 +8555,8 @@
     "name": "Sableye",
     "image": "cPK_10_006510_00_YAMIRAMI_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7709,7 +8565,8 @@
     "name": "Spoink",
     "image": "cPK_10_006520_00_BANEBOO_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7718,7 +8575,8 @@
     "name": "Grumpig",
     "image": "cPK_10_006530_00_BOOPIG_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7727,7 +8585,8 @@
     "name": "Lunatone",
     "image": "cPK_10_006540_00_LUNATONE_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7736,7 +8595,8 @@
     "name": "Shuppet",
     "image": "cPK_10_006550_00_KAGEBOUZU_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7745,7 +8605,8 @@
     "name": "Banette",
     "image": "cPK_10_006560_00_JUPPETA_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7754,7 +8615,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006570_00_ODORIDORIFURAFURASTYLE_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7763,7 +8625,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006580_00_ODORIDORIMAIMAISTYLE_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7772,7 +8635,8 @@
     "name": "Cutiefly",
     "image": "cPK_10_006590_00_ABULY_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7781,7 +8645,8 @@
     "name": "Ribombee",
     "image": "cPK_10_006600_00_ABURIBBON_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7790,7 +8655,8 @@
     "name": "Comfey",
     "image": "cPK_10_006610_00_CUWAWA_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7799,7 +8665,8 @@
     "name": "Sandygast",
     "image": "cPK_10_006620_00_SUNABA_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7808,7 +8675,8 @@
     "name": "Palossand",
     "image": "cPK_10_006630_00_SIRODETHNA_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7817,7 +8685,8 @@
     "name": "Mimikyu",
     "image": "cPK_10_006640_00_MIMIKKYU_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7826,7 +8695,8 @@
     "name": "Tapu Lele",
     "image": "cPK_10_006650_00_KAPU-TETEFU_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7835,7 +8705,8 @@
     "name": "Cosmog",
     "image": "cPK_10_006660_00_COSMOG_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7844,7 +8715,8 @@
     "name": "Cosmoem",
     "image": "cPK_10_006670_00_COSMOVUM_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7853,7 +8725,8 @@
     "name": "Lunala ex",
     "image": "cPK_10_006680_00_LUNALAex_RR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7862,7 +8735,8 @@
     "name": "Necrozma",
     "image": "cPK_10_006690_00_NECROZMA_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7871,7 +8745,8 @@
     "name": "Cubone",
     "image": "cPK_10_006700_00_KARAKARA_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7880,7 +8755,8 @@
     "name": "Makuhita",
     "image": "cPK_10_006710_00_MAKUNOSHITA_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7889,7 +8765,8 @@
     "name": "Hariyama",
     "image": "cPK_10_006720_00_HARITEYAMA_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7898,7 +8775,8 @@
     "name": "Solrock",
     "image": "cPK_10_006730_00_SOLROCK_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7907,7 +8785,8 @@
     "name": "Drilbur",
     "image": "cPK_10_006740_00_MOGUREW_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7916,7 +8795,8 @@
     "name": "Timburr",
     "image": "cPK_10_006750_00_DOKKORER_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7925,7 +8805,8 @@
     "name": "Gurdurr",
     "image": "cPK_10_006760_00_DOTEKKOTSU_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7934,7 +8815,8 @@
     "name": "Conkeldurr",
     "image": "cPK_10_006770_00_ROUBUSHIN_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7943,7 +8825,8 @@
     "name": "Crabrawler",
     "image": "cPK_10_006780_00_MAKENKANI_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7952,7 +8835,8 @@
     "name": "Rockruff",
     "image": "cPK_10_006790_00_IWANKO_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7961,7 +8845,8 @@
     "name": "Rockruff",
     "image": "cPK_10_006800_00_IWANKO_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7970,7 +8855,8 @@
     "name": "Lycanroc",
     "image": "cPK_10_006810_00_LUGARUGANMAHIRUNOSUGATA_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7979,7 +8865,8 @@
     "name": "Lycanroc",
     "image": "cPK_10_006820_00_LUGARUGANMAYONAKANOSUGATA_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7988,7 +8875,8 @@
     "name": "Mudbray",
     "image": "cPK_10_006830_00_DOROBANKO_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -7997,7 +8885,8 @@
     "name": "Mudsdale",
     "image": "cPK_10_006840_00_BANBADORO_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8006,7 +8895,8 @@
     "name": "Passimian ex",
     "image": "cPK_10_006850_00_NAGETUKESARUex_RR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8015,7 +8905,8 @@
     "name": "Minior",
     "image": "cPK_10_006860_00_METENOAKAIRONOCORE_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8024,7 +8915,8 @@
     "name": "Alolan Rattata",
     "image": "cPK_10_006870_00_ALOLAKORATTA_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8033,7 +8925,8 @@
     "name": "Alolan Raticate",
     "image": "cPK_10_006880_00_ALOLARATTA_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8042,7 +8935,8 @@
     "name": "Alolan Meowth",
     "image": "cPK_10_006890_00_ALOLANYARTH_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8051,7 +8945,8 @@
     "name": "Alolan Persian",
     "image": "cPK_10_006900_00_ALOLAPERSIAN_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8060,7 +8955,8 @@
     "name": "Alolan Grimer",
     "image": "cPK_10_006910_00_ALOLABETBETER_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8069,7 +8965,8 @@
     "name": "Alolan Muk ex",
     "image": "cPK_10_006920_00_ALOLABETBETONex_RR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8078,7 +8975,8 @@
     "name": "Absol",
     "image": "cPK_10_006930_00_ABSOL_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8087,7 +8985,8 @@
     "name": "Trubbish",
     "image": "cPK_10_006940_00_YABUKURON_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8096,7 +8995,8 @@
     "name": "Garbodor",
     "image": "cPK_10_006950_00_DUSTDAS_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8105,7 +9005,8 @@
     "name": "Mareanie",
     "image": "cPK_10_006960_00_HIDOIDE_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8114,7 +9015,8 @@
     "name": "Toxapex",
     "image": "cPK_10_006970_00_DOHIDOIDE_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8123,7 +9025,8 @@
     "name": "Alolan Diglett",
     "image": "cPK_10_006980_00_ALOLADIGDA_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8132,7 +9035,8 @@
     "name": "Alolan Dugtrio",
     "image": "cPK_10_006990_00_ALOLADUGTRIO_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8141,7 +9045,8 @@
     "name": "Excadrill",
     "image": "cPK_10_007000_00_DORYUZU_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8150,7 +9055,8 @@
     "name": "Escavalier",
     "image": "cPK_10_007010_00_CHEVARGO_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8159,7 +9065,8 @@
     "name": "Klefki",
     "image": "cPK_10_007020_00_CLEFFY_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8168,7 +9075,8 @@
     "name": "Solgaleo ex",
     "image": "cPK_10_007030_00_SOLGALEOex_RR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8177,7 +9085,8 @@
     "name": "Magearna",
     "image": "cPK_10_007040_00_MAGEARNA_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8186,7 +9095,8 @@
     "name": "Drampa",
     "image": "cPK_10_007050_00_JIJILONG_R.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8195,7 +9105,8 @@
     "name": "Jangmo-o",
     "image": "cPK_10_007060_00_JYARAKO_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8204,7 +9115,8 @@
     "name": "Hakamo-o",
     "image": "cPK_10_007070_00_JYARANGO_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8213,7 +9125,8 @@
     "name": "Kommo-o",
     "image": "cPK_10_007080_00_JYARARANGA_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8222,7 +9135,8 @@
     "name": "Tauros",
     "image": "cPK_10_007090_00_KENTAUROS_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8231,7 +9145,8 @@
     "name": "Skitty",
     "image": "cPK_10_007100_00_ENECO_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8240,7 +9155,8 @@
     "name": "Delcatty",
     "image": "cPK_10_007110_00_ENEKORORO_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8249,7 +9165,8 @@
     "name": "Fletchling",
     "image": "cPK_10_007120_00_YAYAKOMA_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8258,7 +9175,8 @@
     "name": "Hawlucha",
     "image": "cPK_10_007130_00_LUCHABULL_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8267,7 +9185,8 @@
     "name": "Pikipek",
     "image": "cPK_10_007140_00_TSUTSUKERA_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8276,7 +9195,8 @@
     "name": "Trumbeak",
     "image": "cPK_10_007150_00_KERARAPPA_C.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8285,7 +9205,8 @@
     "name": "Toucannon",
     "image": "cPK_10_007160_00_DODEKABASHI_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8294,7 +9215,8 @@
     "name": "Yungoos",
     "image": "cPK_10_007170_00_YOUNGOOSE_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8303,7 +9225,8 @@
     "name": "Gumshoos",
     "image": "cPK_10_007180_00_DEKAGOOSE_C.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8312,7 +9235,8 @@
     "name": "Stufful",
     "image": "cPK_10_007190_00_NUIKOGUMA_C.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8321,7 +9245,8 @@
     "name": "Bewear",
     "image": "cPK_10_007200_00_KITERUGUMA_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8330,7 +9255,8 @@
     "name": "Oranguru",
     "image": "cPK_10_007210_00_YAREYUUTAN_R.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8339,7 +9265,8 @@
     "name": "Komala",
     "image": "cPK_10_007220_00_NEKKOARA_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8348,7 +9275,8 @@
     "name": "Big Malasada",
     "image": "cTR_10_000460_00_OOKIIMARASADA_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8357,7 +9285,8 @@
     "name": "Fishing Net",
     "image": "cTR_10_000470_00_OSAKANANETTO_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8366,7 +9295,8 @@
     "name": "Rare Candy",
     "image": "cTR_10_000480_00_FUSHIGINAAME_U.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8375,7 +9305,8 @@
     "name": "Rotom Dex",
     "image": "cTR_10_000490_00_ROTOMUZUKAN_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8384,7 +9315,8 @@
     "name": "Poison Barb",
     "image": "cTR_10_000500_00_DOKUBARI_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8393,7 +9325,8 @@
     "name": "Leaf Cape",
     "image": "cTR_10_000510_00_LEAFMANTO_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8402,7 +9335,8 @@
     "name": "Acerola",
     "image": "cTR_10_000520_00_ACEROLA_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8411,7 +9345,8 @@
     "name": "Ilima",
     "image": "cTR_10_000530_00_ILIMA_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8420,7 +9355,8 @@
     "name": "Kiawe",
     "image": "cTR_10_000540_00_KAKI_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8429,7 +9365,8 @@
     "name": "Guzma",
     "image": "cTR_10_000550_00_GUZUMA_U.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8438,7 +9375,8 @@
     "name": "Lana",
     "image": "cTR_10_000560_00_SUIREN_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8447,7 +9385,8 @@
     "name": "Sophocles",
     "image": "cTR_10_000570_00_MAMANE_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8456,7 +9395,8 @@
     "name": "Mallow",
     "image": "cTR_10_000580_00_MAO_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8465,7 +9405,8 @@
     "name": "Lillie",
     "image": "cTR_10_000590_00_LILIE_U.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8474,7 +9415,8 @@
     "name": "Alolan Exeggutor",
     "image": "cPK_20_005830_00_ALOLANASSY_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8483,7 +9425,8 @@
     "name": "Morelull",
     "image": "cPK_20_005970_00_NEMASYU_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8492,7 +9435,8 @@
     "name": "Tsareena",
     "image": "cPK_20_006010_00_AMAJO_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8501,7 +9445,8 @@
     "name": "Tapu Bulu",
     "image": "cPK_20_006050_00_KAPU-BULUL_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8510,7 +9455,8 @@
     "name": "Alolan Marowak",
     "image": "cPK_20_006080_00_ALOLAGARAGARA_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8519,7 +9465,8 @@
     "name": "Turtonator",
     "image": "cPK_20_006180_00_BAKUGAMES_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8528,7 +9475,8 @@
     "name": "Alolan Vulpix",
     "image": "cPK_20_006210_00_ALOLAROKON_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8537,7 +9485,8 @@
     "name": "Pyukumuku",
     "image": "cPK_20_006350_00_NAMAKOBUSHI_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8546,7 +9495,8 @@
     "name": "Tapu Fini",
     "image": "cPK_20_006370_00_KAPU-REHIRE_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8555,7 +9505,8 @@
     "name": "Oricorio",
     "image": "cPK_20_006470_00_ODORIDORIPACHIPACHISTYLE_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8564,7 +9515,8 @@
     "name": "Tapu Koko",
     "image": "cPK_20_006490_00_KAPU-KOKEKO_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8573,7 +9525,8 @@
     "name": "Cutiefly",
     "image": "cPK_20_006590_00_ABULY_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8582,7 +9535,8 @@
     "name": "Comfey",
     "image": "cPK_20_006610_00_CUWAWA_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8591,7 +9545,8 @@
     "name": "Sandygast",
     "image": "cPK_20_006620_00_SUNABA_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8600,7 +9555,8 @@
     "name": "Tapu Lele",
     "image": "cPK_20_006650_00_KAPU-TETEFU_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8609,7 +9565,8 @@
     "name": "Cosmog",
     "image": "cPK_20_006660_00_COSMOG_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8618,7 +9575,8 @@
     "name": "Rockruff",
     "image": "cPK_20_006790_00_IWANKO_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8627,7 +9585,8 @@
     "name": "Mudsdale",
     "image": "cPK_20_006840_00_BANBADORO_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8636,7 +9595,8 @@
     "name": "Minior",
     "image": "cPK_20_006860_00_METENOAKAIRONOCORE_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8645,7 +9605,8 @@
     "name": "Magearna",
     "image": "cPK_20_007040_00_MAGEARNA_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8654,7 +9615,8 @@
     "name": "Drampa",
     "image": "cPK_20_007050_00_JIJILONG_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8663,7 +9625,8 @@
     "name": "Pikipek",
     "image": "cPK_20_007140_00_TSUTSUKERA_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8672,7 +9635,8 @@
     "name": "Bewear",
     "image": "cPK_20_007200_00_KITERUGUMA_AR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8681,7 +9645,8 @@
     "name": "Komala",
     "image": "cPK_20_007220_00_NEKKOARA_AR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8690,7 +9655,8 @@
     "name": "Decidueye ex",
     "image": "cPK_20_005930_00_JUNAIPERex_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8699,7 +9665,8 @@
     "name": "Dhelmise ex",
     "image": "cPK_20_006040_00_DADARINex_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8708,7 +9675,8 @@
     "name": "Incineroar ex",
     "image": "cPK_20_006140_00_GAOGAENex_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8717,7 +9685,8 @@
     "name": "Crabominable ex",
     "image": "cPK_20_006300_00_KEKENKANIex_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8726,7 +9695,8 @@
     "name": "Wishiwashi ex",
     "image": "cPK_20_006320_00_YOWASHIMURETASUGATA_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8735,7 +9705,8 @@
     "name": "Alolan Raichu ex",
     "image": "cPK_20_006390_00_ALOLARAICHUex_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8744,7 +9715,8 @@
     "name": "Lunala ex",
     "image": "cPK_20_006680_00_LUNALAex_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8753,7 +9725,8 @@
     "name": "Passimian ex",
     "image": "cPK_20_006850_00_NAGETUKESARUex_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8762,7 +9735,8 @@
     "name": "Alolan Muk ex",
     "image": "cPK_20_006920_00_ALOLABETBETONex_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8771,7 +9745,8 @@
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_00_SOLGALEOex_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8780,7 +9755,8 @@
     "name": "Acerola",
     "image": "cTR_20_000520_00_ACEROLA_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8789,7 +9765,8 @@
     "name": "Ilima",
     "image": "cTR_20_000530_00_ILIMA_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8798,7 +9775,8 @@
     "name": "Kiawe",
     "image": "cTR_20_000540_00_KAKI_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8807,7 +9785,8 @@
     "name": "Guzma",
     "image": "cTR_20_000550_00_GUZUMA_SR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8816,7 +9795,8 @@
     "name": "Lana",
     "image": "cTR_20_000560_00_SUIREN_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8825,7 +9805,8 @@
     "name": "Sophocles",
     "image": "cTR_20_000570_00_MAMANE_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8834,7 +9815,8 @@
     "name": "Mallow",
     "image": "cTR_20_000580_00_MAO_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8843,7 +9825,8 @@
     "name": "Lillie",
     "image": "cTR_20_000590_00_LILIE_SR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8852,7 +9835,8 @@
     "name": "Decidueye ex",
     "image": "cPK_20_005930_01_JUNAIPERex_SAR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8861,7 +9845,8 @@
     "name": "Dhelmise ex",
     "image": "cPK_20_006040_01_DADARINex_SAR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8870,7 +9855,8 @@
     "name": "Incineroar ex",
     "image": "cPK_20_006140_01_GAOGAENex_SAR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8879,7 +9865,8 @@
     "name": "Crabominable ex",
     "image": "cPK_20_006300_01_KEKENKANIex_SAR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8888,7 +9875,8 @@
     "name": "Wishiwashi ex",
     "image": "cPK_20_006320_01_YOWASHIMURETASUGATA_SAR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8897,7 +9885,8 @@
     "name": "Alolan Raichu ex",
     "image": "cPK_20_006390_01_ALOLARAICHUex_SAR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8906,7 +9895,8 @@
     "name": "Lunala ex",
     "image": "cPK_20_006680_01_LUNALAex_SAR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8915,7 +9905,8 @@
     "name": "Passimian ex",
     "image": "cPK_20_006850_01_NAGETUKESARUex_SAR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8924,7 +9915,8 @@
     "name": "Alolan Muk ex",
     "image": "cPK_20_006920_01_ALOLABETBETONex_SAR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8933,7 +9925,8 @@
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_01_SOLGALEOex_SAR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8942,7 +9935,8 @@
     "name": "Guzma",
     "image": "cTR_20_000550_01_GUZUMA_IM.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8951,7 +9945,8 @@
     "name": "Lillie",
     "image": "cTR_20_000590_01_LILIE_IM.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -8960,7 +9955,8 @@
     "name": "Bulbasaur",
     "image": "cPK_20_000010_01_FUSHIGIDANE_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -8969,7 +9965,8 @@
     "name": "Ivysaur",
     "image": "cPK_20_000020_00_FUSHIGISOU_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -8978,7 +9975,8 @@
     "name": "Venusaur",
     "image": "cPK_20_000030_00_FUSHIGIBANA_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -8987,7 +9985,8 @@
     "name": "Exeggcute",
     "image": "cPK_20_005820_00_TAMATAMA_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -8996,7 +9995,8 @@
     "name": "Exeggutor",
     "image": "cPK_20_002160_01_NASSY_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9005,7 +10005,8 @@
     "name": "Squirtle",
     "image": "cPK_20_000530_01_ZENIGAME_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9014,7 +10015,8 @@
     "name": "Wartortle",
     "image": "cPK_20_000540_00_KAMEIL_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9023,7 +10025,8 @@
     "name": "Blastoise",
     "image": "cPK_20_000550_00_KAMEX_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9032,7 +10035,8 @@
     "name": "Staryu",
     "image": "cPK_20_000740_00_HITODEMAN_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9041,7 +10045,8 @@
     "name": "Starmie",
     "image": "cPK_20_000750_00_STARMIE_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9050,7 +10055,8 @@
     "name": "Gastly",
     "image": "cPK_20_004550_00_GHOS_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9059,7 +10065,8 @@
     "name": "Haunter",
     "image": "cPK_20_001210_00_GHOST_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9068,7 +10075,8 @@
     "name": "Gengar",
     "image": "cPK_20_001220_00_GANGAR_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9077,7 +10085,8 @@
     "name": "Machop",
     "image": "cPK_20_001430_00_WANRIKY_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9086,7 +10095,8 @@
     "name": "Machoke",
     "image": "cPK_20_001440_00_GORIKY_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9095,7 +10105,8 @@
     "name": "Machamp",
     "image": "cPK_20_005020_00_KAIRIKY_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9104,7 +10115,8 @@
     "name": "Cubone",
     "image": "cPK_20_001510_01_KARAKARA_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9113,7 +10125,8 @@
     "name": "Marowak",
     "image": "cPK_20_001520_00_GARAGARA_S.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9122,7 +10135,8 @@
     "name": "Jigglypuff",
     "image": "cPK_20_005750_00_PURIN_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9131,7 +10145,8 @@
     "name": "Wigglytuff",
     "image": "cPK_20_005760_01_PUKURIN_S.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9140,7 +10155,8 @@
     "name": "Venusaur ex",
     "image": "cPK_20_000040_01_FUSHIGIBANAex_SSR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9149,7 +10165,8 @@
     "name": "Exeggutor ex",
     "image": "cPK_20_000230_01_NASSYex_SSR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9158,7 +10175,8 @@
     "name": "Blastoise ex",
     "image": "cPK_20_000560_01_KAMEXex_SSR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9167,7 +10185,8 @@
     "name": "Starmie ex",
     "image": "cPK_20_000760_01_STARMIEex_SSR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9176,7 +10195,8 @@
     "name": "Gengar ex",
     "image": "cPK_20_001230_02_GANGARex_SSR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9185,7 +10205,8 @@
     "name": "Machamp ex",
     "image": "cPK_20_001460_02_KAIRIKYex_SSR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9194,7 +10215,8 @@
     "name": "Marowak ex",
     "image": "cPK_20_001530_01_GARAGARAex_SSR.webp",
     "packs": ["Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9203,7 +10225,8 @@
     "name": "Wigglytuff ex",
     "image": "cPK_20_001950_02_PUKURINex_SSR.webp",
     "packs": ["Solgaleo"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3",
@@ -9212,7 +10235,8 @@
     "name": "Lunala ex",
     "image": "cPK_20_006680_02_LUNALAex_UR.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3",
@@ -9221,7 +10245,8 @@
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_02_SOLGALEOex_UR.webp",
     "packs": ["Solgaleo", "Lunala"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9230,7 +10255,8 @@
     "name": "Petilil",
     "image": "cPK_10_007430_00_CHURINE_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9239,7 +10265,8 @@
     "name": "Lilligant",
     "image": "cPK_10_007440_00_DREDEAR_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9248,7 +10275,8 @@
     "name": "Rowlet",
     "image": "cPK_10_007450_00_MOKUROH_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9257,7 +10285,8 @@
     "name": "Dartrix",
     "image": "cPK_10_007460_00_FUKUTHROW_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9266,7 +10295,8 @@
     "name": "Decidueye",
     "image": "cPK_10_007470_00_JUNAIPER_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9275,7 +10305,8 @@
     "name": "Buzzwole ex",
     "image": "cPK_10_007480_00_MASSIVOONex_RR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9284,7 +10315,8 @@
     "name": "Pheromosa",
     "image": "cPK_10_007490_00_PHEROACHE_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9293,7 +10325,8 @@
     "name": "Kartana",
     "image": "cPK_10_007250_00_KAMITURUGI_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9302,7 +10335,8 @@
     "name": "Blacephalon",
     "image": "cPK_10_007260_00_ZUGADOON_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9311,7 +10345,8 @@
     "name": "Mantine",
     "image": "cPK_10_007500_00_MANTAIN_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9320,7 +10355,8 @@
     "name": "Carvanha",
     "image": "cPK_10_007510_00_KIBANHA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9329,7 +10365,8 @@
     "name": "Sharpedo",
     "image": "cPK_10_007520_00_SAMEHADER_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9338,7 +10375,8 @@
     "name": "Shinx",
     "image": "cPK_10_007530_00_KOLINK_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9347,7 +10385,8 @@
     "name": "Luxio",
     "image": "cPK_10_007540_00_LUXIO_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9356,7 +10395,8 @@
     "name": "Luxray",
     "image": "cPK_10_007550_00_RENTORAR_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9365,7 +10405,8 @@
     "name": "Blitzle",
     "image": "cPK_10_007560_00_SHIMAMA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9374,7 +10415,8 @@
     "name": "Zebstrika",
     "image": "cPK_10_007570_00_ZEBRAIKA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9383,7 +10425,8 @@
     "name": "Emolga",
     "image": "cPK_10_007580_00_EMOLGA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9392,7 +10435,8 @@
     "name": "Tapu Koko ex",
     "image": "cPK_10_007420_00_KAPU-KOKEKOex_RR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9401,7 +10445,8 @@
     "name": "Xurkitree",
     "image": "cPK_10_007270_00_DENJYUMOKU_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9410,7 +10455,8 @@
     "name": "Zeraora",
     "image": "cPK_10_007410_00_ZERAORA_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9419,7 +10465,8 @@
     "name": "Clefairy",
     "image": "cPK_10_007590_00_PIPPI_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9428,7 +10475,8 @@
     "name": "Clefable",
     "image": "cPK_10_007600_00_PIXY_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9437,7 +10485,8 @@
     "name": "Phantump",
     "image": "cPK_10_007610_00_BOKUREI_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9446,7 +10495,8 @@
     "name": "Trevenant",
     "image": "cPK_10_007620_00_OHROT_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9455,7 +10505,8 @@
     "name": "Morelull",
     "image": "cPK_10_007630_00_NEMASYU_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9464,7 +10515,8 @@
     "name": "Shiinotic",
     "image": "cPK_10_007640_00_MASHADE_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9473,7 +10525,8 @@
     "name": "Meditite",
     "image": "cPK_10_007650_00_ASANAN_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9482,7 +10535,8 @@
     "name": "Medicham",
     "image": "cPK_10_007660_00_CHAREM_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9491,7 +10545,8 @@
     "name": "Baltoy",
     "image": "cPK_10_007670_00_YAJILON_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9500,7 +10555,8 @@
     "name": "Claydol",
     "image": "cPK_10_007680_00_NENDOLL_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9509,7 +10565,8 @@
     "name": "Rockruff",
     "image": "cPK_10_007690_00_IWANKO_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9518,7 +10575,8 @@
     "name": "Lycanroc ex",
     "image": "cPK_10_007700_00_LUGARUGANTASOGARENOSUGATA_RR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9527,7 +10585,8 @@
     "name": "Passimian",
     "image": "cPK_10_007710_00_NAGETUKESARU_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9536,7 +10595,8 @@
     "name": "Sandygast",
     "image": "cPK_10_007720_00_SUNABA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9545,7 +10605,8 @@
     "name": "Palossand",
     "image": "cPK_10_007730_00_SIRODETHNA_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9554,7 +10615,8 @@
     "name": "Alolan Meowth",
     "image": "cPK_10_007740_00_ALOLANYARTH_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9563,7 +10625,8 @@
     "name": "Alolan Persian",
     "image": "cPK_10_007750_00_ALOLAPERSIAN_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9572,7 +10635,8 @@
     "name": "Sandile",
     "image": "cPK_10_007760_00_MEGUROCO_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9581,7 +10645,8 @@
     "name": "Krokorok",
     "image": "cPK_10_007770_00_WARUVILE_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9590,7 +10655,8 @@
     "name": "Krookodile",
     "image": "cPK_10_007780_00_WARUVIAL_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9599,7 +10665,8 @@
     "name": "Nihilego",
     "image": "cPK_10_007790_00_UTUROID_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9608,7 +10675,8 @@
     "name": "Guzzlord ex",
     "image": "cPK_10_007800_00_AKUZIKINGex_RR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9617,7 +10685,8 @@
     "name": "Poipole",
     "image": "cPK_10_007370_00_BEVENOM_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9626,7 +10695,8 @@
     "name": "Naganadel",
     "image": "cPK_10_007810_00_AGOYON_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9635,7 +10705,8 @@
     "name": "Alolan Diglett",
     "image": "cPK_10_007820_00_ALOLADIGDA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9644,7 +10715,8 @@
     "name": "Alolan Dugtrio ex",
     "image": "cPK_10_007830_00_ALOLADUGTRIOex_RR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9653,7 +10725,8 @@
     "name": "Aron",
     "image": "cPK_10_007840_00_COKODORA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9662,7 +10735,8 @@
     "name": "Lairon",
     "image": "cPK_10_007850_00_KODORA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9671,7 +10745,8 @@
     "name": "Aggron",
     "image": "cPK_10_007860_00_BOSSGODORA_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9680,7 +10755,8 @@
     "name": "Ferroseed",
     "image": "cPK_10_007870_00_TESSEED_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9689,7 +10765,8 @@
     "name": "Ferrothorn",
     "image": "cPK_10_007880_00_NUTREY_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9698,7 +10775,8 @@
     "name": "Stakataka",
     "image": "cPK_10_007300_00_TUNDETUNDE_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9707,7 +10785,8 @@
     "name": "Lillipup",
     "image": "cPK_10_007890_00_YORTERRIE_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9716,7 +10795,8 @@
     "name": "Herdier",
     "image": "cPK_10_007900_00_HERDERRIE_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9725,7 +10805,8 @@
     "name": "Stoutland",
     "image": "cPK_10_007910_00_MOOLAND_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9734,7 +10815,8 @@
     "name": "Stufful",
     "image": "cPK_10_007380_00_NUIKOGUMA_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9743,7 +10825,8 @@
     "name": "Bewear",
     "image": "cPK_10_007920_00_KITERUGUMA_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9752,7 +10835,8 @@
     "name": "Oranguru",
     "image": "cPK_10_007930_00_YAREYUUTAN_C.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9761,7 +10845,8 @@
     "name": "Type: Null",
     "image": "cPK_10_007940_00_TYPENULL_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9770,7 +10855,8 @@
     "name": "Silvally",
     "image": "cPK_10_007950_00_SILVADY_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9779,7 +10865,8 @@
     "name": "Celesteela",
     "image": "cPK_10_007960_00_TEKKAGUYA_R.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9788,7 +10875,8 @@
     "name": "Beast Wall",
     "image": "cTR_10_000600_00_BISUTOWORU_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9797,7 +10885,8 @@
     "name": "Repel",
     "image": "cTR_10_000610_00_MUSHIYOKESUPUREI_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9806,7 +10895,8 @@
     "name": "Electrical Cord",
     "image": "cTR_10_000620_00_EREKIKORD_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9815,7 +10905,8 @@
     "name": "Beastite",
     "image": "cTR_10_000630_00_BISUTONAITO_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9824,7 +10915,8 @@
     "name": "Gladion",
     "image": "cTR_10_000640_00_GLAZIO_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9833,7 +10925,8 @@
     "name": "Looker",
     "image": "cTR_10_000650_00_HANDSOME_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9842,7 +10935,8 @@
     "name": "Lusamine",
     "image": "cTR_10_000660_00_LUSAMINE_U.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9851,7 +10945,8 @@
     "name": "Rowlet",
     "image": "cPK_20_007450_00_MOKUROH_AR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9860,7 +10955,8 @@
     "name": "Pheromosa",
     "image": "cPK_20_007490_00_PHEROACHE_AR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9869,7 +10965,8 @@
     "name": "Blacephalon",
     "image": "cPK_20_007260_00_ZUGADOON_AR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9878,7 +10975,8 @@
     "name": "Alolan Meowth",
     "image": "cPK_20_007740_00_ALOLANYARTH_AR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9887,7 +10985,8 @@
     "name": "Silvally",
     "image": "cPK_20_007950_00_SILVADY_AR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9896,7 +10995,8 @@
     "name": "Celesteela",
     "image": "cPK_20_007960_00_TEKKAGUYA_AR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9905,7 +11005,8 @@
     "name": "Buzzwole ex",
     "image": "cPK_20_007480_00_MASSIVOONex_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9914,7 +11015,8 @@
     "name": "Tapu Koko ex",
     "image": "cPK_20_007420_00_KAPU-KOKEKOex_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9923,7 +11025,8 @@
     "name": "Lycanroc ex",
     "image": "cPK_20_007700_00_LUGARUGANex_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9932,7 +11035,8 @@
     "name": "Guzzlord ex",
     "image": "cPK_20_007800_00_AKUZIKINGex_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9941,7 +11045,8 @@
     "name": "Alolan Dugtrio ex",
     "image": "cPK_20_007830_00_ALOLADUGTRIOex_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9950,7 +11055,8 @@
     "name": "Gladion",
     "image": "cTR_20_000640_00_GLAZIO_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9959,7 +11065,8 @@
     "name": "Looker",
     "image": "cTR_20_000650_00_HANDSOME_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9968,7 +11075,8 @@
     "name": "Lusamine",
     "image": "cTR_20_000660_00_LUSAMINE_SR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9977,7 +11085,8 @@
     "name": "Tapu Koko ex",
     "image": "cPK_20_007420_01_KAPU-KOKEKOex_SAR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9986,7 +11095,8 @@
     "name": "Lycanroc ex",
     "image": "cPK_20_007700_01_LUGARUGANex_SAR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -9995,7 +11105,8 @@
     "name": "Guzzlord ex",
     "image": "cPK_20_007800_01_AKUZIKINGex_SAR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -10004,7 +11115,8 @@
     "name": "Alolan Dugtrio ex",
     "image": "cPK_20_007830_01_ALOLADUGTRIOex_SAR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -10013,7 +11125,8 @@
     "name": "Buzzwole ex",
     "image": "cPK_20_007480_01_MASSIVOONex_IM.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3a",
@@ -10022,7 +11135,8 @@
     "name": "Growlithe",
     "image": "cPK_20_000390_00_GARDIE_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10031,7 +11145,8 @@
     "name": "Arcanine",
     "image": "cPK_20_000400_00_WINDIE_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10040,7 +11155,8 @@
     "name": "Froakie",
     "image": "cPK_20_000870_00_KEROMATSU_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10049,7 +11165,8 @@
     "name": "Frogadier",
     "image": "cPK_20_000880_00_GEKOGASHIRA_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10058,7 +11175,8 @@
     "name": "Greninja",
     "image": "cPK_20_000890_00_GEKKOUGA_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10067,7 +11185,8 @@
     "name": "Jynx",
     "image": "cPK_20_001270_00_ROUGELA_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10076,7 +11195,8 @@
     "name": "Pidgey",
     "image": "cPK_20_001860_00_POPPO_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10085,7 +11205,8 @@
     "name": "Pidgeotto",
     "image": "cPK_20_001870_00_PIGEON_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10094,7 +11215,8 @@
     "name": "Pidgeot",
     "image": "cPK_20_001880_01_PIGEOT_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10103,7 +11225,8 @@
     "name": "Aerodactyl",
     "image": "cPK_20_002080_00_PTERA_S.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10112,7 +11235,8 @@
     "name": "Celebi ex",
     "image": "cPK_20_002170_02_CELEBIex_SSR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10121,7 +11245,8 @@
     "name": "Arcanine ex",
     "image": "cPK_20_000410_01_WINDIEex_SSR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10130,7 +11255,8 @@
     "name": "Aerodactyl ex",
     "image": "cPK_20_002590_02_PTERAex_SSR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10139,7 +11265,8 @@
     "name": "Pidgeot ex",
     "image": "cPK_20_002720_01_PIGEOTex_SSR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3a",
@@ -10148,7 +11275,8 @@
     "name": "Nihilego",
     "image": "cPK_20_007790_00_UTUROID_UR.webp",
     "packs": ["Extradimensional"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10157,7 +11285,8 @@
     "name": "Tropius",
     "image": "cPK_10_007970_00_TROPIUS_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10166,7 +11295,8 @@
     "name": "Leafeon",
     "image": "cPK_10_007980_00_LEAFIA_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10175,7 +11305,8 @@
     "name": "Bounsweet",
     "image": "cPK_10_007990_00_AMAKAJI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10184,7 +11315,8 @@
     "name": "Steenee",
     "image": "cPK_10_008000_00_AMAMAIKO_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10193,7 +11325,8 @@
     "name": "Tsareena",
     "image": "cPK_10_008010_00_AMAJO_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10202,7 +11335,8 @@
     "name": "Applin",
     "image": "cPK_10_008020_00_KAJICCHU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10211,7 +11345,8 @@
     "name": "Appletun",
     "image": "cPK_10_008030_00_TARUPPLE_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10220,7 +11355,8 @@
     "name": "Flareon",
     "image": "cPK_10_008040_00_BOOSTER_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10229,7 +11365,8 @@
     "name": "Flareon ex",
     "image": "cPK_10_008050_00_BOOSTERex_RR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10238,7 +11375,8 @@
     "name": "Torkoal",
     "image": "cPK_10_008060_00_COTOISE_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10247,7 +11385,8 @@
     "name": "Litten",
     "image": "cPK_10_008070_00_NYABBY_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10256,7 +11395,8 @@
     "name": "Torracat",
     "image": "cPK_10_008080_00_NYAHEAT_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10265,7 +11405,8 @@
     "name": "Incineroar",
     "image": "cPK_10_008090_00_GAOGAEN_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10274,7 +11415,8 @@
     "name": "Salandit",
     "image": "cPK_10_008100_00_YATOUMORI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10283,7 +11425,8 @@
     "name": "Salazzle",
     "image": "cPK_10_008110_00_ENNEWT_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10292,7 +11435,8 @@
     "name": "Vaporeon",
     "image": "cPK_10_008120_00_SHOWERS_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10301,7 +11445,8 @@
     "name": "Glaceon",
     "image": "cPK_10_008130_00_GLACIA_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10310,7 +11455,8 @@
     "name": "Vanillite",
     "image": "cPK_10_007320_00_VANIPETI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10319,7 +11465,8 @@
     "name": "Vanillish",
     "image": "cPK_10_008140_00_VANIRICH_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10328,7 +11475,8 @@
     "name": "Vanilluxe",
     "image": "cPK_10_008150_00_BAIVANILLA_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10337,7 +11485,8 @@
     "name": "Alomomola",
     "image": "cPK_10_008160_00_MAMANBOU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10346,7 +11495,8 @@
     "name": "Popplio",
     "image": "cPK_10_008170_00_ASHIMARI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10355,7 +11505,8 @@
     "name": "Brionne",
     "image": "cPK_10_008180_00_OSYAMARI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10364,7 +11515,8 @@
     "name": "Primarina ex",
     "image": "cPK_10_008190_00_ASHIRENEex_RR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10373,7 +11525,8 @@
     "name": "Jolteon",
     "image": "cPK_10_007330_00_THUNDERS_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10382,7 +11535,8 @@
     "name": "Joltik",
     "image": "cPK_10_008200_00_BACHURU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10391,7 +11545,8 @@
     "name": "Galvantula",
     "image": "cPK_10_008210_00_DENTULA_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10400,7 +11555,8 @@
     "name": "Espeon",
     "image": "cPK_10_008220_00_EIFIE_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10409,7 +11565,8 @@
     "name": "Woobat",
     "image": "cPK_10_008230_00_KOROMORI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10418,7 +11575,8 @@
     "name": "Swoobat",
     "image": "cPK_10_008240_00_KOKOROMORI_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10427,7 +11585,8 @@
     "name": "Swirlix",
     "image": "cPK_10_008250_00_PEROPPAFU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10436,7 +11595,8 @@
     "name": "Slurpuff",
     "image": "cPK_10_008260_00_PEROREAM_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10445,7 +11605,8 @@
     "name": "Sylveon",
     "image": "cPK_10_008270_00_NYMPHIA_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10454,7 +11615,8 @@
     "name": "Sylveon ex",
     "image": "cPK_10_008280_00_NYMPHIAex_RR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10463,7 +11625,8 @@
     "name": "Mimikyu",
     "image": "cPK_10_008290_00_MIMIKKYU_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10472,7 +11635,8 @@
     "name": "Milcery",
     "image": "cPK_10_008300_00_MAHOMIL_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10481,7 +11645,8 @@
     "name": "Alcremie",
     "image": "cPK_10_007340_00_MAWHIP_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10490,7 +11655,8 @@
     "name": "Barboach",
     "image": "cPK_10_008310_00_DOJOACH_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10499,7 +11665,8 @@
     "name": "Whiscash",
     "image": "cPK_10_008320_00_NAMAZUN_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10508,7 +11675,8 @@
     "name": "Mienfoo",
     "image": "cPK_10_008330_00_KOJOFU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10517,7 +11685,8 @@
     "name": "Mienshao",
     "image": "cPK_10_008340_00_KOJONDO_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10526,7 +11695,8 @@
     "name": "Carbink",
     "image": "cPK_10_008350_00_MELECIE_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10535,7 +11705,8 @@
     "name": "Umbreon",
     "image": "cPK_10_008360_00_BRACKY_R.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10544,7 +11715,8 @@
     "name": "Sableye",
     "image": "cPK_10_008370_00_YAMIRAMI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10553,7 +11725,8 @@
     "name": "Purrloin",
     "image": "cPK_10_008380_00_CHORONEKO_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10562,7 +11735,8 @@
     "name": "Liepard",
     "image": "cPK_10_008390_00_LEPARDAS_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10571,7 +11745,8 @@
     "name": "Mawile",
     "image": "cPK_10_008400_00_KUCHEAT_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10580,7 +11755,8 @@
     "name": "Togedemaru",
     "image": "cPK_10_007390_00_TOGEDEMARU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10589,7 +11765,8 @@
     "name": "Meltan",
     "image": "cPK_10_008410_00_MELTAN_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10598,7 +11775,8 @@
     "name": "Melmetal",
     "image": "cPK_10_008420_00_MELMETAL_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10607,7 +11785,8 @@
     "name": "Dratini",
     "image": "cPK_10_008430_00_MINIRYU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10616,7 +11795,8 @@
     "name": "Dragonair",
     "image": "cPK_10_008440_00_HAKURYU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10625,7 +11805,8 @@
     "name": "Dragonite ex",
     "image": "cPK_10_008450_00_KAIRYUex_RR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10634,7 +11815,8 @@
     "name": "Drampa",
     "image": "cPK_10_008460_00_JIJILONG_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10643,7 +11825,8 @@
     "name": "Eevee",
     "image": "cPK_10_008470_00_EIEVUI_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10652,7 +11835,8 @@
     "name": "Eevee ex",
     "image": "cPK_10_008480_00_EIEVUIex_RR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10661,7 +11845,8 @@
     "name": "Snorlax ex",
     "image": "cPK_10_008490_00_KABIGONex_RR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10670,7 +11855,8 @@
     "name": "Aipom",
     "image": "cPK_10_008500_00_EIPAM_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10679,7 +11865,8 @@
     "name": "Ambipom",
     "image": "cPK_10_008510_00_ETEBOTH_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10688,7 +11875,8 @@
     "name": "Chatot",
     "image": "cPK_10_008520_00_PERAP_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10697,7 +11885,8 @@
     "name": "Audino",
     "image": "cPK_10_008530_00_TABUNNE_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10706,7 +11895,8 @@
     "name": "Minccino",
     "image": "cPK_10_008540_00_CHILLARMY_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10715,7 +11905,8 @@
     "name": "Cinccino",
     "image": "cPK_10_008550_00_CHILLACCINO_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10724,7 +11915,8 @@
     "name": "Skwovet",
     "image": "cPK_10_008560_00_HOSHIGARISU_C.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10733,7 +11925,8 @@
     "name": "Greedent",
     "image": "cPK_10_007400_00_YOKUBARISU_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10742,7 +11935,8 @@
     "name": "Eevee Bag",
     "image": "cTR_10_000670_00_IIBUINOBAKKU_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10751,7 +11945,8 @@
     "name": "Leftovers",
     "image": "cTR_10_000680_00_TABENOKOSHI_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10760,7 +11955,8 @@
     "name": "Hau",
     "image": "cTR_10_000690_00_HAU_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10769,7 +11965,8 @@
     "name": "Penny",
     "image": "cTR_10_000700_00_BOTAN_U.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10778,7 +11975,8 @@
     "name": "Leafeon",
     "image": "cPK_20_007980_00_LEAFIA_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10787,7 +11985,8 @@
     "name": "Flareon",
     "image": "cPK_20_008040_00_BOOSTER_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10796,7 +11995,8 @@
     "name": "Vaporeon",
     "image": "cPK_20_008120_00_SHOWERS_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10805,7 +12005,8 @@
     "name": "Glaceon",
     "image": "cPK_20_008130_00_GLACIA_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10814,7 +12015,8 @@
     "name": "Jolteon",
     "image": "cPK_20_007330_00_THUNDERS_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10823,7 +12025,8 @@
     "name": "Espeon",
     "image": "cPK_20_008220_00_EIFIE_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10832,7 +12035,8 @@
     "name": "Sylveon",
     "image": "cPK_20_008270_00_NYMPHIA_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10841,7 +12045,8 @@
     "name": "Umbreon",
     "image": "cPK_20_008360_00_BRACKY_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10850,7 +12055,8 @@
     "name": "Eevee",
     "image": "cPK_20_008470_00_EIEVUI_AR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10859,7 +12065,8 @@
     "name": "Flareon ex",
     "image": "cPK_20_008050_00_BOOSTERex_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10868,7 +12075,8 @@
     "name": "Primarina ex",
     "image": "cPK_20_008190_00_ASHIRENEex_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10877,7 +12085,8 @@
     "name": "Sylveon ex",
     "image": "cPK_20_008280_00_NYMPHIAex_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10886,7 +12095,8 @@
     "name": "Dragonite ex",
     "image": "cPK_20_008450_00_KAIRYUex_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10895,7 +12105,8 @@
     "name": "Eevee ex",
     "image": "cPK_20_008480_00_EIEVUIex_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10904,7 +12115,8 @@
     "name": "Snorlax ex",
     "image": "cPK_20_008490_00_KABIGONex_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10913,7 +12125,8 @@
     "name": "Hau",
     "image": "cTR_20_000690_00_HAU_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10922,7 +12135,8 @@
     "name": "Penny",
     "image": "cTR_20_000700_00_BOTAN_SR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10931,7 +12145,8 @@
     "name": "Flareon ex",
     "image": "cPK_20_008050_01_BOOSTERex_SAR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10940,7 +12155,8 @@
     "name": "Primarina ex",
     "image": "cPK_20_008190_01_ASHIRENEex_SAR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10949,7 +12165,8 @@
     "name": "Sylveon ex",
     "image": "cPK_20_008280_01_NYMPHIAex_SAR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10958,7 +12175,8 @@
     "name": "Dragonite ex",
     "image": "cPK_20_008450_01_KAIRYUex_SAR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10967,7 +12185,8 @@
     "name": "Snorlax ex",
     "image": "cPK_20_008490_01_KABIGONex_SAR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10976,7 +12195,8 @@
     "name": "Eevee ex",
     "image": "cPK_20_008480_01_EIEVUIex_IM.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A3b",
@@ -10985,7 +12205,8 @@
     "name": "Pinsir",
     "image": "cPK_20_005240_00_KAILIOS_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -10994,7 +12215,8 @@
     "name": "Lapras",
     "image": "cPK_20_000790_01_LAPLACE_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11003,7 +12225,8 @@
     "name": "Voltorb",
     "image": "cPK_20_003350_00_BIRIRIDAMA_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11012,7 +12235,8 @@
     "name": "Electrode",
     "image": "cPK_20_003360_00_MARUMINE_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11021,7 +12245,8 @@
     "name": "Ralts",
     "image": "cPK_20_003490_00_RALTS_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11030,7 +12255,8 @@
     "name": "Kirlia",
     "image": "cPK_20_003500_00_KIRLIA_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11039,7 +12265,8 @@
     "name": "Gardevoir",
     "image": "cPK_20_001320_00_SIRNIGHT_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11048,7 +12275,8 @@
     "name": "Ekans",
     "image": "cPK_20_001640_00_ARBO_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11057,16 +12285,18 @@
     "name": "Arbok",
     "image": "cPK_20_001650_00_ARBOK_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
     "number": 102,
     "rarity": "S",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_20_001980_00_KAMONEGI_S.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11075,7 +12305,8 @@
     "name": "Moltres ex",
     "image": "cPK_20_000470_02_FIREex_SSR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11084,7 +12315,8 @@
     "name": "Articuno ex",
     "image": "cPK_20_000840_02_FREEZERex_SSR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11093,7 +12325,8 @@
     "name": "Zapdos ex",
     "image": "cPK_20_001040_02_THUNDERex_SSR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11102,7 +12335,8 @@
     "name": "Gallade ex",
     "image": "cPK_20_003760_02_ERUREIDOex_SSR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A3b",
@@ -11111,7 +12345,8 @@
     "name": "Eevee Bag",
     "image": "cTR_20_000670_00_IIBUINOBAKKU_UR.webp",
     "packs": ["Eevee"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11120,7 +12355,8 @@
     "name": "Oddish",
     "image": "cPK_10_008570_00_NAZONOKUSA_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11129,7 +12365,8 @@
     "name": "Gloom",
     "image": "cPK_10_008580_00_KUSAIHANA_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11138,7 +12375,8 @@
     "name": "Bellossom",
     "image": "cPK_10_008590_00_KIREIHANA_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11147,7 +12385,8 @@
     "name": "Tangela",
     "image": "cPK_10_008600_00_MONJARA_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11156,7 +12395,8 @@
     "name": "Tangrowth",
     "image": "cPK_10_008610_00_MOJUMBO_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11165,7 +12405,8 @@
     "name": "Scyther",
     "image": "cPK_10_008620_00_STRIKE_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11174,7 +12415,8 @@
     "name": "Pinsir",
     "image": "cPK_10_008630_00_KAILIOS_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11183,7 +12425,8 @@
     "name": "Chikorita",
     "image": "cPK_10_008640_00_CHICORITA_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11192,7 +12435,8 @@
     "name": "Bayleef",
     "image": "cPK_10_008650_00_BAYLEAF_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11201,7 +12445,8 @@
     "name": "Meganium",
     "image": "cPK_10_008660_00_MEGANIUM_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11210,7 +12455,8 @@
     "name": "Ledyba",
     "image": "cPK_10_008670_00_REDIBA_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11219,7 +12465,8 @@
     "name": "Ledian",
     "image": "cPK_10_008680_00_REDIAN_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11228,7 +12475,8 @@
     "name": "Hoppip",
     "image": "cPK_10_008690_00_HANECCO_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11237,7 +12485,8 @@
     "name": "Skiploom",
     "image": "cPK_10_008700_00_POPOCCO_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11246,7 +12495,8 @@
     "name": "Jumpluff",
     "image": "cPK_10_008710_00_WATACCO_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11255,7 +12505,8 @@
     "name": "Sunkern",
     "image": "cPK_10_008720_00_HIMANUTS_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11264,7 +12515,8 @@
     "name": "Sunflora",
     "image": "cPK_10_008730_00_KIMAWARI_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11273,7 +12525,8 @@
     "name": "Yanma",
     "image": "cPK_10_008740_00_YANYANMA_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11282,7 +12535,8 @@
     "name": "Yanmega",
     "image": "cPK_10_008750_00_MEGAYANMA_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11291,7 +12545,8 @@
     "name": "Pineco",
     "image": "cPK_10_008760_00_KUNUGIDAMA_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11300,7 +12555,8 @@
     "name": "Shuckle ex",
     "image": "cPK_10_008770_00_TSUBOTSUBOex_RR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11309,7 +12565,8 @@
     "name": "Heracross",
     "image": "cPK_10_008780_00_HERACROS_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11318,7 +12575,8 @@
     "name": "Cherubi",
     "image": "cPK_10_008790_00_CHERINBO_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11327,7 +12585,8 @@
     "name": "Cherrim",
     "image": "cPK_10_008800_00_CHERRIM_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11336,7 +12595,8 @@
     "name": "Vulpix",
     "image": "cPK_10_008810_00_ROKON_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11345,7 +12605,8 @@
     "name": "Ninetales",
     "image": "cPK_10_008820_00_KYUKON_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11354,7 +12615,8 @@
     "name": "Cyndaquil",
     "image": "cPK_10_008830_00_HINOARASHI_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11363,7 +12625,8 @@
     "name": "Quilava",
     "image": "cPK_10_008840_00_MAGMARASHI_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11372,7 +12635,8 @@
     "name": "Typhlosion",
     "image": "cPK_10_008850_00_BAKPHOON_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11381,7 +12645,8 @@
     "name": "Slugma",
     "image": "cPK_10_008860_00_MAGMAG_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11390,7 +12655,8 @@
     "name": "Magcargo",
     "image": "cPK_10_008870_00_MAGCARGOT_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11399,7 +12665,8 @@
     "name": "Magby",
     "image": "cPK_10_008880_00_BUBY_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11408,7 +12675,8 @@
     "name": "Entei",
     "image": "cPK_10_008890_00_ENTEI_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11417,7 +12685,8 @@
     "name": "Ho-Oh ex",
     "image": "cPK_10_008900_00_HOUOUex_RR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11426,7 +12695,8 @@
     "name": "Darumaka",
     "image": "cPK_10_008910_00_DARUMAKKA_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11435,7 +12705,8 @@
     "name": "Darmanitan",
     "image": "cPK_10_008920_00_HIHIDARUMA_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11444,7 +12715,8 @@
     "name": "Heatmor",
     "image": "cPK_10_008930_00_KUITARAN_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11453,7 +12725,8 @@
     "name": "Poliwag",
     "image": "cPK_10_008940_00_NYOROMO_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11462,7 +12735,8 @@
     "name": "Poliwhirl",
     "image": "cPK_10_008950_00_NYOROZO_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11471,7 +12745,8 @@
     "name": "Politoed",
     "image": "cPK_10_008960_00_NYOROTONO_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11480,7 +12755,8 @@
     "name": "Horsea",
     "image": "cPK_10_008970_00_TATTU_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11489,7 +12765,8 @@
     "name": "Seadra",
     "image": "cPK_10_008980_00_SEADRA_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11498,7 +12775,8 @@
     "name": "Kingdra ex",
     "image": "cPK_10_008990_00_KINGDRAex_RR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11507,7 +12785,8 @@
     "name": "Magikarp",
     "image": "cPK_10_009000_00_KOIKING_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11516,7 +12795,8 @@
     "name": "Gyarados",
     "image": "cPK_10_009010_00_GYARADOS_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11525,7 +12805,8 @@
     "name": "Totodile",
     "image": "cPK_10_009020_00_WANINOKO_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11534,7 +12815,8 @@
     "name": "Croconaw",
     "image": "cPK_10_009030_00_ALLIGATES_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11543,7 +12825,8 @@
     "name": "Feraligatr",
     "image": "cPK_10_009040_00_ORDILE_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11552,7 +12835,8 @@
     "name": "Marill",
     "image": "cPK_10_009050_00_MARIL_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11561,7 +12845,8 @@
     "name": "Azumarill",
     "image": "cPK_10_009060_00_MARILLI_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11570,7 +12855,8 @@
     "name": "Wooper",
     "image": "cPK_10_009070_00_UPAH_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11579,7 +12865,8 @@
     "name": "Quagsire",
     "image": "cPK_10_009080_00_NUOH_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11588,7 +12875,8 @@
     "name": "Qwilfish",
     "image": "cPK_10_009090_00_HARYSEN_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11597,7 +12885,8 @@
     "name": "Corsola",
     "image": "cPK_10_009100_00_SUNNYGO_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11606,7 +12895,8 @@
     "name": "Remoraid",
     "image": "cPK_10_009110_00_TEPPOUO_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11615,7 +12905,8 @@
     "name": "Octillery",
     "image": "cPK_10_009120_00_OKUTANK_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11624,7 +12915,8 @@
     "name": "Delibird",
     "image": "cPK_10_009130_00_DELIBIRD_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11633,7 +12925,8 @@
     "name": "Mantine",
     "image": "cPK_10_009140_00_MANTAIN_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11642,7 +12935,8 @@
     "name": "Suicune",
     "image": "cPK_10_009150_00_SUICUNE_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11651,7 +12945,8 @@
     "name": "Corphish",
     "image": "cPK_10_009160_00_HEIGANI_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11660,7 +12955,8 @@
     "name": "Crawdaunt",
     "image": "cPK_10_009170_00_SHIZARIGER_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11669,7 +12965,8 @@
     "name": "Ducklett",
     "image": "cPK_10_009180_00_KOARUHIE_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11678,7 +12975,8 @@
     "name": "Swanna",
     "image": "cPK_10_009190_00_SWANNA_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11687,7 +12985,8 @@
     "name": "Chinchou",
     "image": "cPK_10_009200_00_CHONCHIE_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11696,7 +12995,8 @@
     "name": "Lanturn ex",
     "image": "cPK_10_009210_00_LANTERNex_RR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11705,7 +13005,8 @@
     "name": "Pichu",
     "image": "cPK_10_009220_00_PICHU_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11714,7 +13015,8 @@
     "name": "Mareep",
     "image": "cPK_10_009230_00_MERRIEP_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11723,7 +13025,8 @@
     "name": "Flaaffy",
     "image": "cPK_10_009240_00_MOKOKO_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11732,7 +13035,8 @@
     "name": "Ampharos",
     "image": "cPK_10_009250_00_DENRYU_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11741,7 +13045,8 @@
     "name": "Elekid",
     "image": "cPK_10_009260_00_ELEKID_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11750,7 +13055,8 @@
     "name": "Raikou",
     "image": "cPK_10_009270_00_RAIKOU_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11759,7 +13065,8 @@
     "name": "Emolga",
     "image": "cPK_10_009280_00_EMOLGA_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11768,7 +13075,8 @@
     "name": "Slowpoke",
     "image": "cPK_10_009290_00_YADON_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11777,7 +13085,8 @@
     "name": "Slowking",
     "image": "cPK_10_009300_00_YADOKING_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11786,7 +13095,8 @@
     "name": "Smoochum",
     "image": "cPK_10_009310_00_MUCHUL_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11795,7 +13105,8 @@
     "name": "Jynx",
     "image": "cPK_10_009320_00_ROUGELA_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11804,7 +13115,8 @@
     "name": "Cleffa",
     "image": "cPK_10_009330_00_PY_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11813,7 +13125,8 @@
     "name": "Togepi",
     "image": "cPK_10_009340_00_TOGEPY_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11822,7 +13135,8 @@
     "name": "Togetic",
     "image": "cPK_10_009350_00_TOGECHICK_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11831,7 +13145,8 @@
     "name": "Togekiss",
     "image": "cPK_10_009360_00_TOGEKISS_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11840,7 +13155,8 @@
     "name": "Natu",
     "image": "cPK_10_009370_00_NATY_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11849,7 +13165,8 @@
     "name": "Xatu",
     "image": "cPK_10_009380_00_NATIO_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11858,7 +13175,8 @@
     "name": "Espeon ex",
     "image": "cPK_10_009390_00_EIFIEex_RR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11867,7 +13185,8 @@
     "name": "Unown",
     "image": "cPK_10_009400_00_UNKNOWN_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11876,7 +13195,8 @@
     "name": "Unown",
     "image": "cPK_10_009410_00_UNKNOWN_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11885,7 +13205,8 @@
     "name": "Wobbuffet",
     "image": "cPK_10_009420_00_SONANS_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11894,7 +13215,8 @@
     "name": "Girafarig",
     "image": "cPK_10_009430_00_KIRINRIKI_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11903,7 +13225,8 @@
     "name": "Snubbull",
     "image": "cPK_10_009440_00_BULU_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11912,7 +13235,8 @@
     "name": "Granbull",
     "image": "cPK_10_009450_00_GRANBULU_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11921,7 +13245,8 @@
     "name": "Munna",
     "image": "cPK_10_009460_00_MUNNA_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11930,7 +13255,8 @@
     "name": "Musharna",
     "image": "cPK_10_009470_00_MUSHARNA_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11939,7 +13265,8 @@
     "name": "Onix",
     "image": "cPK_10_009480_00_IWARK_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11948,7 +13275,8 @@
     "name": "Sudowoodo",
     "image": "cPK_10_009490_00_USOKKIE_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11957,7 +13285,8 @@
     "name": "Gligar",
     "image": "cPK_10_009500_00_GLIGER_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11966,7 +13295,8 @@
     "name": "Gliscor",
     "image": "cPK_10_009510_00_GLION_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11975,7 +13305,8 @@
     "name": "Swinub",
     "image": "cPK_10_009520_00_URIMOO_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11984,7 +13315,8 @@
     "name": "Piloswine",
     "image": "cPK_10_009530_00_INOMOO_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -11993,7 +13325,8 @@
     "name": "Mamoswine",
     "image": "cPK_10_009540_00_MAMMOO_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12002,7 +13335,8 @@
     "name": "Phanpy",
     "image": "cPK_10_009550_00_GOMAZOU_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12011,7 +13345,8 @@
     "name": "Donphan ex",
     "image": "cPK_10_009560_00_DONFANex_RR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12020,7 +13355,8 @@
     "name": "Tyrogue",
     "image": "cPK_10_009570_00_BALKIE_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12029,7 +13365,8 @@
     "name": "Hitmontop",
     "image": "cPK_10_009580_00_KAPOERER_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12038,7 +13375,8 @@
     "name": "Larvitar",
     "image": "cPK_10_009590_00_YOGIRAS_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12047,7 +13385,8 @@
     "name": "Pupitar",
     "image": "cPK_10_009600_00_SANAGIRAS_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12056,7 +13395,8 @@
     "name": "Binacle",
     "image": "cPK_10_009610_00_KAMETETE_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12065,7 +13405,8 @@
     "name": "Barbaracle",
     "image": "cPK_10_009620_00_GAMENODES_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12074,7 +13415,8 @@
     "name": "Zubat",
     "image": "cPK_10_009630_00_ZUBAT_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12083,7 +13425,8 @@
     "name": "Golbat",
     "image": "cPK_10_009640_00_GOLBAT_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12092,7 +13435,8 @@
     "name": "Crobat ex",
     "image": "cPK_10_009650_00_CROBATex_RR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12101,7 +13445,8 @@
     "name": "Spinarak",
     "image": "cPK_10_009660_00_ITOMARU_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12110,7 +13455,8 @@
     "name": "Ariados",
     "image": "cPK_10_009670_00_ARIADOS_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12119,7 +13465,8 @@
     "name": "Umbreon ex",
     "image": "cPK_10_009680_00_BRACKYex_RR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12128,7 +13475,8 @@
     "name": "Murkrow",
     "image": "cPK_10_009690_00_YAMIKARASU_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12137,7 +13485,8 @@
     "name": "Honchkrow",
     "image": "cPK_10_009700_00_DONGKARASU_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12146,7 +13495,8 @@
     "name": "Sneasel",
     "image": "cPK_10_009710_00_NYULA_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12155,7 +13505,8 @@
     "name": "Weavile",
     "image": "cPK_10_009720_00_MANYULA_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12164,7 +13515,8 @@
     "name": "Houndour",
     "image": "cPK_10_009730_00_DELVIL_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12173,7 +13525,8 @@
     "name": "Houndoom",
     "image": "cPK_10_009740_00_HELLGAR_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12182,7 +13535,8 @@
     "name": "Tyranitar",
     "image": "cPK_10_009750_00_BANGIRAS_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12191,7 +13545,8 @@
     "name": "Absol",
     "image": "cPK_10_009760_00_ABSOL_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12200,7 +13555,8 @@
     "name": "Forretress",
     "image": "cPK_10_009770_00_FORETOS_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12209,7 +13565,8 @@
     "name": "Steelix",
     "image": "cPK_10_009780_00_HAGANEIL_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12218,7 +13575,8 @@
     "name": "Scizor",
     "image": "cPK_10_009790_00_HASSAM_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12227,7 +13585,8 @@
     "name": "Skarmory ex",
     "image": "cPK_10_009800_00_AIRMDex_RR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12236,7 +13595,8 @@
     "name": "Mawile",
     "image": "cPK_10_009810_00_KUCHEAT_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12245,7 +13605,8 @@
     "name": "Klink",
     "image": "cPK_10_009820_00_GIARU_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12254,7 +13615,8 @@
     "name": "Klang",
     "image": "cPK_10_009830_00_GIGIARU_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12263,7 +13625,8 @@
     "name": "Klinklang",
     "image": "cPK_10_009840_00_GIGIGIARU_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12272,7 +13635,8 @@
     "name": "Spearow",
     "image": "cPK_10_009850_00_ONISUZUME_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12281,7 +13645,8 @@
     "name": "Fearow",
     "image": "cPK_10_009860_00_ONIDRILL_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12290,7 +13655,8 @@
     "name": "Chansey",
     "image": "cPK_10_009870_00_LUCKY_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12299,7 +13665,8 @@
     "name": "Blissey",
     "image": "cPK_10_009880_00_HAPPINAS_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12308,7 +13675,8 @@
     "name": "Kangaskhan",
     "image": "cPK_10_009890_00_GARURA_R.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12317,7 +13685,8 @@
     "name": "Eevee",
     "image": "cPK_10_009900_00_EIEVUI_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12326,7 +13695,8 @@
     "name": "Porygon",
     "image": "cPK_10_009910_00_PORYGON_C.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12335,7 +13705,8 @@
     "name": "Porygon2",
     "image": "cPK_10_009920_00_PORYGON2_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12344,7 +13715,8 @@
     "name": "Porygon-Z",
     "image": "cPK_10_009930_00_PORYGON-Z_R.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12353,7 +13725,8 @@
     "name": "Sentret",
     "image": "cPK_10_009940_00_OTACHI_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12362,7 +13735,8 @@
     "name": "Furret",
     "image": "cPK_10_009950_00_OOTACHI_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12371,7 +13745,8 @@
     "name": "Hoothoot",
     "image": "cPK_10_009960_00_HOHO_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12380,7 +13755,8 @@
     "name": "Noctowl",
     "image": "cPK_10_009970_00_YORUNOZUKU_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12389,7 +13765,8 @@
     "name": "Aipom",
     "image": "cPK_10_009980_00_EIPAM_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12398,7 +13775,8 @@
     "name": "Ambipom",
     "image": "cPK_10_009990_00_ETEBOTH_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12407,7 +13785,8 @@
     "name": "Dunsparce",
     "image": "cPK_10_010000_00_NOKOCCHI_C.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12416,7 +13795,8 @@
     "name": "Teddiursa",
     "image": "cPK_10_010010_00_HIMEGUMA_C.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12425,7 +13805,8 @@
     "name": "Ursaring",
     "image": "cPK_10_010020_00_RINGUMA_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12434,7 +13815,8 @@
     "name": "Stantler",
     "image": "cPK_10_010030_00_ODOSHISHI_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12443,7 +13825,8 @@
     "name": "Smeargle",
     "image": "cPK_10_010040_00_DOBLE_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12452,7 +13835,8 @@
     "name": "Lugia ex",
     "image": "cPK_10_010050_00_LUGIAex_RR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12461,7 +13845,8 @@
     "name": "Bouffalant",
     "image": "cPK_10_010060_00_BUFFRON_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12470,7 +13855,8 @@
     "name": "Elemental Switch",
     "image": "cTR_10_000710_00_EREMENTARUTSUKEKAE_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12479,7 +13865,8 @@
     "name": "Squirt Bottle",
     "image": "cTR_10_000720_00_ZEHIGAMEJOURO_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12488,7 +13875,8 @@
     "name": "Steel Apron",
     "image": "cTR_10_000730_00_GOUTETUNOMAEKAKE_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12497,7 +13885,8 @@
     "name": "Dark Pendant",
     "image": "cTR_10_000740_00_DARKPENDANTO_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12506,7 +13895,8 @@
     "name": "Rescue Scarf",
     "image": "cTR_10_000750_00_RESUKYUSUKAFU_U.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12515,7 +13905,8 @@
     "name": "Will",
     "image": "cTR_10_000760_00_ITSUKI_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12524,7 +13915,8 @@
     "name": "Lyra",
     "image": "cTR_10_000770_00_KOTONE_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12533,7 +13925,8 @@
     "name": "Silver",
     "image": "cTR_10_000780_00_SILVER_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12542,7 +13935,8 @@
     "name": "Fisher",
     "image": "cTR_10_000790_00_FISHER_U.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12551,7 +13945,8 @@
     "name": "Jasmine",
     "image": "cTR_10_000800_00_MIKAN_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12560,7 +13955,8 @@
     "name": "Hiker",
     "image": "cTR_10_000810_00_HIKER_U.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12569,7 +13965,8 @@
     "name": "Chikorita",
     "image": "cPK_20_008640_00_CHICORITA_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12578,7 +13975,8 @@
     "name": "Bellossom",
     "image": "cPK_20_008590_00_KIREIHANA_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12587,7 +13985,8 @@
     "name": "Heracross",
     "image": "cPK_20_008780_00_HERACROS_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12596,7 +13995,8 @@
     "name": "Cyndaquil",
     "image": "cPK_20_008830_00_HINOARASHI_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12605,7 +14005,8 @@
     "name": "Magby",
     "image": "cPK_20_008880_00_BUBY_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12614,7 +14015,8 @@
     "name": "Totodile",
     "image": "cPK_20_009020_00_WANINOKO_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12623,7 +14025,8 @@
     "name": "Qwilfish",
     "image": "cPK_20_009090_00_HARYSEN_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12632,7 +14035,8 @@
     "name": "Octillery",
     "image": "cPK_20_009120_00_OKUTANK_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12641,7 +14045,8 @@
     "name": "Delibird",
     "image": "cPK_20_009130_00_DELIBIRD_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12650,7 +14055,8 @@
     "name": "Pichu",
     "image": "cPK_20_009220_00_PICHU_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12659,7 +14065,8 @@
     "name": "Ampharos",
     "image": "cPK_20_009250_00_DENRYU_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12668,7 +14075,8 @@
     "name": "Togepi",
     "image": "cPK_20_009340_00_TOGEPY_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12677,7 +14085,8 @@
     "name": "Xatu",
     "image": "cPK_20_009380_00_NATIO_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12686,7 +14095,8 @@
     "name": "Wobbuffet",
     "image": "cPK_20_009420_00_SONANS_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12695,7 +14105,8 @@
     "name": "Gligar",
     "image": "cPK_20_009500_00_GLIGER_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12704,7 +14115,8 @@
     "name": "Spinarak",
     "image": "cPK_20_009660_00_ITOMARU_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12713,7 +14125,8 @@
     "name": "Murkrow",
     "image": "cPK_20_009690_00_YAMIKARASU_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12722,7 +14135,8 @@
     "name": "Tyranitar",
     "image": "cPK_20_009750_00_BANGIRAS_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12731,7 +14145,8 @@
     "name": "Scizor",
     "image": "cPK_20_009790_00_HASSAM_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12740,7 +14155,8 @@
     "name": "Sentret",
     "image": "cPK_20_009940_00_OTACHI_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12749,7 +14165,8 @@
     "name": "Hoothoot",
     "image": "cPK_20_009960_00_HOHO_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12758,7 +14175,8 @@
     "name": "Stantler",
     "image": "cPK_20_010030_00_ODOSHISHI_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12767,7 +14185,8 @@
     "name": "Smeargle",
     "image": "cPK_20_010040_00_DOBLE_AR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12776,7 +14195,8 @@
     "name": "Blissey",
     "image": "cPK_20_009880_00_HAPPINAS_AR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12785,7 +14205,8 @@
     "name": "Shuckle ex",
     "image": "cPK_20_008770_00_TSUBOTSUBOex_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12794,7 +14215,8 @@
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_00_HOUOUex_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12803,7 +14225,8 @@
     "name": "Kingdra ex",
     "image": "cPK_20_008990_00_KINGDRAex_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12812,7 +14235,8 @@
     "name": "Lanturn ex",
     "image": "cPK_20_009210_00_LANTERNex_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12821,7 +14245,8 @@
     "name": "Espeon ex",
     "image": "cPK_20_009390_00_EIFIEex_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12830,7 +14255,8 @@
     "name": "Donphan ex",
     "image": "cPK_20_009560_00_DONFANex_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12839,7 +14265,8 @@
     "name": "Crobat ex",
     "image": "cPK_20_009650_00_CROBATex_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12848,7 +14275,8 @@
     "name": "Umbreon ex",
     "image": "cPK_20_009680_00_BRACKYex_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12857,7 +14285,8 @@
     "name": "Skarmory ex",
     "image": "cPK_20_009800_00_AIRMDex_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12866,7 +14295,8 @@
     "name": "Lugia ex",
     "image": "cPK_20_010050_00_LUGIAex_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12875,7 +14305,8 @@
     "name": "Will",
     "image": "cTR_20_000760_00_ITSUKI_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12884,7 +14315,8 @@
     "name": "Lyra",
     "image": "cTR_20_000770_00_KOTONE_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12893,7 +14325,8 @@
     "name": "Silver",
     "image": "cTR_20_000780_00_SILVER_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12902,7 +14335,8 @@
     "name": "Fisher",
     "image": "cTR_20_000790_00_FISHER_SR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12911,7 +14345,8 @@
     "name": "Jasmine",
     "image": "cTR_20_000800_00_MIKAN_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12920,7 +14355,8 @@
     "name": "Hiker",
     "image": "cTR_20_000810_00_HIKER_SR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12929,7 +14365,8 @@
     "name": "Shuckle ex",
     "image": "cPK_20_008770_01_TSUBOTSUBOex_SAR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12938,7 +14375,8 @@
     "name": "Kingdra ex",
     "image": "cPK_20_008990_01_KINGDRAex_SAR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12947,7 +14385,8 @@
     "name": "Lanturn ex",
     "image": "cPK_20_009210_01_LANTERNex_SAR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12956,7 +14395,8 @@
     "name": "Espeon ex",
     "image": "cPK_20_009390_01_EIFIEex_SAR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12965,7 +14405,8 @@
     "name": "Donphan ex",
     "image": "cPK_20_009560_01_DONFANex_SAR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12974,7 +14415,8 @@
     "name": "Crobat ex",
     "image": "cPK_20_009650_01_CROBATex_SAR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12983,7 +14425,8 @@
     "name": "Umbreon ex",
     "image": "cPK_20_009680_01_BRACKYex_SAR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -12992,7 +14435,8 @@
     "name": "Skarmory ex",
     "image": "cPK_20_009800_01_AIRMDex_SAR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -13001,7 +14445,8 @@
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_01_HOUOUex_IM.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -13010,7 +14455,8 @@
     "name": "Lugia ex",
     "image": "cPK_20_010050_01_LUGIAex_IM.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -13019,7 +14465,8 @@
     "name": "Yanma",
     "image": "cPK_20_008740_00_YANYANMA_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13028,7 +14475,8 @@
     "name": "Flareon",
     "image": "cPK_20_008040_01_BOOSTER_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13037,7 +14485,8 @@
     "name": "Magikarp",
     "image": "cPK_20_002310_00_KOIKING_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13046,7 +14495,8 @@
     "name": "Gyarados",
     "image": "cPK_20_009010_00_GYARADOS_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13055,7 +14505,8 @@
     "name": "Vaporeon",
     "image": "cPK_20_000800_00_SHOWERS_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13064,7 +14515,8 @@
     "name": "Magnemite",
     "image": "cPK_20_000970_00_COIL_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13073,7 +14525,8 @@
     "name": "Magneton",
     "image": "cPK_20_000980_00_RARECOIL_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13082,7 +14535,8 @@
     "name": "Jolteon",
     "image": "cPK_20_007330_01_THUNDERS_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13091,7 +14545,8 @@
     "name": "Misdreavus",
     "image": "cPK_20_003470_00_MUMA_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13100,7 +14555,8 @@
     "name": "Mankey",
     "image": "cPK_20_002540_00_MANKEY_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13109,16 +14565,18 @@
     "name": "Primeape",
     "image": "cPK_20_001420_00_OKORIZARU_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
     "number": 223,
     "rarity": "S",
-    "name": "Nidoran\u2640",
+    "name": "Nidoran♀",
     "image": "cPK_20_001660_00_NIDORAN%E2%99%80_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13127,7 +14585,8 @@
     "name": "Nidorina",
     "image": "cPK_20_001670_00_NIDORINA_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13136,16 +14595,18 @@
     "name": "Nidoqueen",
     "image": "cPK_20_001680_01_NIDOQUEEN_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
     "number": 226,
     "rarity": "S",
-    "name": "Nidoran\u2642",
+    "name": "Nidoran♂",
     "image": "cPK_20_001690_00_NIDORAN%E2%99%82_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13154,7 +14615,8 @@
     "name": "Nidorino",
     "image": "cPK_20_001700_00_NIDORINO_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13163,7 +14625,8 @@
     "name": "Nidoking",
     "image": "cPK_20_001710_01_NIDOKING_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13172,7 +14635,8 @@
     "name": "Sneasel",
     "image": "cPK_20_009710_00_NYULA_S.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13181,7 +14645,8 @@
     "name": "Lickitung",
     "image": "cPK_20_004050_00_BERORINGA_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13190,7 +14655,8 @@
     "name": "Eevee",
     "image": "cPK_20_009900_00_EIEVUI_S.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13199,7 +14665,8 @@
     "name": "Yanmega ex",
     "image": "cPK_20_002880_02_MEGAYANMAex_SSR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13208,7 +14675,8 @@
     "name": "Leafeon ex",
     "image": "cPK_20_004340_02_LEAFIAex_SSR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13217,7 +14685,8 @@
     "name": "Gyarados ex",
     "image": "cPK_20_002320_01_GYARADOSex_SSR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13226,7 +14695,8 @@
     "name": "Glaceon ex",
     "image": "cPK_20_004460_02_GLACIAex_SSR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13235,7 +14705,8 @@
     "name": "Pachirisu ex",
     "image": "cPK_20_003420_02_PACHIRISUex_SSR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13244,7 +14715,8 @@
     "name": "Mismagius ex",
     "image": "cPK_20_003480_02_MUMARGIex_SSR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13253,7 +14725,8 @@
     "name": "Weavile ex",
     "image": "cPK_20_003800_02_MANYULAex_SSR.webp",
     "packs": ["Lugia"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13262,7 +14735,8 @@
     "name": "Lickilicky ex",
     "image": "cPK_20_004060_02_BEROBELTex_SSR.webp",
     "packs": ["Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4",
@@ -13271,7 +14745,8 @@
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_02_HOUOUex_UR.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4",
@@ -13280,7 +14755,8 @@
     "name": "Lugia ex",
     "image": "cPK_20_010050_02_LUGIAex_UR.webp",
     "packs": ["Lugia", "Ho-Oh"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13289,7 +14765,8 @@
     "name": "Hoppip",
     "image": "cPK_10_010220_00_HANECCO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13298,7 +14775,8 @@
     "name": "Skiploom",
     "image": "cPK_10_010230_00_POPOCCO_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13307,7 +14785,8 @@
     "name": "Jumpluff ex",
     "image": "cPK_10_010240_00_WATACCOex_RR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13316,7 +14795,8 @@
     "name": "Sunkern",
     "image": "cPK_10_010250_00_HIMANUTS_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13325,7 +14805,8 @@
     "name": "Sunflora",
     "image": "cPK_10_010260_00_KIMAWARI_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13334,7 +14815,8 @@
     "name": "Celebi",
     "image": "cPK_10_010270_00_CELEBI_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13343,7 +14825,8 @@
     "name": "Durant",
     "image": "cPK_10_010280_00_AIANT_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13352,7 +14835,8 @@
     "name": "Slugma",
     "image": "cPK_10_010290_00_MAGMAG_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13361,7 +14845,8 @@
     "name": "Magcargo",
     "image": "cPK_10_010300_00_MAGCARGOT_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13370,7 +14855,8 @@
     "name": "Entei ex",
     "image": "cPK_10_010210_00_ENTEIex_RR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13379,7 +14865,8 @@
     "name": "Fletchinder",
     "image": "cPK_10_010310_00_HINOYAKOMA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13388,7 +14875,8 @@
     "name": "Talonflame",
     "image": "cPK_10_010320_00_FIARROW_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13397,7 +14885,8 @@
     "name": "Poliwag",
     "image": "cPK_10_010330_00_NYOROMO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13406,7 +14895,8 @@
     "name": "Poliwhirl",
     "image": "cPK_10_010340_00_NYOROZO_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13415,7 +14905,8 @@
     "name": "Tentacool",
     "image": "cPK_10_010350_00_MENOKURAGE_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13424,7 +14915,8 @@
     "name": "Tentacruel",
     "image": "cPK_10_010360_00_DOKUKURAGE_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13433,7 +14925,8 @@
     "name": "Slowpoke",
     "image": "cPK_10_010370_00_YADON_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13442,7 +14935,8 @@
     "name": "Slowking",
     "image": "cPK_10_010380_00_YADOKING_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13451,7 +14945,8 @@
     "name": "Jynx",
     "image": "cPK_10_010390_00_ROUGELA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13460,7 +14955,8 @@
     "name": "Suicune ex",
     "image": "cPK_10_010400_00_SUICUNEex_RR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13469,7 +14965,8 @@
     "name": "Feebas",
     "image": "cPK_10_010410_00_HINBASS_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13478,7 +14975,8 @@
     "name": "Milotic",
     "image": "cPK_10_010120_00_MILOKAROSS_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13487,7 +14985,8 @@
     "name": "Mantyke",
     "image": "cPK_10_010420_00_TAMANTA_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13496,7 +14995,8 @@
     "name": "Cryogonal",
     "image": "cPK_10_010430_00_FREEGEO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13505,7 +15005,8 @@
     "name": "Raikou ex",
     "image": "cPK_10_010440_00_RAIKOUex_RR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13514,7 +15015,8 @@
     "name": "Tynamo",
     "image": "cPK_10_010450_00_SHIBISHIRASU_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13523,7 +15025,8 @@
     "name": "Eelektrik",
     "image": "cPK_10_010460_00_SHIBIBEEL_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13532,7 +15035,8 @@
     "name": "Eelektross",
     "image": "cPK_10_010470_00_SHIBIRUDON_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13541,7 +15045,8 @@
     "name": "Stunfisk",
     "image": "cPK_10_010480_00_MAGGYO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13550,7 +15055,8 @@
     "name": "Yamper",
     "image": "cPK_10_010490_00_WANPACHI_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13559,7 +15065,8 @@
     "name": "Boltund",
     "image": "cPK_10_010500_00_PULSEWAN_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13568,7 +15075,8 @@
     "name": "Misdreavus",
     "image": "cPK_10_010510_00_MUMA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13577,7 +15085,8 @@
     "name": "Mismagius",
     "image": "cPK_10_010520_00_MUMARGI_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13586,7 +15095,8 @@
     "name": "Galarian Corsola",
     "image": "cPK_10_010530_00_GALARSUNNYGO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13595,7 +15105,8 @@
     "name": "Galarian Cursola",
     "image": "cPK_10_010540_00_GALARSUNIGOON_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13604,7 +15115,8 @@
     "name": "Latias",
     "image": "cPK_10_010200_00_LATIAS_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13613,7 +15125,8 @@
     "name": "Latios",
     "image": "cPK_10_010550_00_LATIOS_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13622,7 +15135,8 @@
     "name": "Frillish",
     "image": "cPK_10_010560_00_PURURILL_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13631,7 +15145,8 @@
     "name": "Jellicent",
     "image": "cPK_10_010570_00_BURUNGEL_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13640,7 +15155,8 @@
     "name": "Diglett",
     "image": "cPK_10_010580_00_DIGDA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13649,7 +15165,8 @@
     "name": "Dugtrio",
     "image": "cPK_10_010590_00_DUGTRIO_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13658,7 +15175,8 @@
     "name": "Poliwrath ex",
     "image": "cPK_10_010600_00_NYOROBONex_RR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13667,7 +15185,8 @@
     "name": "Phanpy",
     "image": "cPK_10_010190_00_GOMAZOU_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13676,7 +15195,8 @@
     "name": "Donphan",
     "image": "cPK_10_010610_00_DONFAN_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13685,7 +15205,8 @@
     "name": "Relicanth",
     "image": "cPK_10_010620_00_GLANTH_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13694,7 +15215,8 @@
     "name": "Dwebble",
     "image": "cPK_10_010630_00_ISHIZUMAI_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13703,7 +15225,8 @@
     "name": "Crustle",
     "image": "cPK_10_010640_00_IWAPALACE_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13712,7 +15235,8 @@
     "name": "Seviper",
     "image": "cPK_10_010650_00_HABUNAKE_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13721,7 +15245,8 @@
     "name": "Zorua",
     "image": "cPK_10_010130_00_ZORUA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13730,7 +15255,8 @@
     "name": "Zoroark",
     "image": "cPK_10_010140_00_ZOROARK_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13739,7 +15265,8 @@
     "name": "Inkay",
     "image": "cPK_10_010660_00_MAAIIKA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13748,7 +15275,8 @@
     "name": "Malamar",
     "image": "cPK_10_010670_00_CALAMANERO_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13757,7 +15285,8 @@
     "name": "Skrelp",
     "image": "cPK_10_010680_00_KUZUMO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13766,7 +15295,8 @@
     "name": "Dragalge",
     "image": "cPK_10_010690_00_DRAMIDORO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13775,16 +15305,18 @@
     "name": "Altaria",
     "image": "cPK_10_010700_00_TYLTALIS_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
     "number": 56,
     "rarity": "C",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_10_010710_00_KAMONEGI_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13793,7 +15325,8 @@
     "name": "Lickitung",
     "image": "cPK_10_010720_00_BERORINGA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13802,7 +15335,8 @@
     "name": "Lickilicky",
     "image": "cPK_10_010730_00_BEROBELT_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13811,7 +15345,8 @@
     "name": "Igglybuff",
     "image": "cPK_10_010740_00_PUPURIN_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13820,7 +15355,8 @@
     "name": "Teddiursa",
     "image": "cPK_10_010750_00_HIMEGUMA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13829,7 +15365,8 @@
     "name": "Ursaring",
     "image": "cPK_10_010760_00_RINGUMA_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13838,7 +15375,8 @@
     "name": "Miltank",
     "image": "cPK_10_010180_00_MILTANK_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13847,7 +15385,8 @@
     "name": "Azurill",
     "image": "cPK_10_010770_00_RURIRI_R.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13856,7 +15395,8 @@
     "name": "Swablu",
     "image": "cPK_10_010780_00_TYLTTO_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13865,7 +15405,8 @@
     "name": "Zangoose",
     "image": "cPK_10_010790_00_ZANGOOSE_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13874,7 +15415,8 @@
     "name": "Fletchling",
     "image": "cPK_10_010800_00_YAYAKOMA_C.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13883,7 +15425,8 @@
     "name": "Inflatable Boat",
     "image": "cTR_10_000820_00_WHOTABOTO_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13892,7 +15435,8 @@
     "name": "Memory Light",
     "image": "cTR_10_000830_00_MEMORYLIGHT_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13901,7 +15445,8 @@
     "name": "Whitney",
     "image": "cTR_10_000840_00_AKANE_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13910,7 +15455,8 @@
     "name": "Traveling Merchant",
     "image": "cTR_10_000850_00_TABINOGYOUSHOUNIN_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13919,7 +15465,8 @@
     "name": "Morty",
     "image": "cTR_10_000860_00_MATSUBA_U.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13928,7 +15475,8 @@
     "name": "Milotic",
     "image": "cPK_20_010120_00_MILOKAROSS_AR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13937,7 +15485,8 @@
     "name": "Stunfisk",
     "image": "cPK_20_010480_00_MAGGYO_AR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13946,7 +15495,8 @@
     "name": "Yamper",
     "image": "cPK_20_010490_00_WANPACHI_AR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13955,7 +15505,8 @@
     "name": "Latios",
     "image": "cPK_20_010550_00_LATIOS_AR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13964,7 +15515,8 @@
     "name": "Phanpy",
     "image": "cPK_20_010190_00_GOMAZOU_AR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13973,7 +15525,8 @@
     "name": "Azurill",
     "image": "cPK_20_010770_00_RURIRI_AR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13982,7 +15535,8 @@
     "name": "Jumpluff ex",
     "image": "cPK_20_010240_00_WATACCOex_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -13991,7 +15545,8 @@
     "name": "Entei ex",
     "image": "cPK_20_010210_00_ENTEIex_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14000,7 +15555,8 @@
     "name": "Suicune ex",
     "image": "cPK_20_010400_00_SUICUNEex_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14009,7 +15565,8 @@
     "name": "Raikou ex",
     "image": "cPK_20_010440_00_RAIKOUex_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14018,7 +15575,8 @@
     "name": "Poliwrath ex",
     "image": "cPK_20_010600_00_NYOROBONex_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14027,7 +15585,8 @@
     "name": "Whitney",
     "image": "cTR_20_000840_00_AKANE_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14036,7 +15595,8 @@
     "name": "Traveling Merchant",
     "image": "cTR_20_000850_00_TABINOGYOUSHOUNIN_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14045,7 +15605,8 @@
     "name": "Morty",
     "image": "cTR_20_000860_00_MATSUBA_SR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14054,7 +15615,8 @@
     "name": "Jumpluff ex",
     "image": "cPK_20_010240_01_WATACCOex_SAR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14063,7 +15625,8 @@
     "name": "Entei ex",
     "image": "cPK_20_010210_01_ENTEIex_SAR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14072,7 +15635,8 @@
     "name": "Raikou ex",
     "image": "cPK_20_010440_01_RAIKOUex_SAR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14081,7 +15645,8 @@
     "name": "Poliwrath ex",
     "image": "cPK_20_010600_01_NYOROBONex_SAR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14090,7 +15655,8 @@
     "name": "Suicune ex",
     "image": "cPK_20_010400_01_SUICUNEex_IM.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4a",
@@ -14099,7 +15665,8 @@
     "name": "Chimchar",
     "image": "cPK_20_003080_00_HIKOZARU_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14108,7 +15675,8 @@
     "name": "Monferno",
     "image": "cPK_20_003090_00_MOUKAZARU_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14117,7 +15685,8 @@
     "name": "Psyduck",
     "image": "cPK_20_000570_00_KODUCK_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14126,7 +15695,8 @@
     "name": "Golduck",
     "image": "cPK_20_000580_00_GOLDUCK_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14135,7 +15705,8 @@
     "name": "Krabby",
     "image": "cPK_20_000680_00_CRAB_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14144,7 +15715,8 @@
     "name": "Kingler",
     "image": "cPK_20_000690_00_KINGLER_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14153,7 +15725,8 @@
     "name": "Pyukumuku",
     "image": "cPK_20_006350_01_NAMAKOBUSHI_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14162,7 +15735,8 @@
     "name": "Gible",
     "image": "cPK_20_004690_00_FUKAMARU_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14171,7 +15745,8 @@
     "name": "Gabite",
     "image": "cPK_20_004700_00_GABITE_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14180,7 +15755,8 @@
     "name": "Paldean Wooper",
     "image": "cPK_20_005620_00_PALDEAUPAH_S.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14189,7 +15765,8 @@
     "name": "Infernape ex",
     "image": "cPK_20_003100_02_GOUKAZARUex_SSR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14198,7 +15775,8 @@
     "name": "Mew ex",
     "image": "cPK_20_002450_03_MEWex_SSR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14207,7 +15785,8 @@
     "name": "Garchomp ex",
     "image": "cPK_20_004710_02_GABURIASex_SSR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14216,7 +15795,8 @@
     "name": "Paldean Clodsire ex",
     "image": "cPK_20_005630_02_PALDEADOOHex_SSR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4a",
@@ -14225,7 +15805,8 @@
     "name": "Mantyke",
     "image": "cPK_20_010420_00_TAMANTA_UR.webp",
     "packs": ["Secluded"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14234,7 +15815,8 @@
     "name": "Bulbasaur",
     "image": "cPK_10_000010_00_FUSHIGIDANE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14243,7 +15825,8 @@
     "name": "Bulbasaur",
     "image": "cPK_10_000010_01_FUSHIGIDANE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14252,7 +15835,8 @@
     "name": "Ivysaur",
     "image": "cPK_10_000020_00_FUSHIGISOU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14261,7 +15845,8 @@
     "name": "Ivysaur",
     "image": "cPK_10_000020_01_FUSHIGISOU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14270,7 +15855,8 @@
     "name": "Venusaur ex",
     "image": "cPK_10_000040_00_FUSHIGIBANAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14279,7 +15865,8 @@
     "name": "Weedle",
     "image": "cPK_10_005210_00_BEEDLE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14288,7 +15875,8 @@
     "name": "Weedle",
     "image": "cPK_10_005210_01_BEEDLE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14297,7 +15885,8 @@
     "name": "Kakuna",
     "image": "cPK_10_005220_00_COCOON_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14306,7 +15895,8 @@
     "name": "Kakuna",
     "image": "cPK_10_005220_01_COCOON_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14315,7 +15905,8 @@
     "name": "Beedrill ex",
     "image": "cPK_10_005230_00_SPEARex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14324,7 +15915,8 @@
     "name": "Exeggcute",
     "image": "cPK_10_000210_00_TAMATAMA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14333,7 +15925,8 @@
     "name": "Exeggcute",
     "image": "cPK_10_000210_01_TAMATAMA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14342,7 +15935,8 @@
     "name": "Exeggutor ex",
     "image": "cPK_10_000230_00_NASSYex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14351,7 +15945,8 @@
     "name": "Hoppip",
     "image": "cPK_10_008690_00_HANECCO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14360,7 +15955,8 @@
     "name": "Hoppip",
     "image": "cPK_10_008690_01_HANECCO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14369,7 +15965,8 @@
     "name": "Skiploom",
     "image": "cPK_10_008700_00_POPOCCO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14378,7 +15975,8 @@
     "name": "Skiploom",
     "image": "cPK_10_008700_01_POPOCCO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14387,7 +15985,8 @@
     "name": "Jumpluff",
     "image": "cPK_10_008710_00_WATACCO_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14396,7 +15995,8 @@
     "name": "Jumpluff",
     "image": "cPK_10_008710_01_WATACCO_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14405,7 +16005,8 @@
     "name": "Yanma",
     "image": "cPK_10_002870_00_YANYANMA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14414,7 +16015,8 @@
     "name": "Yanma",
     "image": "cPK_10_002870_01_YANYANMA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14423,7 +16025,8 @@
     "name": "Yanmega ex",
     "image": "cPK_10_002880_00_MEGAYANMAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14432,7 +16035,8 @@
     "name": "Shuckle ex",
     "image": "cPK_10_008770_00_TSUBOTSUBOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14441,7 +16045,8 @@
     "name": "Celebi ex",
     "image": "cPK_10_002170_00_CELEBIex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14450,7 +16055,8 @@
     "name": "Cherubi",
     "image": "cPK_10_008790_00_CHERINBO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14459,7 +16065,8 @@
     "name": "Cherubi",
     "image": "cPK_10_008790_01_CHERINBO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14468,7 +16075,8 @@
     "name": "Cherrim",
     "image": "cPK_10_008800_00_CHERRIM_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14477,7 +16085,8 @@
     "name": "Cherrim",
     "image": "cPK_10_008800_01_CHERRIM_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14486,7 +16095,8 @@
     "name": "Leafeon ex",
     "image": "cPK_10_004340_00_LEAFIAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14495,7 +16105,8 @@
     "name": "Shaymin",
     "image": "cPK_10_003030_00_SHAYMIN_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14504,7 +16115,8 @@
     "name": "Shaymin",
     "image": "cPK_10_003030_01_SHAYMIN_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14513,7 +16125,8 @@
     "name": "Snivy",
     "image": "cPK_10_002180_00_TSUTARJA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14522,7 +16135,8 @@
     "name": "Snivy",
     "image": "cPK_10_002180_01_TSUTARJA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14531,7 +16145,8 @@
     "name": "Servine",
     "image": "cPK_10_002190_00_JANOVY_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14540,7 +16155,8 @@
     "name": "Servine",
     "image": "cPK_10_002190_01_JANOVY_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14549,7 +16165,8 @@
     "name": "Serperior",
     "image": "cPK_10_002200_00_JALORDA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14558,7 +16175,8 @@
     "name": "Serperior",
     "image": "cPK_10_002200_01_JALORDA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14567,7 +16185,8 @@
     "name": "Rowlet",
     "image": "cPK_10_005910_00_MOKUROH_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14576,7 +16195,8 @@
     "name": "Rowlet",
     "image": "cPK_10_005910_01_MOKUROH_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14585,7 +16205,8 @@
     "name": "Dartrix",
     "image": "cPK_10_005920_00_FUKUTHROW_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14594,7 +16215,8 @@
     "name": "Dartrix",
     "image": "cPK_10_005920_01_FUKUTHROW_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14603,7 +16225,8 @@
     "name": "Decidueye ex",
     "image": "cPK_10_005930_00_JUNAIPERex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14612,7 +16235,8 @@
     "name": "Dhelmise ex",
     "image": "cPK_10_006040_00_DADARINex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14621,7 +16245,8 @@
     "name": "Buzzwole ex",
     "image": "cPK_10_007480_00_MASSIVOONex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14630,7 +16255,8 @@
     "name": "Pheromosa",
     "image": "cPK_10_007490_00_PHEROACHE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14639,7 +16265,8 @@
     "name": "Pheromosa",
     "image": "cPK_10_007490_01_PHEROACHE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14648,7 +16275,8 @@
     "name": "Kartana",
     "image": "cPK_10_007250_00_KAMITURUGI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14657,7 +16285,8 @@
     "name": "Kartana",
     "image": "cPK_10_007250_01_KAMITURUGI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14666,7 +16295,8 @@
     "name": "Sprigatito",
     "image": "cPK_10_005080_00_NYAHOJA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14675,7 +16305,8 @@
     "name": "Sprigatito",
     "image": "cPK_10_005080_01_NYAHOJA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14684,7 +16315,8 @@
     "name": "Floragato",
     "image": "cPK_10_005250_00_NYAROTE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14693,7 +16325,8 @@
     "name": "Floragato",
     "image": "cPK_10_005250_01_NYAROTE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14702,7 +16335,8 @@
     "name": "Meowscarada",
     "image": "cPK_10_005260_00_MASQUERNYA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14711,7 +16345,8 @@
     "name": "Meowscarada",
     "image": "cPK_10_005260_01_MASQUERNYA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14720,7 +16355,8 @@
     "name": "Charmander",
     "image": "cPK_10_000330_00_HITOKAGE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14729,7 +16365,8 @@
     "name": "Charmander",
     "image": "cPK_10_000330_01_HITOKAGE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14738,7 +16375,8 @@
     "name": "Charmeleon",
     "image": "cPK_10_000340_00_LIZARDO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14747,7 +16385,8 @@
     "name": "Charmeleon",
     "image": "cPK_10_000340_01_LIZARDO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14756,7 +16395,8 @@
     "name": "Charizard ex",
     "image": "cPK_10_000360_00_LIZARDONex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14765,7 +16405,8 @@
     "name": "Charizard ex",
     "image": "cPK_10_005290_00_LIZARDONex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14774,7 +16415,8 @@
     "name": "Growlithe",
     "image": "cPK_10_000390_00_GARDIE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14783,7 +16425,8 @@
     "name": "Growlithe",
     "image": "cPK_10_000390_01_GARDIE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14792,7 +16435,8 @@
     "name": "Arcanine ex",
     "image": "cPK_10_000410_00_WINDIEex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14801,7 +16445,8 @@
     "name": "Flareon",
     "image": "cPK_10_008040_00_BOOSTER_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14810,7 +16455,8 @@
     "name": "Flareon",
     "image": "cPK_10_008040_01_BOOSTER_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14819,7 +16465,8 @@
     "name": "Flareon ex",
     "image": "cPK_10_008050_00_BOOSTERex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14828,7 +16475,8 @@
     "name": "Moltres ex",
     "image": "cPK_10_000470_00_FIREex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14837,7 +16485,8 @@
     "name": "Ho-Oh ex",
     "image": "cPK_10_008900_00_HOUOUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14846,7 +16495,8 @@
     "name": "Torkoal",
     "image": "cPK_10_008060_00_COTOISE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14855,7 +16505,8 @@
     "name": "Torkoal",
     "image": "cPK_10_008060_01_COTOISE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14864,7 +16515,8 @@
     "name": "Chimchar",
     "image": "cPK_10_003080_00_HIKOZARU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14873,7 +16525,8 @@
     "name": "Chimchar",
     "image": "cPK_10_003080_01_HIKOZARU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14882,7 +16535,8 @@
     "name": "Monferno",
     "image": "cPK_10_003090_00_MOUKAZARU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14891,7 +16545,8 @@
     "name": "Monferno",
     "image": "cPK_10_003090_01_MOUKAZARU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14900,7 +16555,8 @@
     "name": "Infernape ex",
     "image": "cPK_10_003100_00_GOUKAZARUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14909,7 +16565,8 @@
     "name": "Heatran",
     "image": "cPK_10_004370_00_HEATRAN_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14918,7 +16575,8 @@
     "name": "Heatran",
     "image": "cPK_10_004370_01_HEATRAN_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14927,7 +16585,8 @@
     "name": "Litten",
     "image": "cPK_10_006110_00_NYABBY_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14936,7 +16595,8 @@
     "name": "Litten",
     "image": "cPK_10_006110_01_NYABBY_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14945,7 +16605,8 @@
     "name": "Torracat",
     "image": "cPK_10_006130_00_NYAHEAT_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14954,7 +16615,8 @@
     "name": "Torracat",
     "image": "cPK_10_006130_01_NYAHEAT_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14963,7 +16625,8 @@
     "name": "Incineroar ex",
     "image": "cPK_10_006140_00_GAOGAENex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14972,7 +16635,8 @@
     "name": "Squirtle",
     "image": "cPK_10_000530_00_ZENIGAME_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14981,7 +16645,8 @@
     "name": "Squirtle",
     "image": "cPK_10_000530_01_ZENIGAME_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14990,7 +16655,8 @@
     "name": "Wartortle",
     "image": "cPK_10_000540_00_KAMEIL_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -14999,7 +16665,8 @@
     "name": "Wartortle",
     "image": "cPK_10_000540_01_KAMEIL_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15008,7 +16675,8 @@
     "name": "Blastoise ex",
     "image": "cPK_10_000560_00_KAMEXex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15017,7 +16685,8 @@
     "name": "Horsea",
     "image": "cPK_10_008970_00_TATTU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15026,7 +16695,8 @@
     "name": "Horsea",
     "image": "cPK_10_008970_01_TATTU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15035,7 +16705,8 @@
     "name": "Seadra",
     "image": "cPK_10_008980_00_SEADRA_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15044,7 +16715,8 @@
     "name": "Seadra",
     "image": "cPK_10_008980_01_SEADRA_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15053,7 +16725,8 @@
     "name": "Kingdra ex",
     "image": "cPK_10_008990_00_KINGDRAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15062,7 +16735,8 @@
     "name": "Staryu",
     "image": "cPK_10_000740_00_HITODEMAN_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15071,7 +16745,8 @@
     "name": "Staryu",
     "image": "cPK_10_000740_01_HITODEMAN_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15080,7 +16755,8 @@
     "name": "Starmie ex",
     "image": "cPK_10_000760_00_STARMIEex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15089,7 +16765,8 @@
     "name": "Magikarp",
     "image": "cPK_10_002310_00_KOIKING_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15098,7 +16775,8 @@
     "name": "Magikarp",
     "image": "cPK_10_002310_01_KOIKING_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15107,7 +16785,8 @@
     "name": "Gyarados ex",
     "image": "cPK_10_002320_00_GYARADOSex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15116,7 +16795,8 @@
     "name": "Vaporeon",
     "image": "cPK_10_002330_00_SHOWERS_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15125,7 +16805,8 @@
     "name": "Vaporeon",
     "image": "cPK_10_002330_01_SHOWERS_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15134,7 +16815,8 @@
     "name": "Articuno ex",
     "image": "cPK_10_000840_00_FREEZERex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15143,7 +16825,8 @@
     "name": "Corphish",
     "image": "cPK_10_009160_00_HEIGANI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15152,7 +16835,8 @@
     "name": "Corphish",
     "image": "cPK_10_009160_01_HEIGANI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15161,7 +16845,8 @@
     "name": "Crawdaunt",
     "image": "cPK_10_009170_00_SHIZARIGER_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15170,7 +16855,8 @@
     "name": "Crawdaunt",
     "image": "cPK_10_009170_01_SHIZARIGER_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15179,7 +16865,8 @@
     "name": "Glaceon ex",
     "image": "cPK_10_004460_00_GLACIAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15188,7 +16875,8 @@
     "name": "Palkia ex",
     "image": "cPK_10_003300_00_PALKIAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15197,7 +16885,8 @@
     "name": "Manaphy",
     "image": "cPK_10_003310_00_MANAPHY_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15206,7 +16895,8 @@
     "name": "Manaphy",
     "image": "cPK_10_003310_01_MANAPHY_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15215,7 +16905,8 @@
     "name": "Froakie",
     "image": "cPK_10_000870_00_KEROMATSU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15224,7 +16915,8 @@
     "name": "Froakie",
     "image": "cPK_10_000870_01_KEROMATSU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15233,7 +16925,8 @@
     "name": "Frogadier",
     "image": "cPK_10_000880_00_GEKOGASHIRA_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15242,7 +16935,8 @@
     "name": "Frogadier",
     "image": "cPK_10_000880_01_GEKOGASHIRA_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15251,7 +16945,8 @@
     "name": "Greninja",
     "image": "cPK_10_000890_00_GEKKOUGA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15260,7 +16955,8 @@
     "name": "Greninja",
     "image": "cPK_10_000890_01_GEKKOUGA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15269,7 +16965,8 @@
     "name": "Popplio",
     "image": "cPK_10_008170_00_ASHIMARI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15278,7 +16975,8 @@
     "name": "Popplio",
     "image": "cPK_10_008170_01_ASHIMARI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15287,7 +16985,8 @@
     "name": "Brionne",
     "image": "cPK_10_008180_00_OSYAMARI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15296,7 +16995,8 @@
     "name": "Brionne",
     "image": "cPK_10_008180_01_OSYAMARI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15305,7 +17005,8 @@
     "name": "Primarina ex",
     "image": "cPK_10_008190_00_ASHIRENEex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15314,7 +17015,8 @@
     "name": "Crabominable ex",
     "image": "cPK_10_006300_00_KEKENKANIex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15323,7 +17025,8 @@
     "name": "Wishiwashi",
     "image": "cPK_10_006310_00_YOWASHITANDOKUNOSUGATA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15332,7 +17035,8 @@
     "name": "Wishiwashi",
     "image": "cPK_10_006310_01_YOWASHITANDOKUNOSUGATA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15341,7 +17045,8 @@
     "name": "Wishiwashi ex",
     "image": "cPK_10_006320_00_YOWASHIMURETASUGATA_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15350,7 +17055,8 @@
     "name": "Wiglett",
     "image": "cPK_10_005370_00_UMIDIGDA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15359,7 +17065,8 @@
     "name": "Wiglett",
     "image": "cPK_10_005370_01_UMIDIGDA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15368,7 +17075,8 @@
     "name": "Wugtrio ex",
     "image": "cPK_10_005380_00_UMITRIOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15377,7 +17085,8 @@
     "name": "Pikachu",
     "image": "cPK_10_000940_00_PIKACHU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15386,7 +17095,8 @@
     "name": "Pikachu",
     "image": "cPK_10_000940_01_PIKACHU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15395,7 +17105,8 @@
     "name": "Alolan Raichu ex",
     "image": "cPK_10_006390_00_ALOLARAICHUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15404,7 +17115,8 @@
     "name": "Pikachu ex",
     "image": "cPK_10_000960_00_PIKACHUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15413,7 +17125,8 @@
     "name": "Pikachu ex",
     "image": "cPK_10_005410_00_PIKACHUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15422,7 +17135,8 @@
     "name": "Magnemite",
     "image": "cPK_10_000970_00_COIL_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15431,7 +17145,8 @@
     "name": "Magnemite",
     "image": "cPK_10_000970_01_COIL_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15440,7 +17155,8 @@
     "name": "Magneton",
     "image": "cPK_10_000980_00_RARECOIL_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15449,7 +17165,8 @@
     "name": "Magneton",
     "image": "cPK_10_000980_01_RARECOIL_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15458,7 +17175,8 @@
     "name": "Magnezone",
     "image": "cPK_10_003340_00_JIBACOIL_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15467,7 +17185,8 @@
     "name": "Magnezone",
     "image": "cPK_10_003340_01_JIBACOIL_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15476,7 +17195,8 @@
     "name": "Zapdos ex",
     "image": "cPK_10_001040_00_THUNDERex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15485,7 +17205,8 @@
     "name": "Chinchou",
     "image": "cPK_10_009200_00_CHONCHIE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15494,7 +17215,8 @@
     "name": "Chinchou",
     "image": "cPK_10_009200_01_CHONCHIE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15503,7 +17225,8 @@
     "name": "Lanturn ex",
     "image": "cPK_10_009210_00_LANTERNex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15512,7 +17235,8 @@
     "name": "Pachirisu",
     "image": "cPK_10_005060_00_PACHIRISU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15521,7 +17245,8 @@
     "name": "Pachirisu",
     "image": "cPK_10_005060_01_PACHIRISU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15530,7 +17255,8 @@
     "name": "Pachirisu ex",
     "image": "cPK_10_003420_00_PACHIRISUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15539,7 +17265,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006470_00_ODORIDORIPACHIPACHISTYLE_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15548,7 +17275,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006470_01_ODORIDORIPACHIPACHISTYLE_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15557,7 +17285,8 @@
     "name": "Tapu Koko ex",
     "image": "cPK_10_007420_00_KAPU-KOKEKOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15566,7 +17295,8 @@
     "name": "Zeraora",
     "image": "cPK_10_007410_00_ZERAORA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15575,7 +17305,8 @@
     "name": "Zeraora",
     "image": "cPK_10_007410_01_ZERAORA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15584,7 +17315,8 @@
     "name": "Gastly",
     "image": "cPK_10_001200_00_GHOS_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15593,7 +17325,8 @@
     "name": "Gastly",
     "image": "cPK_10_001200_01_GHOS_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15602,7 +17335,8 @@
     "name": "Haunter",
     "image": "cPK_10_001210_00_GHOST_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15611,7 +17345,8 @@
     "name": "Haunter",
     "image": "cPK_10_001210_01_GHOST_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15620,7 +17355,8 @@
     "name": "Gengar ex",
     "image": "cPK_10_001230_00_GANGARex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15629,7 +17365,8 @@
     "name": "Jynx",
     "image": "cPK_10_001270_00_ROUGELA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15638,7 +17375,8 @@
     "name": "Jynx",
     "image": "cPK_10_001270_01_ROUGELA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15647,7 +17385,8 @@
     "name": "Mewtwo ex",
     "image": "cPK_10_001290_00_MEWTWOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15656,7 +17395,8 @@
     "name": "Mew ex",
     "image": "cPK_10_002450_00_MEWex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15665,7 +17405,8 @@
     "name": "Espeon ex",
     "image": "cPK_10_009390_00_EIFIEex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15674,7 +17415,8 @@
     "name": "Misdreavus",
     "image": "cPK_10_003470_00_MUMA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15683,7 +17425,8 @@
     "name": "Misdreavus",
     "image": "cPK_10_003470_01_MUMA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15692,7 +17435,8 @@
     "name": "Mismagius ex",
     "image": "cPK_10_003480_00_MUMARGIex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15701,7 +17445,8 @@
     "name": "Ralts",
     "image": "cPK_10_003490_00_RALTS_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15710,7 +17455,8 @@
     "name": "Ralts",
     "image": "cPK_10_003490_01_RALTS_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15719,7 +17465,8 @@
     "name": "Kirlia",
     "image": "cPK_10_003500_00_KIRLIA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15728,7 +17475,8 @@
     "name": "Kirlia",
     "image": "cPK_10_003500_01_KIRLIA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15737,7 +17485,8 @@
     "name": "Gardevoir",
     "image": "cPK_10_001320_00_SIRNIGHT_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15746,7 +17495,8 @@
     "name": "Gardevoir",
     "image": "cPK_10_001320_01_SIRNIGHT_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15755,7 +17505,8 @@
     "name": "Giratina",
     "image": "cPK_10_003590_00_ORIGINGIRATINA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15764,7 +17515,8 @@
     "name": "Giratina",
     "image": "cPK_10_003590_01_ORIGINGIRATINA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15773,7 +17525,8 @@
     "name": "Giratina ex",
     "image": "cPK_10_005520_00_GIRATINAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15782,7 +17535,8 @@
     "name": "Swirlix",
     "image": "cPK_10_008250_00_PEROPPAFU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15791,7 +17545,8 @@
     "name": "Swirlix",
     "image": "cPK_10_008250_01_PEROPPAFU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15800,7 +17555,8 @@
     "name": "Slurpuff",
     "image": "cPK_10_008260_00_PEROREAM_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15809,7 +17565,8 @@
     "name": "Slurpuff",
     "image": "cPK_10_008260_01_PEROREAM_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15818,7 +17575,8 @@
     "name": "Sylveon ex",
     "image": "cPK_10_008280_00_NYMPHIAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15827,7 +17585,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006580_00_ODORIDORIMAIMAISTYLE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15836,7 +17595,8 @@
     "name": "Oricorio",
     "image": "cPK_10_006580_01_ODORIDORIMAIMAISTYLE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15845,7 +17605,8 @@
     "name": "Cosmog",
     "image": "cPK_10_006660_00_COSMOG_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15854,7 +17615,8 @@
     "name": "Cosmog",
     "image": "cPK_10_006660_01_COSMOG_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15863,7 +17625,8 @@
     "name": "Cosmoem",
     "image": "cPK_10_006670_00_COSMOVUM_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15872,7 +17635,8 @@
     "name": "Cosmoem",
     "image": "cPK_10_006670_01_COSMOVUM_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15881,7 +17645,8 @@
     "name": "Lunala ex",
     "image": "cPK_10_006680_00_LUNALAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15890,7 +17655,8 @@
     "name": "Milcery",
     "image": "cPK_10_008300_00_MAHOMIL_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15899,7 +17665,8 @@
     "name": "Milcery",
     "image": "cPK_10_008300_01_MAHOMIL_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15908,7 +17675,8 @@
     "name": "Alcremie",
     "image": "cPK_10_007340_00_MAWHIP_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15917,7 +17685,8 @@
     "name": "Alcremie",
     "image": "cPK_10_007340_01_MAWHIP_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15926,7 +17695,8 @@
     "name": "Machop",
     "image": "cPK_10_001430_00_WANRIKY_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15935,7 +17705,8 @@
     "name": "Machop",
     "image": "cPK_10_001430_01_WANRIKY_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15944,7 +17715,8 @@
     "name": "Machoke",
     "image": "cPK_10_001440_00_GORIKY_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15953,7 +17725,8 @@
     "name": "Machoke",
     "image": "cPK_10_001440_01_GORIKY_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15962,7 +17735,8 @@
     "name": "Machamp ex",
     "image": "cPK_10_001460_00_KAIRIKYex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15971,7 +17745,8 @@
     "name": "Cubone",
     "image": "cPK_10_001510_00_KARAKARA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15980,7 +17755,8 @@
     "name": "Cubone",
     "image": "cPK_10_001510_01_KARAKARA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15989,7 +17765,8 @@
     "name": "Marowak ex",
     "image": "cPK_10_001530_00_GARAGARAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -15998,7 +17775,8 @@
     "name": "Aerodactyl ex",
     "image": "cPK_10_002590_00_PTERAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16007,7 +17785,8 @@
     "name": "Sudowoodo",
     "image": "cPK_10_004600_00_USOKKIE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16016,7 +17795,8 @@
     "name": "Sudowoodo",
     "image": "cPK_10_004600_01_USOKKIE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16025,7 +17805,8 @@
     "name": "Phanpy",
     "image": "cPK_10_009550_00_GOMAZOU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16034,7 +17815,8 @@
     "name": "Phanpy",
     "image": "cPK_10_009550_01_GOMAZOU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16043,7 +17825,8 @@
     "name": "Donphan ex",
     "image": "cPK_10_009560_00_DONFANex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16052,7 +17835,8 @@
     "name": "Nosepass",
     "image": "cPK_10_004660_00_NOSEPASS_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16061,7 +17845,8 @@
     "name": "Nosepass",
     "image": "cPK_10_004660_01_NOSEPASS_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16070,7 +17855,8 @@
     "name": "Gible",
     "image": "cPK_10_004690_00_FUKAMARU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16079,7 +17865,8 @@
     "name": "Gible",
     "image": "cPK_10_004690_01_FUKAMARU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16088,7 +17875,8 @@
     "name": "Gabite",
     "image": "cPK_10_004700_00_GABITE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16097,7 +17885,8 @@
     "name": "Gabite",
     "image": "cPK_10_004700_01_GABITE_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16106,7 +17895,8 @@
     "name": "Garchomp ex",
     "image": "cPK_10_004710_00_GABURIASex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16115,7 +17905,8 @@
     "name": "Riolu",
     "image": "cPK_10_005070_00_RIOLU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16124,7 +17915,8 @@
     "name": "Riolu",
     "image": "cPK_10_005070_01_RIOLU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16133,7 +17925,8 @@
     "name": "Lucario",
     "image": "cPK_10_003730_00_LUCARIO_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16142,7 +17935,8 @@
     "name": "Lucario",
     "image": "cPK_10_003730_01_LUCARIO_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16151,7 +17945,8 @@
     "name": "Lucario ex",
     "image": "cPK_10_005580_00_LUCARIOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16160,7 +17955,8 @@
     "name": "Gallade ex",
     "image": "cPK_10_003760_00_ERUREIDOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16169,7 +17965,8 @@
     "name": "Drilbur",
     "image": "cPK_10_006740_00_MOGUREW_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16178,7 +17975,8 @@
     "name": "Drilbur",
     "image": "cPK_10_006740_01_MOGUREW_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16187,7 +17985,8 @@
     "name": "Crabrawler",
     "image": "cPK_10_006780_00_MAKENKANI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16196,7 +17995,8 @@
     "name": "Crabrawler",
     "image": "cPK_10_006780_01_MAKENKANI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16205,7 +18005,8 @@
     "name": "Rockruff",
     "image": "cPK_10_007690_00_IWANKO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16214,7 +18015,8 @@
     "name": "Rockruff",
     "image": "cPK_10_007690_01_IWANKO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16223,7 +18025,8 @@
     "name": "Lycanroc ex",
     "image": "cPK_10_007700_00_LUGARUGANTASOGARENOSUGATA_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16232,7 +18035,8 @@
     "name": "Passimian ex",
     "image": "cPK_10_006850_00_NAGETUKESARUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16241,7 +18045,8 @@
     "name": "Marshadow",
     "image": "cPK_10_002600_00_MARSHADOW_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16250,7 +18055,8 @@
     "name": "Marshadow",
     "image": "cPK_10_002600_01_MARSHADOW_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16259,7 +18065,8 @@
     "name": "Zubat",
     "image": "cPK_10_004720_00_ZUBAT_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16268,7 +18075,8 @@
     "name": "Zubat",
     "image": "cPK_10_004720_01_ZUBAT_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16277,7 +18085,8 @@
     "name": "Golbat",
     "image": "cPK_10_004730_00_GOLBAT_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16286,7 +18095,8 @@
     "name": "Golbat",
     "image": "cPK_10_004730_01_GOLBAT_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16295,7 +18105,8 @@
     "name": "Crobat",
     "image": "cPK_10_004740_00_CROBAT_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16304,7 +18115,8 @@
     "name": "Crobat",
     "image": "cPK_10_004740_01_CROBAT_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16313,7 +18125,8 @@
     "name": "Crobat ex",
     "image": "cPK_10_009650_00_CROBATex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16322,7 +18135,8 @@
     "name": "Alolan Grimer",
     "image": "cPK_10_006910_00_ALOLABETBETER_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16331,7 +18145,8 @@
     "name": "Alolan Grimer",
     "image": "cPK_10_006910_01_ALOLABETBETER_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16340,7 +18155,8 @@
     "name": "Alolan Muk ex",
     "image": "cPK_10_006920_00_ALOLABETBETONex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16349,7 +18165,8 @@
     "name": "Paldean Wooper",
     "image": "cPK_10_005620_00_PALDEAUPAH_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16358,7 +18175,8 @@
     "name": "Paldean Wooper",
     "image": "cPK_10_005620_01_PALDEAUPAH_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16367,7 +18185,8 @@
     "name": "Paldean Clodsire ex",
     "image": "cPK_10_005630_00_PALDEADOOHex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16376,7 +18195,8 @@
     "name": "Umbreon",
     "image": "cPK_10_008360_00_BRACKY_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16385,7 +18205,8 @@
     "name": "Umbreon",
     "image": "cPK_10_008360_01_BRACKY_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16394,7 +18215,8 @@
     "name": "Umbreon ex",
     "image": "cPK_10_009680_00_BRACKYex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16403,7 +18225,8 @@
     "name": "Sneasel",
     "image": "cPK_10_003790_00_NYULA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16412,7 +18235,8 @@
     "name": "Sneasel",
     "image": "cPK_10_003790_01_NYULA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16421,7 +18245,8 @@
     "name": "Weavile ex",
     "image": "cPK_10_003800_00_MANYULAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16430,7 +18255,8 @@
     "name": "Darkrai ex",
     "image": "cPK_10_003910_00_DARKRAIex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16439,7 +18265,8 @@
     "name": "Nihilego",
     "image": "cPK_10_007790_00_UTUROID_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16448,7 +18275,8 @@
     "name": "Nihilego",
     "image": "cPK_10_007790_01_UTUROID_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16457,7 +18285,8 @@
     "name": "Guzzlord ex",
     "image": "cPK_10_007800_00_AKUZIKINGex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16466,7 +18295,8 @@
     "name": "Alolan Diglett",
     "image": "cPK_10_007820_00_ALOLADIGDA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16475,7 +18305,8 @@
     "name": "Alolan Diglett",
     "image": "cPK_10_007820_01_ALOLADIGDA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16484,7 +18315,8 @@
     "name": "Alolan Dugtrio ex",
     "image": "cPK_10_007830_00_ALOLADUGTRIOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16493,7 +18325,8 @@
     "name": "Skarmory ex",
     "image": "cPK_10_009800_00_AIRMDex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16502,7 +18335,8 @@
     "name": "Probopass ex",
     "image": "cPK_10_004810_00_DAINOSEex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16511,7 +18345,8 @@
     "name": "Dialga ex",
     "image": "cPK_10_004000_00_DIALGAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16520,7 +18355,8 @@
     "name": "Excadrill",
     "image": "cPK_10_007000_00_DORYUZU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16529,7 +18365,8 @@
     "name": "Excadrill",
     "image": "cPK_10_007000_01_DORYUZU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16538,7 +18375,8 @@
     "name": "Klefki",
     "image": "cPK_10_007020_00_CLEFFY_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16547,7 +18385,8 @@
     "name": "Klefki",
     "image": "cPK_10_007020_01_CLEFFY_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16556,7 +18395,8 @@
     "name": "Solgaleo ex",
     "image": "cPK_10_007030_00_SOLGALEOex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16565,7 +18405,8 @@
     "name": "Magearna",
     "image": "cPK_10_007040_00_MAGEARNA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16574,7 +18415,8 @@
     "name": "Magearna",
     "image": "cPK_10_007040_01_MAGEARNA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16583,7 +18425,8 @@
     "name": "Tinkatink",
     "image": "cPK_10_005670_00_KANUCHAN_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16592,7 +18435,8 @@
     "name": "Tinkatink",
     "image": "cPK_10_005670_01_KANUCHAN_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16601,7 +18445,8 @@
     "name": "Tinkatuff",
     "image": "cPK_10_005680_00_NAKANUCHAN_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16610,7 +18455,8 @@
     "name": "Tinkatuff",
     "image": "cPK_10_005680_01_NAKANUCHAN_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16619,7 +18465,8 @@
     "name": "Tinkaton ex",
     "image": "cPK_10_005690_00_DEKANUCHANex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16628,7 +18475,8 @@
     "name": "Dratini",
     "image": "cPK_10_008430_00_MINIRYU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16637,7 +18485,8 @@
     "name": "Dratini",
     "image": "cPK_10_008430_01_MINIRYU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16646,7 +18495,8 @@
     "name": "Dragonair",
     "image": "cPK_10_008440_00_HAKURYU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16655,7 +18505,8 @@
     "name": "Dragonair",
     "image": "cPK_10_008440_01_HAKURYU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16664,7 +18515,8 @@
     "name": "Dragonite ex",
     "image": "cPK_10_008450_00_KAIRYUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16673,7 +18525,8 @@
     "name": "Pidgey",
     "image": "cPK_10_002700_00_POPPO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16682,7 +18535,8 @@
     "name": "Pidgey",
     "image": "cPK_10_002700_01_POPPO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16691,7 +18545,8 @@
     "name": "Pidgeotto",
     "image": "cPK_10_002710_00_PIGEON_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16700,7 +18555,8 @@
     "name": "Pidgeotto",
     "image": "cPK_10_002710_01_PIGEON_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16709,7 +18565,8 @@
     "name": "Pidgeot ex",
     "image": "cPK_10_002720_00_PIGEOTex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16718,7 +18575,8 @@
     "name": "Jigglypuff",
     "image": "cPK_10_001930_00_PURIN_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16727,7 +18585,8 @@
     "name": "Jigglypuff",
     "image": "cPK_10_001930_01_PURIN_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16736,25 +18595,28 @@
     "name": "Wigglytuff ex",
     "image": "cPK_10_001950_00_PUKURINex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
     "number": 280,
     "rarity": "C",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_10_001980_00_KAMONEGI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
     "number": 281,
     "rarity": "C",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_10_001980_01_KAMONEGI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16763,7 +18625,8 @@
     "name": "Lickitung",
     "image": "cPK_10_004050_00_BERORINGA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16772,7 +18635,8 @@
     "name": "Lickitung",
     "image": "cPK_10_004050_01_BERORINGA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16781,7 +18645,8 @@
     "name": "Lickilicky ex",
     "image": "cPK_10_004060_00_BEROBELTex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16790,7 +18655,8 @@
     "name": "Eevee",
     "image": "cPK_10_008470_00_EIEVUI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16799,7 +18665,8 @@
     "name": "Eevee",
     "image": "cPK_10_008470_01_EIEVUI_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16808,7 +18675,8 @@
     "name": "Eevee ex",
     "image": "cPK_10_008480_00_EIEVUIex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16817,7 +18685,8 @@
     "name": "Snorlax ex",
     "image": "cPK_10_008490_00_KABIGONex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16826,7 +18695,8 @@
     "name": "Lugia ex",
     "image": "cPK_10_010050_00_LUGIAex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16835,7 +18705,8 @@
     "name": "Skitty",
     "image": "cPK_10_007100_00_ENECO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16844,7 +18715,8 @@
     "name": "Skitty",
     "image": "cPK_10_007100_01_ENECO_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16853,7 +18725,8 @@
     "name": "Delcatty",
     "image": "cPK_10_007110_00_ENEKORORO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16862,7 +18735,8 @@
     "name": "Delcatty",
     "image": "cPK_10_007110_01_ENEKORORO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16871,7 +18745,8 @@
     "name": "Bidoof",
     "image": "cPK_10_005040_00_BIPPA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16880,7 +18755,8 @@
     "name": "Bidoof",
     "image": "cPK_10_005040_01_BIPPA_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16889,7 +18765,8 @@
     "name": "Bibarel ex",
     "image": "cPK_10_005790_00_BEADARUex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16898,7 +18775,8 @@
     "name": "Shaymin",
     "image": "cPK_10_004930_00_SHAYMIN_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16907,7 +18785,8 @@
     "name": "Shaymin",
     "image": "cPK_10_004930_01_SHAYMIN_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16916,7 +18795,8 @@
     "name": "Arceus ex",
     "image": "cPK_10_004950_00_ARCEUSex_RR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16925,7 +18805,8 @@
     "name": "Type: Null",
     "image": "cPK_10_007940_00_TYPENULL_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16934,7 +18815,8 @@
     "name": "Type: Null",
     "image": "cPK_10_007940_01_TYPENULL_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16943,7 +18825,8 @@
     "name": "Silvally",
     "image": "cPK_10_007950_00_SILVADY_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16952,7 +18835,8 @@
     "name": "Silvally",
     "image": "cPK_10_007950_01_SILVADY_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16961,7 +18845,8 @@
     "name": "Celesteela",
     "image": "cPK_10_007960_00_TEKKAGUYA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16970,7 +18855,8 @@
     "name": "Celesteela",
     "image": "cPK_10_007960_01_TEKKAGUYA_R.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16979,7 +18865,8 @@
     "name": "Cyclizar",
     "image": "cPK_10_005090_00_MOTOTOKAGE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16988,7 +18875,8 @@
     "name": "Cyclizar",
     "image": "cPK_10_005090_01_MOTOTOKAGE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -16997,7 +18885,8 @@
     "name": "Eevee Bag",
     "image": "cTR_10_000670_00_IIBUINOBAKKU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17006,7 +18895,8 @@
     "name": "Eevee Bag",
     "image": "cTR_10_000670_01_IIBUINOBAKKU_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17015,7 +18905,8 @@
     "name": "Elemental Switch",
     "image": "cTR_10_000710_00_EREMENTARUTSUKEKAE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17024,7 +18915,8 @@
     "name": "Elemental Switch",
     "image": "cTR_10_000710_01_EREMENTARUTSUKEKAE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17033,7 +18925,8 @@
     "name": "Old Amber",
     "image": "cTR_10_000100_00_HIMITSUNOKOHAKU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17042,7 +18935,8 @@
     "name": "Old Amber",
     "image": "cTR_10_000100_01_HIMITSUNOKOHAKU_C.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17051,7 +18945,8 @@
     "name": "Rare Candy",
     "image": "cTR_10_000480_00_FUSHIGINAAME_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17060,25 +18955,28 @@
     "name": "Rare Candy",
     "image": "cTR_10_000480_01_FUSHIGINAAME_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
     "number": 316,
     "rarity": "U",
-    "name": "Pok\u00e9mon Communication",
+    "name": "Pokémon Communication",
     "image": "cTR_10_000280_00_POKEMONTSUUSHIN_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
     "number": 317,
     "rarity": "U",
-    "name": "Pok\u00e9mon Communication",
+    "name": "Pokémon Communication",
     "image": "cTR_10_000280_01_POKEMONTSUUSHIN_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17087,7 +18985,8 @@
     "name": "Electrical Cord",
     "image": "cTR_10_000620_00_EREKIKORD_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17096,7 +18995,8 @@
     "name": "Electrical Cord",
     "image": "cTR_10_000620_01_EREKIKORD_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17105,7 +19005,8 @@
     "name": "Giant Cape",
     "image": "cTR_10_000290_00_OOKINAMANTO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17114,7 +19015,8 @@
     "name": "Giant Cape",
     "image": "cTR_10_000290_01_OOKINAMANTO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17123,7 +19025,8 @@
     "name": "Rocky Helmet",
     "image": "cTR_10_000300_00_GOTSUGOTSUMETTO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17132,7 +19035,8 @@
     "name": "Rocky Helmet",
     "image": "cTR_10_000300_01_GOTSUGOTSUMETTO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17141,7 +19045,8 @@
     "name": "Leaf Cape",
     "image": "cTR_10_000510_00_LEAFMANTO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17150,7 +19055,8 @@
     "name": "Leaf Cape",
     "image": "cTR_10_000510_01_LEAFMANTO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17159,7 +19065,8 @@
     "name": "Cyrus",
     "image": "cTR_10_000320_00_AKAGI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17168,7 +19075,8 @@
     "name": "Cyrus",
     "image": "cTR_10_000320_01_AKAGI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17177,7 +19085,8 @@
     "name": "Erika",
     "image": "cTR_10_000110_00_ERIKA_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17186,7 +19095,8 @@
     "name": "Erika",
     "image": "cTR_10_000110_01_ERIKA_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17195,7 +19105,8 @@
     "name": "Irida",
     "image": "cTR_10_000380_00_KAI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17204,7 +19115,8 @@
     "name": "Irida",
     "image": "cTR_10_000380_01_KAI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17213,7 +19125,8 @@
     "name": "Lyra",
     "image": "cTR_10_000770_00_KOTONE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17222,7 +19135,8 @@
     "name": "Lyra",
     "image": "cTR_10_000770_01_KOTONE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17231,7 +19145,8 @@
     "name": "Giovanni",
     "image": "cTR_10_000150_00_SAKAKI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17240,7 +19155,8 @@
     "name": "Giovanni",
     "image": "cTR_10_000150_01_SAKAKI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17249,7 +19165,8 @@
     "name": "Silver",
     "image": "cTR_10_000780_00_SILVER_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17258,7 +19175,8 @@
     "name": "Silver",
     "image": "cTR_10_000780_01_SILVER_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17267,7 +19185,8 @@
     "name": "Sabrina",
     "image": "cTR_10_000170_00_NATSUME_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17276,7 +19195,8 @@
     "name": "Sabrina",
     "image": "cTR_10_000170_01_NATSUME_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17285,7 +19205,8 @@
     "name": "Iono",
     "image": "cTR_10_000420_00_NANJYAMO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17294,7 +19215,8 @@
     "name": "Iono",
     "image": "cTR_10_000420_01_NANJYAMO_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17303,7 +19225,8 @@
     "name": "Dawn",
     "image": "cTR_10_000360_00_HIKARI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17312,7 +19235,8 @@
     "name": "Dawn",
     "image": "cTR_10_000360_01_HIKARI_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17321,7 +19245,8 @@
     "name": "Mars",
     "image": "cTR_10_000370_00_MARS_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17330,7 +19255,8 @@
     "name": "Mars",
     "image": "cTR_10_000370_01_MARS_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17339,7 +19265,8 @@
     "name": "Leaf",
     "image": "cTR_10_000230_00_LEAF_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17348,7 +19275,8 @@
     "name": "Leaf",
     "image": "cTR_10_000230_01_LEAF_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17357,7 +19285,8 @@
     "name": "Lillie",
     "image": "cTR_10_000590_00_LILIE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17366,7 +19295,8 @@
     "name": "Lillie",
     "image": "cTR_10_000590_01_LILIE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17375,7 +19305,8 @@
     "name": "Lusamine",
     "image": "cTR_10_000660_00_LUSAMINE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17384,7 +19315,8 @@
     "name": "Lusamine",
     "image": "cTR_10_000660_01_LUSAMINE_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17393,7 +19325,8 @@
     "name": "Red",
     "image": "cTR_10_000440_00_RED_U.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17402,7 +19335,8 @@
     "name": "Red",
     "image": "cTR_10_000440_01_RED_U.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17411,7 +19345,8 @@
     "name": "Floragato",
     "image": "cPK_20_005250_00_NYAROTE_AR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17420,7 +19355,8 @@
     "name": "Crawdaunt",
     "image": "cPK_20_009170_00_SHIZARIGER_AR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17429,7 +19365,8 @@
     "name": "Greninja",
     "image": "cPK_20_000890_01_GEKKOUGA_AR.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17438,7 +19375,8 @@
     "name": "Gardevoir",
     "image": "cPK_20_001320_01_SIRNIGHT_AR.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17447,16 +19385,18 @@
     "name": "Slurpuff",
     "image": "cPK_20_008260_00_PEROREAM_AR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
     "number": 359,
     "rarity": "AR",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_20_001980_01_KAMONEGI_AR.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17465,7 +19405,8 @@
     "name": "Buzzwole ex",
     "image": "cPK_20_007480_02_MASSIVOONex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17474,7 +19415,8 @@
     "name": "Charizard ex",
     "image": "cPK_20_000360_03_LIZARDONex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17483,7 +19425,8 @@
     "name": "Ho-Oh ex",
     "image": "cPK_20_008900_03_HOUOUex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17492,7 +19435,8 @@
     "name": "Palkia ex",
     "image": "cPK_20_003300_03_PALKIAex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17501,7 +19445,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_000960_03_PIKACHUex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17510,7 +19455,8 @@
     "name": "Mewtwo ex",
     "image": "cPK_20_001290_03_MEWTWOex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17519,7 +19465,8 @@
     "name": "Mew ex",
     "image": "cPK_20_002450_04_MEWex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17528,7 +19475,8 @@
     "name": "Lunala ex",
     "image": "cPK_20_006680_03_LUNALAex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17537,7 +19485,8 @@
     "name": "Dialga ex",
     "image": "cPK_20_004000_03_DIALGAex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17546,7 +19495,8 @@
     "name": "Solgaleo ex",
     "image": "cPK_20_007030_03_SOLGALEOex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17555,7 +19505,8 @@
     "name": "Eevee ex",
     "image": "cPK_20_008480_02_EIEVUIex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17564,7 +19515,8 @@
     "name": "Lugia ex",
     "image": "cPK_20_010050_03_LUGIAex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17573,16 +19525,18 @@
     "name": "Arceus ex",
     "image": "cPK_20_004950_03_ARCEUSex_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
     "number": 373,
     "rarity": "SR",
-    "name": "Professor\u2019s Research",
+    "name": "Professor’s Research",
     "image": "cTR_20_000040_00_HAKASENOKENKYU_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17591,7 +19545,8 @@
     "name": "Lillie",
     "image": "cTR_20_000590_02_LILIE_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17600,7 +19555,8 @@
     "name": "Lusamine",
     "image": "cTR_20_000660_01_LUSAMINE_SR.webp",
     "packs": ["Deluxe"],
-    "parallel": true
+    "parallel": true,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17609,7 +19565,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_000960_04_PIKACHUex_IM.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "A4b",
@@ -17618,7 +19575,8 @@
     "name": "Giratina ex",
     "image": "cPK_20_005520_02_GIRATINAex_SSR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4b",
@@ -17627,7 +19585,8 @@
     "name": "Darkrai ex",
     "image": "cPK_20_003910_02_DARKRAIex_SSR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "A4b",
@@ -17636,7 +19595,8 @@
     "name": "Rare Candy",
     "image": "cTR_20_000480_00_FUSHIGINAAME_UR.webp",
     "packs": ["Deluxe"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17644,7 +19604,8 @@
     "rarity": "C",
     "name": "Potion",
     "image": "cTR_90_000010_00_KIZUGUSURI_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17652,7 +19613,8 @@
     "rarity": "C",
     "name": "X Speed",
     "image": "cTR_90_000020_00_SPEEDER_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17660,23 +19622,26 @@
     "rarity": "C",
     "name": "Hand Scope",
     "image": "cTR_90_000050_00_HANDSCOPE_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
     "number": 4,
     "rarity": "C",
-    "name": "Pok\u00e9dex",
+    "name": "Pokédex",
     "image": "cTR_90_000060_00_POKEMONZUKAN_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
     "number": 5,
     "rarity": "C",
-    "name": "Pok\u00e9 Ball",
+    "name": "Poké Ball",
     "image": "cTR_90_000030_00_MONSTERBALL_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17684,23 +19649,26 @@
     "rarity": "C",
     "name": "Red Card",
     "image": "cTR_90_000070_00_REDCARD_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
     "number": 7,
     "rarity": "C",
-    "name": "Professor\u2019s Research",
+    "name": "Professor’s Research",
     "image": "cTR_90_000040_00_HAKASENOKENKYU_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
     "number": 8,
     "rarity": "C",
-    "name": "Pok\u00e9dex",
+    "name": "Pokédex",
     "image": "cTR_90_000060_01_POKEMONZUKAN_C.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17708,7 +19676,8 @@
     "rarity": "AR",
     "name": "Pikachu",
     "image": "cPK_90_000940_02_PIKACHU_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17716,7 +19685,8 @@
     "rarity": "AR",
     "name": "Mewtwo",
     "image": "cPK_90_001280_00_MEWTWO_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17724,7 +19694,8 @@
     "rarity": "R",
     "name": "Chansey",
     "image": "cPK_90_002020_00_LUCKY_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17732,7 +19703,8 @@
     "rarity": "R",
     "name": "Meowth",
     "image": "cPK_90_001960_00_NYARTH_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17741,7 +19713,8 @@
     "name": "Butterfree",
     "image": "cPK_90_000070_00_BUTTERFREE_R.webp",
     "packs": ["Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17750,7 +19723,8 @@
     "name": "Lapras ex",
     "image": "cPK_90_002760_00_LAPLACEex_RR.webp",
     "packs": ["Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17759,7 +19733,8 @@
     "name": "Pikachu",
     "image": "cPK_90_000940_01_PIKACHU_C.webp",
     "packs": ["Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17768,7 +19743,8 @@
     "name": "Clefairy",
     "image": "cPK_90_001130_00_PIPPI_C.webp",
     "packs": ["Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17777,7 +19753,8 @@
     "name": "Mankey",
     "image": "cPK_90_002770_00_MANKEY_C.webp",
     "packs": ["Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17786,7 +19763,8 @@
     "name": "Venusaur",
     "image": "cPK_90_000030_00_FUSHIGIBANA_AR.webp",
     "packs": ["Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17795,7 +19773,8 @@
     "name": "Greninja",
     "image": "cPK_90_000890_00_GEKKOUGA_R.webp",
     "packs": ["Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17804,7 +19783,8 @@
     "name": "Haunter",
     "image": "cPK_90_002780_00_GHOST_C.webp",
     "packs": ["Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17813,7 +19793,8 @@
     "name": "Onix",
     "image": "cPK_90_001500_00_IWARK_C.webp",
     "packs": ["Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17822,7 +19803,8 @@
     "name": "Jigglypuff",
     "image": "cPK_90_002790_00_PURIN_C.webp",
     "packs": ["Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17830,7 +19812,8 @@
     "rarity": "R",
     "name": "Bulbasaur",
     "image": "cPK_90_000010_00_FUSHIGIDANE_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17838,7 +19821,8 @@
     "rarity": "R",
     "name": "Magnemite",
     "image": "cPK_90_000970_00_COIL_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17846,7 +19830,8 @@
     "rarity": "RR",
     "name": "Moltres ex",
     "image": "cPK_90_000470_00_FIREex_RR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17854,7 +19839,8 @@
     "rarity": "AR",
     "name": "Pikachu",
     "image": "cPK_90_000940_00_PIKACHU_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17863,7 +19849,8 @@
     "name": "Snivy",
     "image": "cPK_90_002800_00_TSUTARJA_C.webp",
     "packs": ["Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17872,7 +19859,8 @@
     "name": "Volcarona",
     "image": "cPK_90_002280_00_ULGAMOTH_R.webp",
     "packs": ["Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17881,7 +19869,8 @@
     "name": "Blastoise",
     "image": "cPK_90_000550_00_KAMEX_AR.webp",
     "packs": ["Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17890,7 +19879,8 @@
     "name": "Eevee",
     "image": "cPK_90_002810_00_EIEVUI_C.webp",
     "packs": ["Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17899,7 +19889,8 @@
     "name": "Cinccino",
     "image": "cPK_90_002110_00_CHILLACCINO_C.webp",
     "packs": ["Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17907,7 +19898,8 @@
     "rarity": "R",
     "name": "Charmander",
     "image": "cPK_90_000330_00_HITOKAGE_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17915,7 +19907,8 @@
     "rarity": "R",
     "name": "Squirtle",
     "image": "cPK_90_000530_00_ZENIGAME_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17923,7 +19916,8 @@
     "rarity": "AR",
     "name": "Piplup",
     "image": "cPK_90_003160_00_POCHAMA_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17932,7 +19926,8 @@
     "name": "Turtwig",
     "image": "cPK_90_002910_00_NAETLE_C.webp",
     "packs": ["Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17941,7 +19936,8 @@
     "name": "Electivire",
     "image": "cPK_90_003380_00_ELEKIBLE_R.webp",
     "packs": ["Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17950,7 +19946,8 @@
     "name": "Cresselia ex",
     "image": "cPK_90_004960_00_CRESSELIAex_RR.webp",
     "packs": ["Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17959,7 +19956,8 @@
     "name": "Misdreavus",
     "image": "cPK_90_004970_00_MUMA_C.webp",
     "packs": ["Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17968,7 +19966,8 @@
     "name": "Skarmory",
     "image": "cPK_90_003920_00_AIRMD_C.webp",
     "packs": ["Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17976,7 +19975,8 @@
     "rarity": "R",
     "name": "Chimchar",
     "image": "cPK_90_003080_00_HIKOZARU_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17984,7 +19984,8 @@
     "rarity": "R",
     "name": "Togepi",
     "image": "cPK_90_003440_00_TOGEPY_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -17992,7 +19993,8 @@
     "rarity": "RR",
     "name": "Darkrai ex",
     "image": "cPK_90_003910_00_DARKRAIex_RR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18001,7 +20003,8 @@
     "name": "Cherrim",
     "image": "cPK_90_004320_00_CHERRIM_C.webp",
     "packs": ["Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18010,7 +20013,8 @@
     "name": "Raichu",
     "image": "cPK_90_004500_00_RAICHU_R.webp",
     "packs": ["Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18019,7 +20023,8 @@
     "name": "Nosepass",
     "image": "cPK_90_004980_00_NOSEPASS_C.webp",
     "packs": ["Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18028,7 +20033,8 @@
     "name": "Gible",
     "image": "cPK_90_004690_00_FUKAMARU_AR.webp",
     "packs": ["Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18037,7 +20043,8 @@
     "name": "Staraptor",
     "image": "cPK_90_004990_00_MUKUHAWK_C.webp",
     "packs": ["Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18045,7 +20052,8 @@
     "rarity": "R",
     "name": "Manaphy",
     "image": "cPK_90_003310_00_MANAPHY_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18053,7 +20061,8 @@
     "rarity": "R",
     "name": "Snorlax",
     "image": "cPK_90_004870_00_KABIGON_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18061,7 +20070,8 @@
     "rarity": "SSR",
     "name": "Mewtwo ex",
     "image": "cPK_90_001290_00_MEWTWOex_SSR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "PROMO-A",
@@ -18069,7 +20079,8 @@
     "rarity": "S",
     "name": "Cyclizar",
     "image": "cPK_90_005090_00_MOTOTOKAGE_S.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "PROMO-A",
@@ -18077,7 +20088,8 @@
     "rarity": "AR",
     "name": "Sprigatito",
     "image": "cPK_90_005080_00_NYAHOJA_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18086,7 +20098,8 @@
     "name": "Floatzel",
     "image": "cPK_90_005000_00_FLOAZEL_C.webp",
     "packs": ["Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18095,7 +20108,8 @@
     "name": "Pawmot",
     "image": "cPK_90_005010_00_PARMOT_AR.webp",
     "packs": ["Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18104,7 +20118,8 @@
     "name": "Machamp",
     "image": "cPK_90_005020_00_KAIRIKY_R.webp",
     "packs": ["Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18113,7 +20128,8 @@
     "name": "Ekans",
     "image": "cPK_90_005030_00_ARBO_C.webp",
     "packs": ["Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18122,7 +20138,8 @@
     "name": "Bidoof",
     "image": "cPK_90_005040_00_BIPPA_C.webp",
     "packs": ["Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18130,7 +20147,8 @@
     "rarity": "R",
     "name": "Pachirisu",
     "image": "cPK_90_005060_00_PACHIRISU_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18138,7 +20156,8 @@
     "rarity": "R",
     "name": "Riolu",
     "image": "cPK_90_005070_00_RIOLU_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18147,7 +20166,8 @@
     "name": "Exeggcute",
     "image": "cPK_90_002150_00_TAMATAMA_C.webp",
     "packs": ["Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18156,16 +20176,18 @@
     "name": "Froakie",
     "image": "cPK_90_000870_00_KEROMATSU_C.webp",
     "packs": ["Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
     "number": 62,
     "rarity": "C",
-    "name": "Farfetch\u2019d",
+    "name": "Farfetch’d",
     "image": "cPK_90_001980_00_KAMONEGI_C.webp",
     "packs": ["Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18174,7 +20196,8 @@
     "name": "Rayquaza",
     "image": "cPK_90_010810_00_RAYQUAZA_R.webp",
     "packs": ["Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18183,7 +20206,8 @@
     "name": "Rayquaza ex",
     "image": "cPK_90_010820_00_RAYQUAZAex_RR.webp",
     "packs": ["Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18191,7 +20215,8 @@
     "rarity": "SR",
     "name": "Rayquaza ex",
     "image": "cPK_90_010820_01_RAYQUAZAex_SR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18199,7 +20224,8 @@
     "rarity": "AR",
     "name": "Mimikyu",
     "image": "cPK_90_006640_00_MIMIKKYU_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18207,7 +20233,8 @@
     "rarity": "R",
     "name": "Cosmog",
     "image": "cPK_90_006660_00_COSMOG_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18215,7 +20242,8 @@
     "rarity": "R",
     "name": "Lycanroc",
     "image": "cPK_90_006810_00_LUGARUGAN_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18224,7 +20252,8 @@
     "name": "Alolan Exeggutor",
     "image": "cPK_90_005830_00_ALOLANASSY_R.webp",
     "packs": ["Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18233,7 +20262,8 @@
     "name": "Alolan Ninetales",
     "image": "cPK_90_006220_00_ALOLAKYUKON_AR.webp",
     "packs": ["Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18242,7 +20272,8 @@
     "name": "Crabrawler",
     "image": "cPK_90_006780_00_MAKENKANI_C.webp",
     "packs": ["Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18251,7 +20282,8 @@
     "name": "Alolan Grimer",
     "image": "cPK_90_007230_00_ALOLABETBETER_C.webp",
     "packs": ["Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18260,7 +20292,8 @@
     "name": "Toucannon",
     "image": "cPK_90_007240_00_DODEKABASHI_C.webp",
     "packs": ["Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18268,7 +20301,8 @@
     "rarity": "AR",
     "name": "Zeraora",
     "image": "cPK_90_007410_00_ZERAORA_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18277,7 +20311,8 @@
     "name": "Kartana",
     "image": "cPK_90_007250_00_KAMITURUGI_C.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18286,7 +20321,8 @@
     "name": "Blacephalon",
     "image": "cPK_90_007260_00_ZUGADOON_C.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18295,7 +20331,8 @@
     "name": "Xurkitree",
     "image": "cPK_90_007270_00_DENJYUMOKU_C.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18304,7 +20341,8 @@
     "name": "Dawn Wings Necrozma",
     "image": "cPK_90_007280_00_NECROZMAAKATSUKINOTSUBASA_R.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18313,7 +20351,8 @@
     "name": "Dusk Mane Necrozma",
     "image": "cPK_90_007290_00_NECROZMATASOGARENOTATEGAMI_R.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18322,7 +20361,8 @@
     "name": "Stakataka",
     "image": "cPK_90_007300_00_TUNDETUNDE_C.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18331,7 +20371,8 @@
     "name": "Ultra Necrozma ex",
     "image": "cPK_90_007310_00_NECROZMAULTRANECROZMAex_RR.webp",
     "packs": ["Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18339,7 +20380,8 @@
     "rarity": "R",
     "name": "Poipole",
     "image": "cPK_90_007370_00_BEVENOM_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18347,7 +20389,8 @@
     "rarity": "R",
     "name": "Stufful",
     "image": "cPK_90_007380_00_NUIKOGUMA_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18355,7 +20398,8 @@
     "rarity": "RR",
     "name": "Tapu Koko ex",
     "image": "cPK_90_007420_00_KAPU-KOKEKOex_RR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18364,7 +20408,8 @@
     "name": "Vanillite",
     "image": "cPK_90_007320_00_VANIPETI_C.webp",
     "packs": ["Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18373,7 +20418,8 @@
     "name": "Jolteon",
     "image": "cPK_90_007330_00_THUNDERS_R.webp",
     "packs": ["Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18382,7 +20428,8 @@
     "name": "Alcremie",
     "image": "cPK_90_007340_00_MAWHIP_AR.webp",
     "packs": ["Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18391,7 +20438,8 @@
     "name": "Dragonair",
     "image": "cPK_90_007350_00_HAKURYU_C.webp",
     "packs": ["Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18400,7 +20448,8 @@
     "name": "Audino",
     "image": "cPK_90_007360_00_TABUNNE_C.webp",
     "packs": ["Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18408,7 +20457,8 @@
     "rarity": "R",
     "name": "Togedemaru",
     "image": "cPK_90_007390_00_TOGEDEMARU_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18416,7 +20466,8 @@
     "rarity": "R",
     "name": "Greedent",
     "image": "cPK_90_007400_00_YOKUBARISU_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18424,7 +20475,8 @@
     "rarity": "R",
     "name": "Eevee",
     "image": "cPK_90_002060_00_EIEVUI_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18432,7 +20484,8 @@
     "rarity": "AR",
     "name": "Cleffa",
     "image": "cPK_90_009330_00_PY_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18441,7 +20494,8 @@
     "name": "Horsea",
     "image": "cPK_90_010070_00_TATTU_C.webp",
     "packs": ["Vol. 11"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18450,7 +20504,8 @@
     "name": "Chinchou",
     "image": "cPK_90_010080_00_CHONCHIE_C.webp",
     "packs": ["Vol. 11"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18459,7 +20514,8 @@
     "name": "Houndoom",
     "image": "cPK_90_009740_00_HELLGAR_C.webp",
     "packs": ["Vol. 11"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18468,7 +20524,8 @@
     "name": "Kangaskhan",
     "image": "cPK_90_009890_00_GARURA_R.webp",
     "packs": ["Vol. 11"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18477,7 +20534,8 @@
     "name": "Blissey ex",
     "image": "cPK_90_010090_00_HAPPINASex_RR.webp",
     "packs": ["Vol. 11"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18485,7 +20543,8 @@
     "rarity": "R",
     "name": "Marill",
     "image": "cPK_90_009050_00_MARIL_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18493,7 +20552,8 @@
     "rarity": "R",
     "name": "Weavile",
     "image": "cPK_90_009720_00_MANYULA_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18501,7 +20561,8 @@
     "rarity": "AR",
     "name": "Latias",
     "image": "cPK_90_010200_00_LATIAS_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18510,7 +20571,8 @@
     "name": "Tropius",
     "image": "cPK_90_010100_00_TROPIUS_C.webp",
     "packs": ["Vol. 12"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18519,7 +20581,8 @@
     "name": "Poliwag",
     "image": "cPK_90_010110_00_NYOROMO_C.webp",
     "packs": ["Vol. 12"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18528,7 +20591,8 @@
     "name": "Milotic",
     "image": "cPK_90_010120_00_MILOKAROSS_R.webp",
     "packs": ["Vol. 12"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18537,7 +20601,8 @@
     "name": "Zorua",
     "image": "cPK_90_010130_00_ZORUA_C.webp",
     "packs": ["Vol. 12"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18546,7 +20611,8 @@
     "name": "Zoroark",
     "image": "cPK_90_010140_00_ZOROARK_AR.webp",
     "packs": ["Vol. 12"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18554,7 +20620,8 @@
     "rarity": "R",
     "name": "Miltank",
     "image": "cPK_90_010180_00_MILTANK_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18562,7 +20629,8 @@
     "rarity": "R",
     "name": "Phanpy",
     "image": "cPK_90_010190_00_GOMAZOU_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18570,7 +20638,8 @@
     "rarity": "SAR",
     "name": "Eevee ex",
     "image": "cPK_90_008480_00_EIEVUIex_SAR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18578,7 +20647,8 @@
     "rarity": "RR",
     "name": "Entei ex",
     "image": "cPK_90_010210_00_ENTEIex_RR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18587,7 +20657,8 @@
     "name": "Pikachu",
     "image": "cPK_90_010150_00_PIKACHU_C.webp",
     "packs": ["Vol. 13"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18596,7 +20667,8 @@
     "name": "Raichu ex",
     "image": "cPK_90_010160_00_RAICHUex_RR.webp",
     "packs": ["Vol. 13"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18605,7 +20677,8 @@
     "name": "Mimikyu",
     "image": "cPK_90_008290_00_MIMIKKYU_C.webp",
     "packs": ["Vol. 13"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18614,7 +20687,8 @@
     "name": "Machamp",
     "image": "cPK_90_010170_00_KAIRIKY_C.webp",
     "packs": ["Vol. 13"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18623,7 +20697,8 @@
     "name": "Regigigas",
     "image": "cPK_90_004240_00_REGIGIGAS_R.webp",
     "packs": ["Vol. 13"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18631,7 +20706,8 @@
     "rarity": "R",
     "name": "Shaymin",
     "image": "cPK_90_003030_00_SHAYMIN_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-A",
@@ -18639,7 +20715,8 @@
     "rarity": "R",
     "name": "Absol",
     "image": "cPK_90_009760_00_ABSOL_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18648,7 +20725,8 @@
     "name": "Pinsir",
     "image": "cPK_10_010830_00_KAILIOS_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18657,7 +20735,8 @@
     "name": "Mega Pinsir ex",
     "image": "cPK_10_010840_00_MEGAKAILIOSex_RR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18666,7 +20745,8 @@
     "name": "Wurmple",
     "image": "cPK_10_010850_00_KEMUSSO_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18675,7 +20755,8 @@
     "name": "Silcoon",
     "image": "cPK_10_010860_00_KARASALIS_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18684,7 +20765,8 @@
     "name": "Beautifly",
     "image": "cPK_10_010870_00_AGEHUNT_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18693,7 +20775,8 @@
     "name": "Cascoon",
     "image": "cPK_10_010880_00_MAYULD_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18702,7 +20785,8 @@
     "name": "Dustox",
     "image": "cPK_10_010890_00_DOKUCALE_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18711,7 +20795,8 @@
     "name": "Seedot",
     "image": "cPK_10_010900_00_TANEBOH_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18720,7 +20805,8 @@
     "name": "Nuzleaf",
     "image": "cPK_10_010910_00_KONOHANA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18729,7 +20815,8 @@
     "name": "Shiftry",
     "image": "cPK_10_010920_00_DIRTENG_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18738,7 +20825,8 @@
     "name": "Shroomish",
     "image": "cPK_10_010930_00_KINOCOCO_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18747,7 +20835,8 @@
     "name": "Breloom",
     "image": "cPK_10_010940_00_KINOGASSA_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18756,7 +20845,8 @@
     "name": "Pansage",
     "image": "cPK_10_010950_00_YANAPPU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18765,7 +20855,8 @@
     "name": "Simisage",
     "image": "cPK_10_010960_00_YANAKKIE_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18774,7 +20865,8 @@
     "name": "Cottonee",
     "image": "cPK_10_010970_00_MONMEN_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18783,7 +20875,8 @@
     "name": "Whimsicott ex",
     "image": "cPK_10_010980_00_ELFUUNex_RR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18792,7 +20885,8 @@
     "name": "Petilil",
     "image": "cPK_10_010990_00_CHURINE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18801,7 +20895,8 @@
     "name": "Lilligant",
     "image": "cPK_10_011000_00_DREDEAR_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18810,7 +20905,8 @@
     "name": "Maractus",
     "image": "cPK_10_011010_00_MARACACCHI_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18819,7 +20915,8 @@
     "name": "Virizion",
     "image": "cPK_10_011020_00_VIRIZION_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18828,7 +20925,8 @@
     "name": "Skiddo",
     "image": "cPK_10_011030_00_MEECLE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18837,7 +20935,8 @@
     "name": "Gogoat",
     "image": "cPK_10_011040_00_GOGOAT_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18846,7 +20945,8 @@
     "name": "Phantump",
     "image": "cPK_10_011050_00_BOKUREI_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18855,7 +20955,8 @@
     "name": "Trevenant",
     "image": "cPK_10_011060_00_OHROT_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18864,7 +20965,8 @@
     "name": "Grookey",
     "image": "cPK_10_011070_00_SARUNORI_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18873,7 +20975,8 @@
     "name": "Thwackey",
     "image": "cPK_10_011080_00_BACHINKEY_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18882,7 +20985,8 @@
     "name": "Rillaboom",
     "image": "cPK_10_011090_00_GORIRANDER_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18891,7 +20995,8 @@
     "name": "Growlithe",
     "image": "cPK_10_011100_00_GARDIE_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18900,7 +21005,8 @@
     "name": "Arcanine",
     "image": "cPK_10_011110_00_WINDIE_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18909,7 +21015,8 @@
     "name": "Ponyta",
     "image": "cPK_10_011120_00_PONYTA_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18918,7 +21025,8 @@
     "name": "Rapidash ex",
     "image": "cPK_10_011130_00_GALLOPex_RR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18927,7 +21035,8 @@
     "name": "Ho-Oh",
     "image": "cPK_10_011140_00_HOUOU_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18936,7 +21045,8 @@
     "name": "Torchic",
     "image": "cPK_10_011150_00_ACHAMO_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18945,7 +21055,8 @@
     "name": "Combusken",
     "image": "cPK_10_011160_00_WAKASYAMO_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18954,7 +21065,8 @@
     "name": "Blaziken",
     "image": "cPK_10_011170_00_BURSYAMO_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18963,7 +21075,8 @@
     "name": "Mega Blaziken ex",
     "image": "cPK_10_011180_00_MEGABURSYAMOex_RR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18972,7 +21085,8 @@
     "name": "Pansear",
     "image": "cPK_10_011190_00_BAOPPU_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18981,7 +21095,8 @@
     "name": "Simisear",
     "image": "cPK_10_011200_00_BAOKKIE_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18990,7 +21105,8 @@
     "name": "Darumaka",
     "image": "cPK_10_011210_00_DARUMAKKA_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -18999,7 +21115,8 @@
     "name": "Darmanitan",
     "image": "cPK_10_011220_00_HIHIDARUMA_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19008,7 +21125,8 @@
     "name": "Litwick",
     "image": "cPK_10_011230_00_HITOMOSHI_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19017,7 +21135,8 @@
     "name": "Lampent",
     "image": "cPK_10_011240_00_LAMPLER_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19026,7 +21145,8 @@
     "name": "Chandelure",
     "image": "cPK_10_011250_00_CHANDELA_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19035,7 +21155,8 @@
     "name": "Heatmor",
     "image": "cPK_10_011260_00_KUITARAN_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19044,7 +21165,8 @@
     "name": "Litleo",
     "image": "cPK_10_011270_00_SHISHIKO_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19053,7 +21175,8 @@
     "name": "Pyroar",
     "image": "cPK_10_011280_00_KAENJISHI_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19062,7 +21185,8 @@
     "name": "Turtonator",
     "image": "cPK_10_011290_00_BAKUGAMES_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19071,7 +21195,8 @@
     "name": "Psyduck",
     "image": "cPK_10_011300_00_KODUCK_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19080,7 +21205,8 @@
     "name": "Golduck",
     "image": "cPK_10_011310_00_GOLDUCK_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19089,7 +21215,8 @@
     "name": "Magikarp",
     "image": "cPK_10_011320_00_KOIKING_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19098,7 +21225,8 @@
     "name": "Gyarados",
     "image": "cPK_10_011330_00_GYARADOS_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19107,7 +21235,8 @@
     "name": "Mega Gyarados ex",
     "image": "cPK_10_011340_00_MEGAGYARADOSex_RR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19116,7 +21245,8 @@
     "name": "Lotad",
     "image": "cPK_10_011350_00_HASSBOH_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19125,7 +21255,8 @@
     "name": "Lombre",
     "image": "cPK_10_011360_00_HASUBRERO_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19134,7 +21265,8 @@
     "name": "Ludicolo",
     "image": "cPK_10_011370_00_RUNPAPPA_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19143,7 +21275,8 @@
     "name": "Wailmer",
     "image": "cPK_10_011380_00_HOERUKO_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19152,7 +21285,8 @@
     "name": "Wailord",
     "image": "cPK_10_011390_00_WHALOH_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19161,7 +21295,8 @@
     "name": "Corphish",
     "image": "cPK_10_011400_00_HEIGANI_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19170,7 +21305,8 @@
     "name": "Crawdaunt",
     "image": "cPK_10_011410_00_SHIZARIGER_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19179,7 +21315,8 @@
     "name": "Luvdisc",
     "image": "cPK_10_011420_00_LOVECUS_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19188,7 +21325,8 @@
     "name": "Panpour",
     "image": "cPK_10_011430_00_HIYAPPU_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19197,7 +21335,8 @@
     "name": "Simipour",
     "image": "cPK_10_011440_00_HIYAKKIE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19206,7 +21345,8 @@
     "name": "Tympole",
     "image": "cPK_10_011450_00_OTAMARO_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19215,7 +21355,8 @@
     "name": "Palpitoad",
     "image": "cPK_10_011460_00_GAMAGARU_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19224,7 +21365,8 @@
     "name": "Seismitoad",
     "image": "cPK_10_011470_00_GAMAGEROGE_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19233,7 +21375,8 @@
     "name": "Tirtouga",
     "image": "cPK_10_011480_00_PROTOGA_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19242,7 +21385,8 @@
     "name": "Carracosta",
     "image": "cPK_10_011490_00_ABAGOURA_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19251,7 +21395,8 @@
     "name": "Frillish",
     "image": "cPK_10_011500_00_PURURILL_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19260,7 +21405,8 @@
     "name": "Jellicent",
     "image": "cPK_10_011510_00_BURUNGEL_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19269,7 +21415,8 @@
     "name": "Keldeo",
     "image": "cPK_10_011520_00_KELDEOITSUMONOSUGATA_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19278,7 +21425,8 @@
     "name": "Froakie",
     "image": "cPK_10_011530_00_KEROMATSU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19287,7 +21435,8 @@
     "name": "Frogadier",
     "image": "cPK_10_011540_00_GEKOGASHIRA_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19296,7 +21445,8 @@
     "name": "Greninja ex",
     "image": "cPK_10_011550_00_GEKKOUGAex_RR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19305,7 +21455,8 @@
     "name": "Bergmite",
     "image": "cPK_10_011560_00_KACHIKOHRU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19314,7 +21465,8 @@
     "name": "Avalugg",
     "image": "cPK_10_011570_00_CREBASE_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19323,7 +21475,8 @@
     "name": "Chewtle",
     "image": "cPK_10_011580_00_KAMUKAME_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19332,7 +21485,8 @@
     "name": "Drednaw",
     "image": "cPK_10_011590_00_KAJIRIGAME_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19341,7 +21495,8 @@
     "name": "Arrokuda",
     "image": "cPK_10_011600_00_SASIKAMASU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19350,7 +21505,8 @@
     "name": "Barraskewda",
     "image": "cPK_10_011610_00_KAMASUJAW_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19359,7 +21515,8 @@
     "name": "Eiscue",
     "image": "cPK_10_011620_00_KORIPPO_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19368,7 +21525,8 @@
     "name": "Jolteon ex",
     "image": "cPK_10_011630_00_THUNDERSex_RR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19377,7 +21535,8 @@
     "name": "Mareep",
     "image": "cPK_10_011640_00_MERRIEP_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19386,7 +21545,8 @@
     "name": "Flaaffy",
     "image": "cPK_10_011650_00_MOKOKO_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19395,7 +21555,8 @@
     "name": "Ampharos",
     "image": "cPK_10_011660_00_DENRYU_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19404,7 +21565,8 @@
     "name": "Mega Ampharos ex",
     "image": "cPK_10_011670_00_MEGADENRYUex_RR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19413,7 +21575,8 @@
     "name": "Shinx",
     "image": "cPK_10_011680_00_KOLINK_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19422,7 +21585,8 @@
     "name": "Luxio",
     "image": "cPK_10_011690_00_LUXIO_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19431,7 +21595,8 @@
     "name": "Luxray",
     "image": "cPK_10_011700_00_RENTORAR_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19440,7 +21605,8 @@
     "name": "Pachirisu",
     "image": "cPK_10_011710_00_PACHIRISU_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19449,7 +21615,8 @@
     "name": "Blitzle",
     "image": "cPK_10_011720_00_SHIMAMA_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19458,7 +21625,8 @@
     "name": "Zebstrika",
     "image": "cPK_10_011730_00_ZEBRAIKA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19467,7 +21635,8 @@
     "name": "Joltik",
     "image": "cPK_10_011740_00_BACHURU_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19476,7 +21645,8 @@
     "name": "Galvantula",
     "image": "cPK_10_011750_00_DENTULA_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19485,7 +21655,8 @@
     "name": "Dedenne",
     "image": "cPK_10_011760_00_DEDENNE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19494,7 +21665,8 @@
     "name": "Yamper",
     "image": "cPK_10_011770_00_WANPACHI_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19503,7 +21675,8 @@
     "name": "Boltund",
     "image": "cPK_10_011780_00_PULSEWAN_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19512,7 +21685,8 @@
     "name": "Natu",
     "image": "cPK_10_011790_00_NATY_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19521,7 +21695,8 @@
     "name": "Xatu",
     "image": "cPK_10_011800_00_NATIO_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19530,7 +21705,8 @@
     "name": "Misdreavus",
     "image": "cPK_10_011810_00_MUMA_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19539,7 +21715,8 @@
     "name": "Mismagius",
     "image": "cPK_10_011820_00_MUMARGI_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19548,7 +21725,8 @@
     "name": "Sableye",
     "image": "cPK_10_011830_00_YAMIRAMI_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19557,7 +21735,8 @@
     "name": "Mega Altaria ex",
     "image": "cPK_10_011840_00_MEGATYLTALISex_RR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19566,7 +21745,8 @@
     "name": "Duskull",
     "image": "cPK_10_011850_00_YOMAWARU_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19575,7 +21755,8 @@
     "name": "Dusclops",
     "image": "cPK_10_011860_00_SAMAYOURU_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19584,7 +21765,8 @@
     "name": "Dusknoir",
     "image": "cPK_10_011870_00_YONOIR_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19593,7 +21775,8 @@
     "name": "Jirachi",
     "image": "cPK_10_011880_00_JIRACHI_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19602,7 +21785,8 @@
     "name": "Drifloon",
     "image": "cPK_10_011890_00_FUWANTE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19611,7 +21795,8 @@
     "name": "Drifblim",
     "image": "cPK_10_011900_00_FUWARIDE_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19620,7 +21805,8 @@
     "name": "Chingling",
     "image": "cPK_10_011910_00_LISYAN_R.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19629,7 +21815,8 @@
     "name": "Yamask",
     "image": "cPK_10_011920_00_DESUMASU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19638,7 +21825,8 @@
     "name": "Cofagrigus",
     "image": "cPK_10_011930_00_DESUKARN_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19647,7 +21835,8 @@
     "name": "Gothita",
     "image": "cPK_10_011940_00_GOTHIMU_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19656,7 +21845,8 @@
     "name": "Gothorita",
     "image": "cPK_10_011950_00_GOTHIMIRU_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19665,7 +21855,8 @@
     "name": "Gothitelle",
     "image": "cPK_10_011960_00_GOTHIRUSELLE_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19674,7 +21865,8 @@
     "name": "Spritzee",
     "image": "cPK_10_011970_00_SHUSHUPU_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19683,7 +21875,8 @@
     "name": "Aromatisse",
     "image": "cPK_10_011980_00_FREFUWAN_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19692,7 +21885,8 @@
     "name": "Swirlix",
     "image": "cPK_10_011990_00_PEROPPAFU_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19701,7 +21895,8 @@
     "name": "Slurpuff",
     "image": "cPK_10_012000_00_PEROREAM_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19710,7 +21905,8 @@
     "name": "Carbink",
     "image": "cPK_10_012010_00_MELECIE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19719,7 +21915,8 @@
     "name": "Klefki",
     "image": "cPK_10_012020_00_CLEFFY_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19728,7 +21925,8 @@
     "name": "Indeedee ex",
     "image": "cPK_10_012030_00_YESSANMESUNOSUGATA_RR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19737,7 +21935,8 @@
     "name": "Sandshrew",
     "image": "cPK_10_012040_00_SAND_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19746,7 +21945,8 @@
     "name": "Sandslash",
     "image": "cPK_10_012050_00_SANDPAN_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19755,7 +21955,8 @@
     "name": "Hitmonchan ex",
     "image": "cPK_10_012060_00_EBIWALARex_RR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19764,7 +21965,8 @@
     "name": "Sudowoodo",
     "image": "cPK_10_012070_00_USOKKIE_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19773,7 +21975,8 @@
     "name": "Makuhita",
     "image": "cPK_10_012080_00_MAKUNOSHITA_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19782,7 +21985,8 @@
     "name": "Hariyama",
     "image": "cPK_10_012090_00_HARITEYAMA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19791,7 +21995,8 @@
     "name": "Hippopotas",
     "image": "cPK_10_012100_00_HIPPOPOTAS_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19800,7 +22005,8 @@
     "name": "Hippowdon",
     "image": "cPK_10_012110_00_KABALDON_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19809,7 +22015,8 @@
     "name": "Sandile",
     "image": "cPK_10_012120_00_MEGUROCO_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19818,7 +22025,8 @@
     "name": "Krokorok",
     "image": "cPK_10_012130_00_WARUVILE_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19827,7 +22035,8 @@
     "name": "Krookodile",
     "image": "cPK_10_012140_00_WARUVIAL_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19836,7 +22045,8 @@
     "name": "Archen",
     "image": "cPK_10_012150_00_ARCHEN_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19845,7 +22055,8 @@
     "name": "Archeops",
     "image": "cPK_10_012160_00_ARCHEOS_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19854,7 +22065,8 @@
     "name": "Golett",
     "image": "cPK_10_012170_00_GOBIT_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19863,7 +22075,8 @@
     "name": "Golurk",
     "image": "cPK_10_012180_00_GOLOOG_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19872,7 +22085,8 @@
     "name": "Terrakion",
     "image": "cPK_10_012190_00_TERRAKION_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19881,7 +22095,8 @@
     "name": "Pancham",
     "image": "cPK_10_012200_00_YANCHAM_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19890,7 +22105,8 @@
     "name": "Crabrawler",
     "image": "cPK_10_012210_00_MAKENKANI_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19899,7 +22115,8 @@
     "name": "Crabominable",
     "image": "cPK_10_012220_00_KEKENKANI_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19908,7 +22125,8 @@
     "name": "Stufful",
     "image": "cPK_10_012230_00_NUIKOGUMA_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19917,7 +22135,8 @@
     "name": "Bewear",
     "image": "cPK_10_012240_00_KITERUGUMA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19926,7 +22145,8 @@
     "name": "Sandygast",
     "image": "cPK_10_012250_00_SUNABA_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19935,7 +22155,8 @@
     "name": "Palossand",
     "image": "cPK_10_012260_00_SIRODETHNA_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19944,7 +22165,8 @@
     "name": "Rolycoly",
     "image": "cPK_10_012270_00_TANDON_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19953,7 +22175,8 @@
     "name": "Carkol",
     "image": "cPK_10_012280_00_TOROGGON_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19962,7 +22185,8 @@
     "name": "Coalossal",
     "image": "cPK_10_012290_00_SEKITANZAN_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19971,7 +22195,8 @@
     "name": "Murkrow",
     "image": "cPK_10_012300_00_YAMIKARASU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19980,7 +22205,8 @@
     "name": "Honchkrow",
     "image": "cPK_10_012310_00_DONGKARASU_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19989,7 +22215,8 @@
     "name": "Absol",
     "image": "cPK_10_012320_00_ABSOL_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -19998,7 +22225,8 @@
     "name": "Mega Absol ex",
     "image": "cPK_10_012330_00_MEGAABSOLex_RR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20007,7 +22235,8 @@
     "name": "Skorupi",
     "image": "cPK_10_012340_00_SCORUPI_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20016,7 +22245,8 @@
     "name": "Drapion",
     "image": "cPK_10_012350_00_DORAPION_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20025,7 +22255,8 @@
     "name": "Darkrai",
     "image": "cPK_10_012360_00_DARKRAI_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20034,7 +22265,8 @@
     "name": "Deino",
     "image": "cPK_10_012370_00_MONOZU_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20043,7 +22275,8 @@
     "name": "Zweilous",
     "image": "cPK_10_012380_00_DIHEAD_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20052,7 +22285,8 @@
     "name": "Hydreigon",
     "image": "cPK_10_012390_00_SAZANDORA_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20061,7 +22295,8 @@
     "name": "Pangoro",
     "image": "cPK_10_012400_00_GORONDA_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20070,7 +22305,8 @@
     "name": "Skrelp",
     "image": "cPK_10_012410_00_KUZUMO_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20079,7 +22315,8 @@
     "name": "Dragalge ex",
     "image": "cPK_10_012420_00_DRAMIDOROex_RR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20088,7 +22325,8 @@
     "name": "Mareanie",
     "image": "cPK_10_012430_00_HIDOIDE_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20097,7 +22335,8 @@
     "name": "Toxapex",
     "image": "cPK_10_012440_00_DOHIDOIDE_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20106,7 +22345,8 @@
     "name": "Impidimp",
     "image": "cPK_10_012450_00_BEROBA_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20115,7 +22355,8 @@
     "name": "Morgrem",
     "image": "cPK_10_012460_00_GIMOH_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20124,7 +22365,8 @@
     "name": "Grimmsnarl",
     "image": "cPK_10_012470_00_OHLONGE_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20133,7 +22375,8 @@
     "name": "Ferroseed",
     "image": "cPK_10_012480_00_TESSEED_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20142,7 +22385,8 @@
     "name": "Ferrothorn",
     "image": "cPK_10_012490_00_NUTREY_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20151,7 +22395,8 @@
     "name": "Durant",
     "image": "cPK_10_012500_00_AIANT_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20160,7 +22405,8 @@
     "name": "Cobalion",
     "image": "cPK_10_012510_00_COBALON_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20169,7 +22415,8 @@
     "name": "Honedge",
     "image": "cPK_10_012520_00_HITOTSUKI_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20178,7 +22425,8 @@
     "name": "Doublade",
     "image": "cPK_10_012530_00_NIDANGILL_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20187,7 +22435,8 @@
     "name": "Aegislash",
     "image": "cPK_10_012540_00_GILLGARDBLADEFORME_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20196,7 +22445,8 @@
     "name": "Meltan",
     "image": "cPK_10_012550_00_MELTAN_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20205,7 +22455,8 @@
     "name": "Melmetal ex",
     "image": "cPK_10_012560_00_MELMETALex_RR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20214,7 +22465,8 @@
     "name": "Corviknight",
     "image": "cPK_10_012570_00_ARMORGA_R.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20223,7 +22475,8 @@
     "name": "Druddigon",
     "image": "cPK_10_012580_00_CRIMGAN_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20232,7 +22485,8 @@
     "name": "Goomy",
     "image": "cPK_10_012590_00_NUMERA_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20241,7 +22495,8 @@
     "name": "Sliggoo",
     "image": "cPK_10_012600_00_NUMEIL_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20250,7 +22505,8 @@
     "name": "Goodra",
     "image": "cPK_10_012610_00_NUMELGON_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20259,7 +22515,8 @@
     "name": "Pidgey",
     "image": "cPK_10_012620_00_POPPO_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20268,7 +22525,8 @@
     "name": "Pidgeotto",
     "image": "cPK_10_012630_00_PIGEON_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20277,7 +22535,8 @@
     "name": "Pidgeot",
     "image": "cPK_10_012640_00_PIGEOT_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20286,7 +22545,8 @@
     "name": "Tauros ex",
     "image": "cPK_10_012650_00_KENTAUROSex_RR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20295,7 +22555,8 @@
     "name": "Eevee",
     "image": "cPK_10_012660_00_EIEVUI_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20304,7 +22565,8 @@
     "name": "Aipom",
     "image": "cPK_10_012670_00_EIPAM_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20313,7 +22575,8 @@
     "name": "Ambipom",
     "image": "cPK_10_012680_00_ETEBOTH_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20322,7 +22585,8 @@
     "name": "Miltank",
     "image": "cPK_10_012690_00_MILTANK_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20331,7 +22595,8 @@
     "name": "Zigzagoon",
     "image": "cPK_10_012700_00_JIGUZAGUMA_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20340,7 +22605,8 @@
     "name": "Linoone",
     "image": "cPK_10_012710_00_MASSUGUMA_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20349,7 +22615,8 @@
     "name": "Whismur",
     "image": "cPK_10_012720_00_GONYONYO_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20358,7 +22625,8 @@
     "name": "Loudred",
     "image": "cPK_10_012730_00_DOGOHMB_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20367,7 +22635,8 @@
     "name": "Exploud",
     "image": "cPK_10_012740_00_BAKUONG_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20376,7 +22645,8 @@
     "name": "Skitty",
     "image": "cPK_10_012750_00_ENECO_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20385,7 +22655,8 @@
     "name": "Delcatty",
     "image": "cPK_10_012760_00_ENEKORORO_R.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20394,7 +22665,8 @@
     "name": "Spinda",
     "image": "cPK_10_012770_00_PATCHEEL_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20403,7 +22675,8 @@
     "name": "Swablu",
     "image": "cPK_10_012780_00_TYLTTO_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20412,7 +22685,8 @@
     "name": "Altaria",
     "image": "cPK_10_012790_00_TYLTALIS_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20421,7 +22695,8 @@
     "name": "Chatot",
     "image": "cPK_10_012800_00_PERAP_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20430,7 +22705,8 @@
     "name": "Patrat",
     "image": "cPK_10_012810_00_MINEZUMI_C.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20439,7 +22715,8 @@
     "name": "Watchog",
     "image": "cPK_10_012820_00_MIRUHOG_U.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20448,7 +22725,8 @@
     "name": "Lillipup",
     "image": "cPK_10_012830_00_YORTERRIE_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20457,7 +22735,8 @@
     "name": "Herdier",
     "image": "cPK_10_012840_00_HERDERRIE_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20466,7 +22745,8 @@
     "name": "Stoutland",
     "image": "cPK_10_012850_00_MOOLAND_R.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20475,7 +22755,8 @@
     "name": "Rufflet",
     "image": "cPK_10_012860_00_WASHIBON_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20484,7 +22765,8 @@
     "name": "Braviary",
     "image": "cPK_10_012870_00_WARRGLE_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20493,7 +22775,8 @@
     "name": "Furfrou",
     "image": "cPK_10_012880_00_TRIMMIENYASEINOSUGATA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20502,7 +22785,8 @@
     "name": "Furfrou",
     "image": "cPK_10_012880_01_TRIMMIENHEARTCUT_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20511,7 +22795,8 @@
     "name": "Furfrou",
     "image": "cPK_10_012880_02_TRIMMIENKINGDOMCUT_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20520,7 +22805,8 @@
     "name": "Rookidee",
     "image": "cPK_10_012890_00_KOKOGARA_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20529,7 +22815,8 @@
     "name": "Corvisquire",
     "image": "cPK_10_012900_00_AOGARASU_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20538,7 +22825,8 @@
     "name": "Wooloo",
     "image": "cPK_10_012910_00_WOOLUU_C.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20547,7 +22835,8 @@
     "name": "Dubwool",
     "image": "cPK_10_012920_00_BAIWOOLUU_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20556,7 +22845,8 @@
     "name": "Prank Spinner",
     "image": "cTR_10_000870_00_ITAZURAROULETTE_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20565,7 +22855,8 @@
     "name": "Plume Fossil",
     "image": "cTR_10_000880_00_HANENOKASEKI_C.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20574,7 +22865,8 @@
     "name": "Hitting Hammer",
     "image": "cTR_10_000890_00_HITHAMMER_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20583,7 +22875,8 @@
     "name": "Cover Fossil",
     "image": "cTR_10_000900_00_FUTANOKASEKI_C.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20592,7 +22885,8 @@
     "name": "Flame Patch",
     "image": "cTR_10_000910_00_FUREIMUPACCHI_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20601,7 +22895,8 @@
     "name": "Sitrus Berry",
     "image": "cTR_10_000920_00_OBONNOMI_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20610,7 +22905,8 @@
     "name": "Heavy Helmet",
     "image": "cTR_10_000930_00_BABYMET_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20619,7 +22915,8 @@
     "name": "Lucky Mittens",
     "image": "cTR_10_000940_00_LUCKYMITTENS_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20628,7 +22925,8 @@
     "name": "Marlon",
     "image": "cTR_10_000950_00_SHIZUI_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20637,7 +22935,8 @@
     "name": "Hala",
     "image": "cTR_10_000960_00_HALA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20646,7 +22945,8 @@
     "name": "May",
     "image": "cTR_10_000970_00_HARUKA_U.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20655,7 +22955,8 @@
     "name": "Fantina",
     "image": "cTR_10_000980_00_MELISSA_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20664,7 +22965,8 @@
     "name": "Copycat",
     "image": "cTR_10_000990_00_MONOMANEMUSUME_U.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20673,7 +22975,8 @@
     "name": "Lisia",
     "image": "cTR_10_001000_00_RUCHIA_U.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20682,7 +22985,8 @@
     "name": "Beautifly",
     "image": "cPK_20_010870_00_AGEHUNT_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20691,7 +22995,8 @@
     "name": "Skiddo",
     "image": "cPK_20_011030_00_MEECLE_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20700,7 +23005,8 @@
     "name": "Rillaboom",
     "image": "cPK_20_011090_00_GORIRANDER_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20709,7 +23015,8 @@
     "name": "Growlithe",
     "image": "cPK_20_011100_00_GARDIE_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20718,7 +23025,8 @@
     "name": "Chandelure",
     "image": "cPK_20_011250_00_CHANDELA_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20727,7 +23035,8 @@
     "name": "Magikarp",
     "image": "cPK_20_011320_00_KOIKING_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20736,7 +23045,8 @@
     "name": "Ludicolo",
     "image": "cPK_20_011370_00_RUNPAPPA_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20745,7 +23055,8 @@
     "name": "Jellicent",
     "image": "cPK_20_011510_00_BURUNGEL_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20754,7 +23065,8 @@
     "name": "Keldeo",
     "image": "cPK_20_011520_00_KELDEOITSUMONOSUGATA_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20763,7 +23075,8 @@
     "name": "Eiscue",
     "image": "cPK_20_011620_00_KORIPPO_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20772,7 +23085,8 @@
     "name": "Luxray",
     "image": "cPK_20_011700_00_RENTORAR_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20781,7 +23095,8 @@
     "name": "Cofagrigus",
     "image": "cPK_20_011930_00_DESUKARN_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20790,7 +23105,8 @@
     "name": "Gothita",
     "image": "cPK_20_011940_00_GOTHIMU_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20799,7 +23115,8 @@
     "name": "Makuhita",
     "image": "cPK_20_012080_00_MAKUNOSHITA_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20808,7 +23125,8 @@
     "name": "Hippowdon",
     "image": "cPK_20_012110_00_KABALDON_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20817,7 +23135,8 @@
     "name": "Archeops",
     "image": "cPK_20_012160_00_ARCHEOS_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20826,7 +23145,8 @@
     "name": "Pancham",
     "image": "cPK_20_012200_00_YANCHAM_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20835,7 +23155,8 @@
     "name": "Honchkrow",
     "image": "cPK_20_012310_00_DONGKARASU_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20844,7 +23165,8 @@
     "name": "Hydreigon",
     "image": "cPK_20_012390_00_SAZANDORA_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20853,7 +23175,8 @@
     "name": "Corviknight",
     "image": "cPK_20_012570_00_ARMORGA_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20862,7 +23185,8 @@
     "name": "Goomy",
     "image": "cPK_20_012590_00_NUMERA_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20871,7 +23195,8 @@
     "name": "Delcatty",
     "image": "cPK_20_012760_00_ENEKORORO_AR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20880,7 +23205,8 @@
     "name": "Stoutland",
     "image": "cPK_20_012850_00_MOOLAND_AR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20889,7 +23215,8 @@
     "name": "Rufflet",
     "image": "cPK_20_012860_00_WASHIBON_AR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20898,7 +23225,8 @@
     "name": "Mega Pinsir ex",
     "image": "cPK_20_010840_00_MEGAKAILIOSex_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20907,7 +23235,8 @@
     "name": "Whimsicott ex",
     "image": "cPK_20_010980_00_ELFUUNex_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20916,7 +23245,8 @@
     "name": "Rapidash ex",
     "image": "cPK_20_011130_00_GALLOPex_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20925,7 +23255,8 @@
     "name": "Mega Blaziken ex",
     "image": "cPK_20_011180_00_MEGABURSYAMOex_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20934,7 +23265,8 @@
     "name": "Mega Gyarados ex",
     "image": "cPK_20_011340_00_MEGAGYARADOSex_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20943,7 +23275,8 @@
     "name": "Greninja ex",
     "image": "cPK_20_011550_00_GEKKOUGAex_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20952,7 +23285,8 @@
     "name": "Jolteon ex",
     "image": "cPK_20_011630_00_THUNDERSex_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20961,7 +23295,8 @@
     "name": "Mega Ampharos ex",
     "image": "cPK_20_011670_00_MEGADENRYUex_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20970,7 +23305,8 @@
     "name": "Mega Altaria ex",
     "image": "cPK_20_011840_00_MEGATYLTALISex_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20979,7 +23315,8 @@
     "name": "Indeedee ex",
     "image": "cPK_20_012030_00_YESSANMESUNOSUGATA_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20988,7 +23325,8 @@
     "name": "Hitmonchan ex",
     "image": "cPK_20_012060_00_EBIWALARex_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -20997,7 +23335,8 @@
     "name": "Mega Absol ex",
     "image": "cPK_20_012330_00_MEGAABSOLex_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21006,7 +23345,8 @@
     "name": "Dragalge ex",
     "image": "cPK_20_012420_00_DRAMIDOROex_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21015,7 +23355,8 @@
     "name": "Melmetal ex",
     "image": "cPK_20_012560_00_MELMETALex_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21024,7 +23365,8 @@
     "name": "Tauros ex",
     "image": "cPK_20_012650_00_KENTAUROSex_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21033,7 +23375,8 @@
     "name": "Marlon",
     "image": "cTR_20_000950_00_SHIZUI_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21042,7 +23385,8 @@
     "name": "Hala",
     "image": "cTR_20_000960_00_HALA_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21051,7 +23395,8 @@
     "name": "May",
     "image": "cTR_20_000970_00_HARUKA_SR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21060,7 +23405,8 @@
     "name": "Fantina",
     "image": "cTR_20_000980_00_MELISSA_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21069,7 +23415,8 @@
     "name": "Copycat",
     "image": "cTR_20_000990_00_MONOMANEMUSUME_SR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21078,7 +23425,8 @@
     "name": "Lisia",
     "image": "cTR_20_001000_00_RUCHIA_SR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21087,7 +23435,8 @@
     "name": "Mega Pinsir ex",
     "image": "cPK_20_010840_01_MEGAKAILIOSex_SAR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21096,7 +23445,8 @@
     "name": "Whimsicott ex",
     "image": "cPK_20_010980_01_ELFUUNex_SAR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21105,7 +23455,8 @@
     "name": "Rapidash ex",
     "image": "cPK_20_011130_01_GALLOPex_SAR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21114,7 +23465,8 @@
     "name": "Greninja ex",
     "image": "cPK_20_011550_01_GEKKOUGAex_SAR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21123,7 +23475,8 @@
     "name": "Jolteon ex",
     "image": "cPK_20_011630_01_THUNDERSex_SAR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21132,7 +23485,8 @@
     "name": "Mega Ampharos ex",
     "image": "cPK_20_011670_01_MEGADENRYUex_SAR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21141,7 +23495,8 @@
     "name": "Indeedee ex",
     "image": "cPK_20_012030_01_YESSANMESUNOSUGATA_SAR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21150,7 +23505,8 @@
     "name": "Hitmonchan ex",
     "image": "cPK_20_012060_01_EBIWALARex_SAR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21159,7 +23515,8 @@
     "name": "Mega Absol ex",
     "image": "cPK_20_012330_01_MEGAABSOLex_SAR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21168,7 +23525,8 @@
     "name": "Dragalge ex",
     "image": "cPK_20_012420_01_DRAMIDOROex_SAR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21177,7 +23535,8 @@
     "name": "Melmetal ex",
     "image": "cPK_20_012560_01_MELMETALex_SAR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21186,7 +23545,8 @@
     "name": "Tauros ex",
     "image": "cPK_20_012650_01_KENTAUROSex_SAR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21195,7 +23555,8 @@
     "name": "Mega Blaziken ex",
     "image": "cPK_20_011180_01_MEGABURSYAMOex_IM.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21204,7 +23565,8 @@
     "name": "Mega Gyarados ex",
     "image": "cPK_20_011340_01_MEGAGYARADOSex_IM.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21213,7 +23575,8 @@
     "name": "Mega Altaria ex",
     "image": "cPK_20_011840_01_MEGATYLTALISex_IM.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21222,7 +23585,8 @@
     "name": "Bellsprout",
     "image": "cPK_20_000180_00_MADATSUBOMI_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21231,7 +23595,8 @@
     "name": "Weepinbell",
     "image": "cPK_20_000190_00_UTSUDON_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21240,7 +23605,8 @@
     "name": "Victreebel",
     "image": "cPK_20_000200_00_UTSUBOT_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21249,7 +23615,8 @@
     "name": "Rowlet",
     "image": "cPK_20_005910_00_MOKUROH_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21258,7 +23625,8 @@
     "name": "Dartrix",
     "image": "cPK_20_007460_00_FUKUTHROW_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21267,7 +23635,8 @@
     "name": "Moltres",
     "image": "cPK_20_000460_00_FIRE_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21276,7 +23645,8 @@
     "name": "Litten",
     "image": "cPK_20_006110_00_NYABBY_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21285,7 +23655,8 @@
     "name": "Torracat",
     "image": "cPK_20_006130_00_NYAHEAT_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21294,7 +23665,8 @@
     "name": "Poliwag",
     "image": "cPK_20_010330_00_NYOROMO_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21303,7 +23675,8 @@
     "name": "Poliwhirl",
     "image": "cPK_20_000600_00_NYOROZO_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21312,7 +23685,8 @@
     "name": "Poliwrath",
     "image": "cPK_20_000610_00_NYOROBON_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21321,7 +23695,8 @@
     "name": "Articuno",
     "image": "cPK_20_000830_00_FREEZER_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21330,7 +23705,8 @@
     "name": "Manaphy",
     "image": "cPK_20_003310_01_MANAPHY_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21339,7 +23715,8 @@
     "name": "Popplio",
     "image": "cPK_20_006260_00_ASHIMARI_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21348,7 +23725,8 @@
     "name": "Brionne",
     "image": "cPK_20_008180_00_OSYAMARI_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21357,7 +23735,8 @@
     "name": "Zapdos",
     "image": "cPK_20_001030_00_THUNDER_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21366,7 +23745,8 @@
     "name": "Oricorio",
     "image": "cPK_20_006470_01_ODORIDORIPACHIPACHISTYLE_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21375,7 +23755,8 @@
     "name": "Zeraora",
     "image": "cPK_20_007410_00_ZERAORA_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21384,7 +23765,8 @@
     "name": "Drowzee",
     "image": "cPK_20_001240_00_SLEEPE_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21393,7 +23775,8 @@
     "name": "Hypno",
     "image": "cPK_20_001250_00_SLEEPER_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21402,7 +23785,8 @@
     "name": "Geodude",
     "image": "cPK_20_001470_00_ISITSUBUTE_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21411,7 +23795,8 @@
     "name": "Graveler",
     "image": "cPK_20_002570_00_GOLONE_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21420,7 +23805,8 @@
     "name": "Golem",
     "image": "cPK_20_002580_00_GOLONYA_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21429,7 +23815,8 @@
     "name": "Rockruff",
     "image": "cPK_20_006790_01_IWANKO_S.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21438,7 +23825,8 @@
     "name": "Alolan Diglett",
     "image": "cPK_20_006980_00_ALOLADIGDA_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21447,7 +23835,8 @@
     "name": "Meowth",
     "image": "cPK_20_001960_01_NYARTH_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21456,7 +23845,8 @@
     "name": "Persian",
     "image": "cPK_20_001970_00_PERSIAN_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21465,7 +23855,8 @@
     "name": "Doduo",
     "image": "cPK_20_001990_00_DODO_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21474,7 +23865,8 @@
     "name": "Dodrio",
     "image": "cPK_20_002000_00_DODORIO_S.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21483,7 +23875,8 @@
     "name": "Bidoof",
     "image": "cPK_20_004160_01_BIPPA_S.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21492,7 +23885,8 @@
     "name": "Decidueye ex",
     "image": "cPK_20_005930_02_JUNAIPERex_SSR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21501,7 +23895,8 @@
     "name": "Incineroar ex",
     "image": "cPK_20_006140_02_GAOGAENex_SSR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21510,7 +23905,8 @@
     "name": "Palkia ex",
     "image": "cPK_20_003300_04_PALKIAex_SSR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21519,7 +23915,8 @@
     "name": "Primarina ex",
     "image": "cPK_20_008190_02_ASHIRENEex_SSR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21528,7 +23925,8 @@
     "name": "Pikachu ex",
     "image": "cPK_20_005410_02_PIKACHUex_SSR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21537,7 +23935,8 @@
     "name": "Tapu Koko ex",
     "image": "cPK_20_007420_02_KAPU-KOKEKOex_SSR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21546,7 +23945,8 @@
     "name": "Lycanroc ex",
     "image": "cPK_20_007700_02_LUGARUGANex_SSR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21555,7 +23955,8 @@
     "name": "Passimian ex",
     "image": "cPK_20_006850_02_NAGETUKESARUex_SSR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21564,7 +23965,8 @@
     "name": "Alolan Dugtrio ex",
     "image": "cPK_20_007830_02_ALOLADUGTRIOex_SSR.webp",
     "packs": ["Mega Blaziken"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21573,7 +23975,8 @@
     "name": "Dialga ex",
     "image": "cPK_20_004000_04_DIALGAex_SSR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21582,7 +23985,8 @@
     "name": "Bibarel ex",
     "image": "cPK_20_005790_02_BEADARUex_SSR.webp",
     "packs": ["Mega Altaria"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21591,7 +23995,8 @@
     "name": "Arceus ex",
     "image": "cPK_20_004950_04_ARCEUSex_SSR.webp",
     "packs": ["Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1",
@@ -21600,7 +24005,8 @@
     "name": "Lilligant",
     "image": "cPK_20_011000_00_DREDEAR_UR.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21609,7 +24015,8 @@
     "name": "Klefki",
     "image": "cPK_20_012020_00_CLEFFY_UR.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1",
@@ -21618,7 +24025,8 @@
     "name": "Flame Patch",
     "image": "cTR_20_000910_00_FUREIMUPACCHI_UR.webp",
     "packs": ["Mega Altaria", "Mega Blaziken", "Mega Gyarados"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21627,7 +24035,8 @@
     "image": "cPK_10_013070_00_FUSHIGIDANE_C.webp",
     "name": "Bulbasaur",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21636,7 +24045,8 @@
     "image": "cPK_10_013080_00_FUSHIGISOU_U.webp",
     "name": "Ivysaur",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21645,7 +24055,8 @@
     "image": "cPK_10_013090_00_FUSHIGIBANA_R.webp",
     "name": "Venusaur",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21654,7 +24065,8 @@
     "image": "cPK_10_013100_00_MEGAFUSHIGIBANAex_RR.webp",
     "name": "Mega Venusaur ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21663,7 +24075,8 @@
     "image": "cPK_10_013110_00_ITOMARU_C.webp",
     "name": "Spinarak",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21672,7 +24085,8 @@
     "image": "cPK_10_013120_00_ARIADOS_U.webp",
     "name": "Ariados",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21681,7 +24095,8 @@
     "image": "cPK_10_013130_00_HIMANUTS_C.webp",
     "name": "Sunkern",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21690,7 +24105,8 @@
     "image": "cPK_10_013140_00_KIMAWARI_U.webp",
     "name": "Sunflora",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21699,7 +24115,8 @@
     "image": "cPK_10_013150_00_MINOMUCCHI_C.webp",
     "name": "Burmy",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21708,7 +24125,8 @@
     "image": "cPK_10_013160_00_GAMALE_C.webp",
     "name": "Mothim",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21717,7 +24135,8 @@
     "image": "cPK_10_013170_00_HITOKAGE_C.webp",
     "name": "Charmander",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21726,7 +24145,8 @@
     "image": "cPK_10_012980_00_LIZARDO_U.webp",
     "name": "Charmeleon",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21735,7 +24155,8 @@
     "image": "cPK_10_013180_00_LIZARDON_R.webp",
     "name": "Charizard",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21744,7 +24165,8 @@
     "image": "cPK_10_013190_00_MEGALIZARDONYex_RR.webp",
     "name": "Mega Charizard Y ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21753,7 +24175,8 @@
     "image": "cPK_10_013200_00_DELVIL_C.webp",
     "name": "Houndour",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21762,7 +24185,8 @@
     "image": "cPK_10_013210_00_HELLGAR_C.webp",
     "name": "Houndoom",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21771,7 +24195,8 @@
     "image": "cPK_10_013220_00_ZENIGAME_C.webp",
     "name": "Squirtle",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21780,7 +24205,8 @@
     "image": "cPK_10_013230_00_KAMEIL_U.webp",
     "name": "Wartortle",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21789,7 +24215,8 @@
     "image": "cPK_10_013240_00_KAMEX_R.webp",
     "name": "Blastoise",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21798,7 +24225,8 @@
     "image": "cPK_10_013250_00_MEGAKAMEXex_RR.webp",
     "name": "Mega Blastoise ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21807,7 +24235,8 @@
     "image": "cPK_10_013260_00_BASSRAOAKASUJINOSUGATA_C.webp",
     "name": "Basculin",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21816,7 +24245,8 @@
     "image": "cPK_10_013270_00_UDEPPOU_C.webp",
     "name": "Clauncher",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21825,7 +24255,8 @@
     "image": "cPK_10_013280_00_BLOSTER_U.webp",
     "name": "Clawitzer",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21834,7 +24265,8 @@
     "image": "cPK_10_013290_00_COIL_C.webp",
     "name": "Magnemite",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21843,7 +24275,8 @@
     "image": "cPK_10_013300_00_RARECOIL_U.webp",
     "name": "Magneton",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21852,7 +24285,8 @@
     "image": "cPK_10_013310_00_JIBACOIL_R.webp",
     "name": "Magnezone",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21861,7 +24295,8 @@
     "image": "cPK_10_013320_00_EMOLGA_C.webp",
     "name": "Emolga",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21870,7 +24305,8 @@
     "image": "cPK_10_013330_00_ERIKITERU_C.webp",
     "name": "Helioptile",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21879,7 +24315,8 @@
     "image": "cPK_10_013030_00_ELEZARD_U.webp",
     "name": "Heliolisk",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21888,7 +24325,8 @@
     "image": "cPK_10_013340_00_MUMA_C.webp",
     "name": "Misdreavus",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21897,7 +24335,8 @@
     "image": "cPK_10_013350_00_MUMARGI_U.webp",
     "name": "Mismagius",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21906,7 +24345,8 @@
     "image": "cPK_10_013360_00_UNIRAN_C.webp",
     "name": "Solosis",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21915,7 +24355,8 @@
     "image": "cPK_10_013370_00_DOUBLAN_C.webp",
     "name": "Duosion",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21924,7 +24365,8 @@
     "image": "cPK_10_013380_00_LANCULUS_R.webp",
     "name": "Reuniclus",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21933,7 +24375,8 @@
     "image": "cPK_10_013390_00_SHUSHUPU_C.webp",
     "name": "Spritzee",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21942,7 +24385,8 @@
     "image": "cPK_10_013400_00_FREFUWAN_C.webp",
     "name": "Aromatisse",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21951,7 +24395,8 @@
     "image": "cPK_10_013410_00_XERNEAS_R.webp",
     "name": "Xerneas",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21960,7 +24405,8 @@
     "image": "cPK_10_013420_00_IWARK_C.webp",
     "name": "Onix",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21969,7 +24415,8 @@
     "image": "cPK_10_013430_00_MAKUNOSHITA_C.webp",
     "name": "Makuhita",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21978,7 +24425,8 @@
     "image": "cPK_10_013440_00_HARITEYAMA_U.webp",
     "name": "Hariyama",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21987,7 +24435,8 @@
     "image": "cPK_10_013450_00_NOSEPASS_C.webp",
     "name": "Nosepass",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -21996,7 +24445,8 @@
     "image": "cPK_10_013460_00_MEGAMIMILOPex_RR.webp",
     "name": "Mega Lopunny ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22005,7 +24455,8 @@
     "image": "cPK_10_013470_00_KOJOFU_C.webp",
     "name": "Mienfoo",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22014,7 +24465,8 @@
     "image": "cPK_10_013480_00_KOJONDO_C.webp",
     "name": "Mienshao",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22023,7 +24475,8 @@
     "image": "cPK_10_013490_00_BETBETER_C.webp",
     "name": "Grimer",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22032,7 +24485,8 @@
     "image": "cPK_10_013500_00_BETBETON_C.webp",
     "name": "Muk",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22041,7 +24495,8 @@
     "image": "cPK_10_013510_00_CHORONEKO_C.webp",
     "name": "Purrloin",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22050,7 +24505,8 @@
     "image": "cPK_10_013520_00_LEPARDAS_U.webp",
     "name": "Liepard",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22059,7 +24515,8 @@
     "image": "cPK_10_013530_00_YABUKURON_C.webp",
     "name": "Trubbish",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22068,7 +24525,8 @@
     "image": "cPK_10_013540_00_DUSTDAS_U.webp",
     "name": "Garbodor",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22077,7 +24535,8 @@
     "image": "cPK_10_013550_00_HAGANEIL_U.webp",
     "name": "Steelix",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22086,7 +24545,8 @@
     "image": "cPK_10_013560_00_MEGAHAGANEILex_RR.webp",
     "name": "Mega Steelix ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22095,7 +24555,8 @@
     "image": "cPK_10_013570_00_DAINOSE_U.webp",
     "name": "Probopass",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22104,7 +24565,8 @@
     "image": "cPK_10_013010_00_GENESECT_R.webp",
     "name": "Genesect",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22113,7 +24575,8 @@
     "image": "cPK_10_013060_00_METAMON_U.webp",
     "name": "Ditto",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22122,7 +24585,8 @@
     "image": "cPK_10_013580_00_PORYGON_C.webp",
     "name": "Porygon",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22131,7 +24595,8 @@
     "image": "cPK_10_013590_00_PORYGON2_U.webp",
     "name": "Porygon2",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22140,7 +24605,8 @@
     "image": "cPK_10_013600_00_PORYGON-Z_R.webp",
     "name": "Porygon-Z",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22149,7 +24615,8 @@
     "image": "cPK_10_013610_00_MUKKURU_C.webp",
     "name": "Starly",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22158,7 +24625,8 @@
     "image": "cPK_10_013620_00_MUKUBIRD_C.webp",
     "name": "Staravia",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22167,7 +24635,8 @@
     "image": "cPK_10_013630_00_MUKUHAWK_U.webp",
     "name": "Staraptor",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22176,7 +24645,8 @@
     "image": "cPK_10_013040_00_MIMIROL_C.webp",
     "name": "Buneary",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22185,7 +24655,8 @@
     "image": "cPK_10_013640_00_MIMILOP_U.webp",
     "name": "Lopunny",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22194,7 +24665,8 @@
     "image": "cPK_10_013650_00_BUFFRON_U.webp",
     "name": "Bouffalant",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22203,16 +24675,18 @@
     "image": "cPK_10_013660_00_TRIMMIENKABUKICUT_U.webp",
     "name": "Furfrou",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
     "number": 66,
     "rarity": "U",
     "image": "cTR_10_001010_00_CITRONNORYUKKU_U.webp",
-    "name": "Clemont\u2019s Backpack",
+    "name": "Clemont’s Backpack",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22221,7 +24695,8 @@
     "image": "cTR_10_001020_00_SOUJYUKUEKISU_U.webp",
     "name": "Quick-Grow Extract",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22230,7 +24705,8 @@
     "image": "cTR_10_001030_00_CITRON_U.webp",
     "name": "Clemont",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22239,7 +24715,8 @@
     "image": "cTR_10_001040_00_SERENA_U.webp",
     "name": "Serena",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22248,7 +24725,8 @@
     "image": "cPK_20_013120_00_ARIADOS_AR.webp",
     "name": "Ariados",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22257,7 +24735,8 @@
     "image": "cPK_20_013140_00_KIMAWARI_AR.webp",
     "name": "Sunflora",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22266,7 +24745,8 @@
     "image": "cPK_20_013380_00_LANCULUS_AR.webp",
     "name": "Reuniclus",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22275,7 +24755,8 @@
     "image": "cPK_20_013410_00_XERNEAS_AR.webp",
     "name": "Xerneas",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22284,7 +24765,8 @@
     "image": "cPK_20_013530_00_YABUKURON_AR.webp",
     "name": "Trubbish",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22293,7 +24775,8 @@
     "image": "cPK_20_013040_00_MIMIROL_AR.webp",
     "name": "Buneary",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22302,7 +24785,8 @@
     "image": "cPK_20_013100_00_MEGAFUSHIGIBANAex_SR.webp",
     "name": "Mega Venusaur ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22311,7 +24795,8 @@
     "image": "cPK_20_013190_00_MEGALIZARDONYex_SR.webp",
     "name": "Mega Charizard Y ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22320,7 +24805,8 @@
     "image": "cPK_20_013250_00_MEGAKAMEXex_SR.webp",
     "name": "Mega Blastoise ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22329,7 +24815,8 @@
     "image": "cPK_20_013460_00_MEGAMIMILOPex_SR.webp",
     "name": "Mega Lopunny ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22338,7 +24825,8 @@
     "image": "cPK_20_013560_00_MEGAHAGANEILex_SR.webp",
     "name": "Mega Steelix ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22347,7 +24835,8 @@
     "image": "cTR_20_001030_00_CITRON_SR.webp",
     "name": "Clemont",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22356,7 +24845,8 @@
     "image": "cTR_20_001040_00_SERENA_SR.webp",
     "name": "Serena",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22365,7 +24855,8 @@
     "image": "cPK_20_013100_01_MEGAFUSHIGIBANAex_SAR.webp",
     "name": "Mega Venusaur ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22374,7 +24865,8 @@
     "image": "cPK_20_013250_01_MEGAKAMEXex_SAR.webp",
     "name": "Mega Blastoise ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22383,7 +24875,8 @@
     "image": "cPK_20_013460_01_MEGAMIMILOPex_SAR.webp",
     "name": "Mega Lopunny ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22392,7 +24885,8 @@
     "image": "cPK_20_013560_01_MEGAHAGANEILex_SAR.webp",
     "name": "Mega Steelix ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22401,7 +24895,8 @@
     "image": "cPK_20_013190_01_MEGALIZARDONYex_IM.webp",
     "name": "Mega Charizard Y ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22410,7 +24905,8 @@
     "image": "cPK_20_008570_00_NAZONOKUSA_S.webp",
     "name": "Oddish",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22419,7 +24915,8 @@
     "image": "cPK_20_008580_00_KUSAIHANA_S.webp",
     "name": "Gloom",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22428,7 +24925,8 @@
     "image": "cPK_20_000130_00_RUFFRESIA_S.webp",
     "name": "Vileplume",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22437,7 +24935,8 @@
     "image": "cPK_20_013180_00_LIZARDON_S.webp",
     "name": "Charizard",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22446,7 +24945,8 @@
     "image": "cPK_20_006230_00_SHELLDER_S.webp",
     "name": "Shellder",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22455,7 +24955,8 @@
     "image": "cPK_20_006240_00_PARSHEN_S.webp",
     "name": "Cloyster",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22464,7 +24965,8 @@
     "image": "cPK_20_012040_00_SAND_S.webp",
     "name": "Sandshrew",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22473,7 +24975,8 @@
     "image": "cPK_20_012050_00_SANDPAN_S.webp",
     "name": "Sandslash",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22482,7 +24985,8 @@
     "image": "cPK_20_007940_00_TYPENULL_S.webp",
     "name": "Type: Null",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22491,7 +24995,8 @@
     "image": "cPK_20_007950_01_SILVADY_S.webp",
     "name": "Silvally",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22500,7 +25005,8 @@
     "image": "cPK_20_007480_03_MASSIVOONex_SSR.webp",
     "name": "Buzzwole ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22509,7 +25015,8 @@
     "image": "cPK_20_006680_04_LUNALAex_SSR.webp",
     "name": "Lunala ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22518,7 +25025,8 @@
     "image": "cPK_20_007800_02_AKUZIKINGex_SSR.webp",
     "name": "Guzzlord ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22527,7 +25035,8 @@
     "image": "cPK_20_007030_04_SOLGALEOex_SSR.webp",
     "name": "Solgaleo ex",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B1a",
@@ -22536,7 +25045,8 @@
     "image": "cPK_20_012540_00_GILLGARDBLADEFORME_UR.webp",
     "name": "Aegislash",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B1a",
@@ -22545,7 +25055,8 @@
     "image": "cTR_20_001020_00_SOUJYUKUEKISU_UR.webp",
     "name": "Quick-Grow Extract",
     "packs": ["Crimson Blaze"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22554,7 +25065,8 @@
     "image": "cPK_10_013670_00_REDIBA_C.webp",
     "name": "Ledyba",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22563,7 +25075,8 @@
     "image": "cPK_10_013680_00_REDIAN_C.webp",
     "name": "Ledian",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22572,7 +25085,8 @@
     "image": "cPK_10_013690_00_TSUBOTSUBO_C.webp",
     "name": "Shuckle",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22581,7 +25095,8 @@
     "image": "cPK_10_013700_00_ROSELIA_C.webp",
     "name": "Roselia",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22590,7 +25105,8 @@
     "image": "cPK_10_013710_00_ROSERADE_R.webp",
     "name": "Roserade",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22599,7 +25115,8 @@
     "image": "cPK_10_013720_00_SABONEA_C.webp",
     "name": "Cacnea",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22608,7 +25125,8 @@
     "image": "cPK_10_013730_00_NOCTUS_U.webp",
     "name": "Cacturne",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22617,7 +25135,8 @@
     "image": "cPK_10_013740_00_HARIMARON_C.webp",
     "name": "Chespin",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22626,7 +25145,8 @@
     "image": "cPK_10_013750_00_HARIBORG_U.webp",
     "name": "Quilladin",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22635,7 +25155,8 @@
     "image": "cPK_10_013760_00_BRIGARRON_R.webp",
     "name": "Chesnaught",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22644,7 +25165,8 @@
     "image": "cPK_10_013770_00_KOFUKIMUSHI_C.webp",
     "name": "Scatterbug",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22653,7 +25175,8 @@
     "image": "cPK_10_013780_00_KOFUURAI_C.webp",
     "name": "Spewpa",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22662,7 +25185,8 @@
     "image": "cPK_10_013790_00_VIVIYON_U.webp",
     "name": "Vivillon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22671,7 +25195,8 @@
     "image": "cPK_10_013800_00_MASSIVOON_R.webp",
     "name": "Buzzwole",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22680,7 +25205,8 @@
     "image": "cPK_10_013810_00_HIMENKA_C.webp",
     "name": "Gossifleur",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22689,7 +25215,8 @@
     "image": "cPK_10_013820_00_WATASHIRAGA_U.webp",
     "name": "Eldegoss",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22698,7 +25225,8 @@
     "image": "cPK_10_013830_00_OGERPONMIDORINOMENex_RR.webp",
     "name": "Teal Mask Ogerpon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22707,7 +25235,8 @@
     "image": "cPK_10_013840_00_ALOLAGARAGARA_U.webp",
     "name": "Alolan Marowak",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22716,7 +25245,8 @@
     "image": "cPK_10_013850_00_RESHIRAM_R.webp",
     "name": "Reshiram",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22725,7 +25255,8 @@
     "image": "cPK_10_013860_00_SHISHIKO_C.webp",
     "name": "Litleo",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22734,7 +25265,8 @@
     "image": "cPK_10_013870_00_KAENJISHI_U.webp",
     "name": "Pyroar",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22743,7 +25275,8 @@
     "image": "cPK_10_013880_00_ODORIDORI_U.webp",
     "name": "Oricorio",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22752,7 +25285,8 @@
     "image": "cPK_10_013890_00_ZUGADOONex_RR.webp",
     "name": "Blacephalon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22761,7 +25295,8 @@
     "image": "cPK_10_013900_00_HIBANNY_C.webp",
     "name": "Scorbunny",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22770,7 +25305,8 @@
     "image": "cPK_10_013910_00_RABBIFUTO_U.webp",
     "name": "Raboot",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22779,7 +25315,8 @@
     "image": "cPK_10_013920_00_ACEBURN_R.webp",
     "name": "Cinderace",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22788,7 +25325,8 @@
     "image": "cPK_10_013930_00_OGERPONKAMADONOMEN_R.webp",
     "name": "Hearthflame Mask Ogerpon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22797,7 +25335,8 @@
     "image": "cPK_10_013940_00_ALOLAROKON_C.webp",
     "name": "Alolan Vulpix",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22806,7 +25345,8 @@
     "image": "cPK_10_013950_00_ALOLAKYUKONex_RR.webp",
     "name": "Alolan Ninetales ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22815,7 +25355,8 @@
     "image": "cPK_10_013960_00_GALARBARRIERD_C.webp",
     "name": "Galarian Mr. Mime",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22824,7 +25365,8 @@
     "image": "cPK_10_013970_00_GALARBARRIKOHRU_U.webp",
     "name": "Galarian Mr. Rime",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22833,7 +25375,8 @@
     "image": "cPK_10_013980_00_DELIBIRD_U.webp",
     "name": "Delibird",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22842,7 +25385,8 @@
     "image": "cPK_10_013990_00_MIZUGOROU_C.webp",
     "name": "Mudkip",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22851,7 +25395,8 @@
     "image": "cPK_10_014000_00_NUMACRAW_U.webp",
     "name": "Marshtomp",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22860,7 +25405,8 @@
     "image": "cPK_10_014010_00_LAGLARGE_R.webp",
     "name": "Swampert",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22869,7 +25415,8 @@
     "image": "cPK_10_014020_00_MEGALAGLARGEex_RR.webp",
     "name": "Mega Swampert ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22878,7 +25425,8 @@
     "image": "cPK_10_014030_00_VANIPETI_C.webp",
     "name": "Vanillite",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22887,7 +25435,8 @@
     "image": "cPK_10_014040_00_VANIRICH_C.webp",
     "name": "Vanillish",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22896,7 +25445,8 @@
     "image": "cPK_10_014050_00_BAIVANILLA_U.webp",
     "name": "Vanilluxe",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22905,7 +25455,8 @@
     "image": "cPK_10_014060_00_FREEGEO_C.webp",
     "name": "Cryogonal",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22914,7 +25465,8 @@
     "image": "cPK_10_014070_00_AMARUS_U.webp",
     "name": "Amaura",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22923,7 +25475,8 @@
     "image": "cPK_10_014080_00_AMARURUGA_R.webp",
     "name": "Aurorus",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22932,7 +25485,8 @@
     "image": "cPK_10_014090_00_KAMUKAME_C.webp",
     "name": "Chewtle",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22941,7 +25495,8 @@
     "image": "cPK_10_014100_00_KAJIRIGAME_U.webp",
     "name": "Drednaw",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22950,7 +25505,8 @@
     "image": "cPK_10_014110_00_UU_C.webp",
     "name": "Cramorant",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22959,7 +25515,8 @@
     "image": "cPK_10_014120_00_SASIKAMASU_C.webp",
     "name": "Arrokuda",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22968,7 +25525,8 @@
     "image": "cPK_10_014130_00_KAMASUJAW_C.webp",
     "name": "Barraskewda",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22977,7 +25535,8 @@
     "image": "cPK_10_014140_00_OGERPONIDONOMEN_R.webp",
     "name": "Wellspring Mask Ogerpon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22986,7 +25545,8 @@
     "image": "cPK_10_014150_00_PIKACHU_C.webp",
     "name": "Pikachu",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -22995,7 +25555,8 @@
     "image": "cPK_10_014160_00_ALOLARAICHU_R.webp",
     "name": "Alolan Raichu",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23004,7 +25565,8 @@
     "image": "cPK_10_014170_00_THUNDER_R.webp",
     "name": "Zapdos",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23013,7 +25575,8 @@
     "image": "cPK_10_014180_00_PRASLE_C.webp",
     "name": "Plusle",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23022,7 +25585,8 @@
     "image": "cPK_10_014190_00_MINUN_C.webp",
     "name": "Minun",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23031,7 +25595,8 @@
     "image": "cPK_10_014200_00_ELESON_C.webp",
     "name": "Toxel",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23040,7 +25605,8 @@
     "image": "cPK_10_014210_00_STRINDERex_RR.webp",
     "name": "Toxtricity ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23049,7 +25615,8 @@
     "image": "cPK_10_014220_00_ZUPIKA_C.webp",
     "name": "Tadbulb",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23058,7 +25625,8 @@
     "image": "cPK_10_014230_00_HARABARIE_U.webp",
     "name": "Bellibolt",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23067,7 +25635,8 @@
     "image": "cPK_10_014240_00_GALARPONYTA_C.webp",
     "name": "Galarian Ponyta",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23076,7 +25645,8 @@
     "image": "cPK_10_014250_00_GALARGALLOP_U.webp",
     "name": "Galarian Rapidash",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23085,7 +25655,8 @@
     "image": "cPK_10_014260_00_SONANS_C.webp",
     "name": "Wobbuffet",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23094,7 +25665,8 @@
     "image": "cPK_10_014270_00_BULU_C.webp",
     "name": "Snubbull",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23103,7 +25675,8 @@
     "image": "cPK_10_014280_00_GRANBULU_U.webp",
     "name": "Granbull",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23112,7 +25685,8 @@
     "image": "cPK_10_014290_00_RALTS_C.webp",
     "name": "Ralts",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23121,7 +25695,8 @@
     "image": "cPK_10_014300_00_KIRLIA_U.webp",
     "name": "Kirlia",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23130,7 +25705,8 @@
     "image": "cPK_10_014310_00_SIRNIGHT_R.webp",
     "name": "Gardevoir",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23139,7 +25715,8 @@
     "image": "cPK_10_014320_00_MEGASIRNIGHTex_RR.webp",
     "name": "Mega Gardevoir ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23148,7 +25725,8 @@
     "image": "cPK_10_014330_00_HITOMOSHI_C.webp",
     "name": "Litwick",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23157,7 +25735,8 @@
     "image": "cPK_10_014340_00_LAMPLER_U.webp",
     "name": "Lampent",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23166,7 +25745,8 @@
     "image": "cPK_10_014350_00_CHANDELA_R.webp",
     "name": "Chandelure",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23175,7 +25755,8 @@
     "image": "cPK_10_014360_00_MELOETTA_U.webp",
     "name": "Meloetta",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23184,7 +25765,8 @@
     "image": "cPK_10_014370_00_BAKECCHA_C.webp",
     "name": "Pumpkaboo",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23193,7 +25775,8 @@
     "image": "cPK_10_014380_00_PUMPJIN_R.webp",
     "name": "Gourgeist",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23202,7 +25785,8 @@
     "image": "cPK_10_014390_00_MIMIKKYUex_RR.webp",
     "name": "Mimikyu ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23211,7 +25795,8 @@
     "image": "cPK_10_014400_00_YABACHA_C.webp",
     "name": "Sinistea",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23220,7 +25805,8 @@
     "image": "cPK_10_014410_00_POTDEATH_U.webp",
     "name": "Polteageist",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23229,7 +25815,8 @@
     "image": "cPK_10_014420_00_YESSAN_C.webp",
     "name": "Indeedee",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23238,7 +25825,8 @@
     "image": "cPK_10_014430_00_SAND_C.webp",
     "name": "Sandshrew",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23247,7 +25835,8 @@
     "image": "cPK_10_014440_00_SANDPAN_C.webp",
     "name": "Sandslash",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23256,7 +25845,8 @@
     "image": "cPK_10_014450_00_WANRIKY_C.webp",
     "name": "Machop",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23265,7 +25855,8 @@
     "image": "cPK_10_014460_00_GORIKY_C.webp",
     "name": "Machoke",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23274,7 +25865,8 @@
     "image": "cPK_10_014470_00_KAIRIKY_U.webp",
     "name": "Machamp",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23283,7 +25875,8 @@
     "image": "cPK_10_014480_00_KARAKARA_C.webp",
     "name": "Cubone",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23292,7 +25885,8 @@
     "image": "cPK_10_014490_00_ASANAN_C.webp",
     "name": "Meditite",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23301,7 +25895,8 @@
     "image": "cPK_10_014500_00_CHAREM_U.webp",
     "name": "Medicham",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23310,7 +25905,8 @@
     "image": "cPK_10_014510_00_DANGORO_C.webp",
     "name": "Roggenrola",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23319,7 +25915,8 @@
     "image": "cPK_10_014520_00_GANTLE_U.webp",
     "name": "Boldore",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23328,7 +25925,8 @@
     "image": "cPK_10_014530_00_GIGAIATHex_RR.webp",
     "name": "Gigalith ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23337,7 +25935,8 @@
     "image": "cPK_10_014540_00_MOGUREW_C.webp",
     "name": "Drilbur",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23346,7 +25945,8 @@
     "image": "cPK_10_014550_00_CHIGORAS_U.webp",
     "name": "Tyrunt",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23355,7 +25955,8 @@
     "image": "cPK_10_014560_00_GACHIGORAS_R.webp",
     "name": "Tyrantrum",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23364,7 +25965,8 @@
     "image": "cPK_10_014570_00_NAGETUKESARU_C.webp",
     "name": "Passimian",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23373,7 +25975,8 @@
     "image": "cPK_10_014580_00_TAIRETSU_U.webp",
     "name": "Falinks",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23382,7 +25985,8 @@
     "image": "cPK_10_014590_00_OGERPONISHIZUENOMEN_R.webp",
     "name": "Cornerstone Mask Ogerpon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23391,7 +25995,8 @@
     "image": "cPK_10_014600_00_ALOLANYARTH_C.webp",
     "name": "Alolan Meowth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23400,7 +26005,8 @@
     "image": "cPK_10_014610_00_ALOLAPERSIAN_U.webp",
     "name": "Alolan Persian",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23409,7 +26015,8 @@
     "image": "cPK_10_014620_00_ALOLABETBETER_C.webp",
     "name": "Alolan Grimer",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23418,7 +26025,8 @@
     "image": "cPK_10_014630_00_ALOLABETBETON_R.webp",
     "name": "Alolan Muk",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23427,7 +26035,8 @@
     "image": "cPK_10_014640_00_GALARJIGUZAGUMA_C.webp",
     "name": "Galarian Zigzagoon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23436,7 +26045,8 @@
     "image": "cPK_10_014650_00_GALARMASSUGUMA_U.webp",
     "name": "Galarian Linoone",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23445,7 +26055,8 @@
     "image": "cPK_10_014660_00_GALARTACHIFUSAGUMA_R.webp",
     "name": "Galarian Obstagoon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23454,7 +26065,8 @@
     "image": "cPK_10_014670_00_SKUNPUU_C.webp",
     "name": "Stunky",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23463,7 +26075,8 @@
     "image": "cPK_10_014680_00_SKUTANK_U.webp",
     "name": "Skuntank",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23472,7 +26085,8 @@
     "image": "cPK_10_014690_00_MIKARUGE_R.webp",
     "name": "Spiritomb",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23481,7 +26095,8 @@
     "image": "cPK_10_014700_00_CHORONEKO_C.webp",
     "name": "Purrloin",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23490,7 +26105,8 @@
     "image": "cPK_10_014710_00_LEPARDAS_U.webp",
     "name": "Liepard",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23499,7 +26115,8 @@
     "image": "cPK_10_014720_00_ZURUGGU_C.webp",
     "name": "Scraggy",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23508,7 +26125,8 @@
     "image": "cPK_10_014730_00_ZURUZUKIN_U.webp",
     "name": "Scrafty",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23517,7 +26135,8 @@
     "image": "cPK_10_014740_00_YVELTAL_R.webp",
     "name": "Yveltal",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23526,7 +26145,8 @@
     "image": "cPK_10_014750_00_AKUZIKING_R.webp",
     "name": "Guzzlord",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23535,7 +26155,8 @@
     "image": "cPK_10_014760_00_GALARNYARTH_C.webp",
     "name": "Galarian Meowth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23544,7 +26165,8 @@
     "image": "cPK_10_014770_00_GALARNYAIKING_R.webp",
     "name": "Galarian Perrserker",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23553,7 +26175,8 @@
     "image": "cPK_10_014780_00_KUCHEAT_C.webp",
     "name": "Mawile",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23562,7 +26185,8 @@
     "image": "cPK_10_014790_00_MEGAKUCHEATex_RR.webp",
     "name": "Mega Mawile ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23571,7 +26195,8 @@
     "image": "cPK_10_014800_00_DORYUZU_U.webp",
     "name": "Excadrill",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23580,7 +26205,8 @@
     "image": "cPK_10_014810_00_TESSEED_C.webp",
     "name": "Ferroseed",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23589,7 +26215,8 @@
     "image": "cPK_10_014820_00_NUTREY_C.webp",
     "name": "Ferrothorn",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23598,7 +26225,8 @@
     "image": "cPK_10_014830_00_GALARMAGGYO_U.webp",
     "name": "Galarian Stunfisk",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23607,7 +26235,8 @@
     "image": "cPK_10_014840_00_HITOTSUKI_C.webp",
     "name": "Honedge",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23616,7 +26245,8 @@
     "image": "cPK_10_014850_00_NIDANGILL_U.webp",
     "name": "Doublade",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23625,7 +26255,8 @@
     "image": "cPK_10_014860_00_GILLGARD_R.webp",
     "name": "Aegislash",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23634,7 +26265,8 @@
     "image": "cPK_10_014870_00_TATSUBAY_C.webp",
     "name": "Bagon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23643,7 +26275,8 @@
     "image": "cPK_10_014880_00_KOMORUU_U.webp",
     "name": "Shelgon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23652,7 +26285,8 @@
     "image": "cPK_10_014890_00_BOHMANDER_R.webp",
     "name": "Salamence",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23661,7 +26295,8 @@
     "image": "cPK_10_014900_00_NYARTH_C.webp",
     "name": "Meowth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23670,7 +26305,8 @@
     "image": "cPK_10_014910_00_PERSIAN_C.webp",
     "name": "Persian",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23679,7 +26315,8 @@
     "image": "cPK_10_014920_00_GARURA_U.webp",
     "name": "Kangaskhan",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23688,7 +26325,8 @@
     "image": "cPK_10_014930_00_MEGAGARURAex_RR.webp",
     "name": "Mega Kangaskhan ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23697,7 +26335,8 @@
     "image": "cPK_10_014940_00_OTACHI_C.webp",
     "name": "Sentret",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23706,7 +26345,8 @@
     "image": "cPK_10_014950_00_OOTACHI_C.webp",
     "name": "Furret",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23715,7 +26355,8 @@
     "image": "cPK_10_014960_00_DOBLE_U.webp",
     "name": "Smeargle",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23724,7 +26365,8 @@
     "image": "cPK_10_014970_00_LUGIA_R.webp",
     "name": "Lugia",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23733,7 +26375,8 @@
     "image": "cPK_10_014980_00_SUBAME_C.webp",
     "name": "Taillow",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23742,7 +26385,8 @@
     "image": "cPK_10_014990_00_OHSUBAME_R.webp",
     "name": "Swellow",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23751,7 +26395,8 @@
     "image": "cPK_10_015000_00_NAMAKERO_C.webp",
     "name": "Slakoth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23760,7 +26405,8 @@
     "image": "cPK_10_015010_00_YARUKIMONO_U.webp",
     "name": "Vigoroth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23769,7 +26415,8 @@
     "image": "cPK_10_015020_00_KEKKING_R.webp",
     "name": "Slaking",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23778,7 +26425,8 @@
     "image": "cPK_10_015030_00_PATCHEEL_C.webp",
     "name": "Spinda",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23787,7 +26435,8 @@
     "image": "cPK_10_015040_00_TORNELOS_R.webp",
     "name": "Tornadus",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23796,7 +26445,8 @@
     "image": "cPK_10_015050_00_HORUBEE_C.webp",
     "name": "Bunnelby",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23805,7 +26455,8 @@
     "image": "cPK_10_015060_00_HORUDO_U.webp",
     "name": "Diggersby",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23814,7 +26465,8 @@
     "image": "cPK_10_015070_00_TRIMMIEN_U.webp",
     "name": "Furfrou",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23823,7 +26475,8 @@
     "image": "cPK_10_015080_00_WAKKANEZUMI_C.webp",
     "name": "Tandemaus",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23832,7 +26485,8 @@
     "image": "cPK_10_015090_00_IKKANEZUMI_U.webp",
     "name": "Maushold",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23841,7 +26495,8 @@
     "image": "cTR_10_001050_00_AGONOKASEKI_C.webp",
     "name": "Jaw Fossil",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23850,7 +26505,8 @@
     "image": "cTR_10_001060_00_ATARITSUKIAISU_U.webp",
     "name": "Lucky Ice Pop",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23859,7 +26515,8 @@
     "image": "cTR_10_001070_00_HIRENOKASEKI_C.webp",
     "name": "Sail Fossil",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23868,7 +26525,8 @@
     "image": "cTR_10_001080_00_MAMORINOPONCHO_U.webp",
     "name": "Protective Poncho",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23877,7 +26535,8 @@
     "image": "cTR_10_001090_00_METARUKOABARIA_U.webp",
     "name": "Metal Core Barrier",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23886,7 +26545,8 @@
     "image": "cTR_10_001100_00_CARNE_U.webp",
     "name": "Diantha",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23895,7 +26555,8 @@
     "image": "cTR_10_001110_00_KANKOUKYAKU_U.webp",
     "name": "Sightseer",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23904,7 +26565,8 @@
     "image": "cTR_10_001120_00_JAGURA_U.webp",
     "name": "Juggler",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23913,7 +26575,8 @@
     "image": "cTR_10_001130_00_NEZU_U.webp",
     "name": "Piers",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23922,7 +26585,8 @@
     "image": "cTR_10_001140_00_TORENINGUERIA_U.webp",
     "name": "Training Area",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23931,7 +26595,8 @@
     "image": "cTR_10_001150_00_HAJIMARINOHEIGEN_U.webp",
     "name": "Starting Plains",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23940,7 +26605,8 @@
     "image": "cTR_10_001160_00_FUSHIGINAHIROBA_U.webp",
     "name": "Peculiar Plaza",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23949,7 +26615,8 @@
     "image": "cPK_20_013720_00_SABONEA_AR.webp",
     "name": "Cacnea",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23958,7 +26625,8 @@
     "image": "cPK_20_013710_00_ROSERADE_AR.webp",
     "name": "Roserade",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23967,7 +26635,8 @@
     "image": "cPK_20_013790_00_VIVIYON_AR.webp",
     "name": "Vivillon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23976,7 +26645,8 @@
     "image": "cPK_20_013800_00_MASSIVOON_AR.webp",
     "name": "Buzzwole",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23985,7 +26655,8 @@
     "image": "cPK_20_013850_00_RESHIRAM_AR.webp",
     "name": "Reshiram",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -23994,7 +26665,8 @@
     "image": "cPK_20_013880_00_ODORIDORI_AR.webp",
     "name": "Oricorio",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24003,7 +26675,8 @@
     "image": "cPK_20_013900_00_HIBANNY_AR.webp",
     "name": "Scorbunny",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24012,7 +26685,8 @@
     "image": "cPK_20_014080_00_AMARURUGA_AR.webp",
     "name": "Aurorus",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24021,7 +26695,8 @@
     "image": "cPK_20_014110_00_UU_AR.webp",
     "name": "Cramorant",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24030,7 +26705,8 @@
     "image": "cPK_20_014190_00_MINUN_AR.webp",
     "name": "Minun",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24039,7 +26715,8 @@
     "image": "cPK_20_014200_00_ELESON_AR.webp",
     "name": "Toxel",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24048,7 +26725,8 @@
     "image": "cPK_20_014240_00_GALARPONYTA_AR.webp",
     "name": "Galarian Ponyta",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24057,7 +26735,8 @@
     "image": "cPK_20_014270_00_BULU_AR.webp",
     "name": "Snubbull",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24066,7 +26745,8 @@
     "image": "cPK_20_014420_00_YESSAN_AR.webp",
     "name": "Indeedee",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24075,7 +26755,8 @@
     "image": "cPK_20_014430_00_SAND_AR.webp",
     "name": "Sandshrew",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24084,7 +26765,8 @@
     "image": "cPK_20_014560_00_GACHIGORAS_AR.webp",
     "name": "Tyrantrum",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24093,7 +26775,8 @@
     "image": "cPK_20_014580_00_TAIRETSU_AR.webp",
     "name": "Falinks",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24102,7 +26785,8 @@
     "image": "cPK_20_014630_00_ALOLABETBETON_AR.webp",
     "name": "Alolan Muk",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24111,7 +26795,8 @@
     "image": "cPK_20_014700_00_CHORONEKO_AR.webp",
     "name": "Purrloin",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24120,7 +26805,8 @@
     "image": "cPK_20_014740_00_YVELTAL_AR.webp",
     "name": "Yveltal",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24129,7 +26815,8 @@
     "image": "cPK_20_014660_00_GALARTACHIFUSAGUMA_AR.webp",
     "name": "Galarian Obstagoon",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24138,7 +26825,8 @@
     "image": "cPK_20_014770_00_GALARNYAIKING_AR.webp",
     "name": "Galarian Perrserker",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24147,7 +26835,8 @@
     "image": "cPK_20_014890_00_BOHMANDER_AR.webp",
     "name": "Salamence",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24156,7 +26845,8 @@
     "image": "cPK_20_015000_00_NAMAKERO_AR.webp",
     "name": "Slakoth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24165,7 +26855,8 @@
     "image": "cPK_20_013830_00_OGERPONMIDORINOMENex_SR.webp",
     "name": "Teal Mask Ogerpon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24174,7 +26865,8 @@
     "image": "cPK_20_013890_00_ZUGADOONex_SR.webp",
     "name": "Blacephalon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24183,7 +26875,8 @@
     "image": "cPK_20_013950_00_ALOLAKYUKONex_SR.webp",
     "name": "Alolan Ninetales ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24192,7 +26885,8 @@
     "image": "cPK_20_014020_00_MEGALAGLARGEex_SR.webp",
     "name": "Mega Swampert ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24201,7 +26895,8 @@
     "image": "cPK_20_014210_00_STRINDERex_SR.webp",
     "name": "Toxtricity ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24210,7 +26905,8 @@
     "image": "cPK_20_014320_00_MEGASIRNIGHTex_SR.webp",
     "name": "Mega Gardevoir ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24219,7 +26915,8 @@
     "image": "cPK_20_014390_00_MIMIKKYUex_SR.webp",
     "name": "Mimikyu ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24228,7 +26925,8 @@
     "image": "cPK_20_014530_00_GIGAIATHex_SR.webp",
     "name": "Gigalith ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24237,7 +26935,8 @@
     "image": "cPK_20_014790_00_MEGAKUCHEATex_SR.webp",
     "name": "Mega Mawile ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24246,7 +26945,8 @@
     "image": "cPK_20_014930_00_MEGAGARURAex_SR.webp",
     "name": "Mega Kangaskhan ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24255,7 +26955,8 @@
     "image": "cTR_20_001100_00_CARNE_SR.webp",
     "name": "Diantha",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24264,7 +26965,8 @@
     "image": "cTR_20_001110_00_KANKOUKYAKU_SR.webp",
     "name": "Sightseer",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24273,7 +26975,8 @@
     "image": "cTR_20_001120_00_JAGURA_SR.webp",
     "name": "Juggler",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24282,7 +26985,8 @@
     "image": "cTR_20_001130_00_NEZU_SR.webp",
     "name": "Piers",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24291,7 +26995,8 @@
     "image": "cPK_20_013830_01_OGERPONMIDORINOMENex_SAR.webp",
     "name": "Teal Mask Ogerpon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24300,7 +27005,8 @@
     "image": "cPK_20_013890_01_ZUGADOONex_SAR.webp",
     "name": "Blacephalon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24309,7 +27015,8 @@
     "image": "cPK_20_013950_01_ALOLAKYUKONex_SAR.webp",
     "name": "Alolan Ninetales ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24318,7 +27025,8 @@
     "image": "cPK_20_014020_01_MEGALAGLARGEex_SAR.webp",
     "name": "Mega Swampert ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24327,7 +27035,8 @@
     "image": "cPK_20_014210_01_STRINDERex_SAR.webp",
     "name": "Toxtricity ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24336,7 +27045,8 @@
     "image": "cPK_20_014390_01_MIMIKKYUex_SAR.webp",
     "name": "Mimikyu ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24345,7 +27055,8 @@
     "image": "cPK_20_014530_01_GIGAIATHex_SAR.webp",
     "name": "Gigalith ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24354,7 +27065,8 @@
     "image": "cPK_20_014790_01_MEGAKUCHEATex_SAR.webp",
     "name": "Mega Mawile ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24363,7 +27075,8 @@
     "image": "cPK_20_014930_01_MEGAGARURAex_SAR.webp",
     "name": "Mega Kangaskhan ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24372,7 +27085,8 @@
     "image": "cPK_20_014320_01_MEGASIRNIGHTex_IM.webp",
     "name": "Mega Gardevoir ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24381,7 +27095,8 @@
     "image": "cPK_20_014900_00_NYARTH_IM.webp",
     "name": "Meowth",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24390,7 +27105,8 @@
     "image": "cPK_20_008600_00_MONJARA_S.webp",
     "name": "Tangela",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24399,7 +27115,8 @@
     "image": "cPK_20_008880_01_BUBY_S.webp",
     "name": "Magby",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24408,7 +27125,8 @@
     "image": "cPK_20_003040_00_BOOBER_S.webp",
     "name": "Magmar",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24417,7 +27135,8 @@
     "image": "cPK_20_008970_00_TATTU_S.webp",
     "name": "Horsea",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24426,7 +27145,8 @@
     "image": "cPK_20_008980_00_SEADRA_S.webp",
     "name": "Seadra",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24435,7 +27155,8 @@
     "image": "cPK_20_010420_01_TAMANTA_S.webp",
     "name": "Mantyke",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24444,7 +27165,8 @@
     "image": "cPK_20_000810_00_OMNITE_S.webp",
     "name": "Omanyte",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24453,7 +27175,8 @@
     "image": "cPK_20_000820_00_OMSTAR_S.webp",
     "name": "Omastar",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24462,7 +27185,8 @@
     "image": "cPK_20_009220_01_PICHU_S.webp",
     "name": "Pichu",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24471,7 +27195,8 @@
     "image": "cPK_20_001130_00_PIPPI_S.webp",
     "name": "Clefairy",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24480,7 +27205,8 @@
     "image": "cPK_20_001140_00_PIXY_S.webp",
     "name": "Clefable",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24489,7 +27215,8 @@
     "image": "cPK_20_010200_00_LATIAS_S.webp",
     "name": "Latias",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24498,7 +27225,8 @@
     "image": "cPK_20_010550_01_LATIOS_S.webp",
     "name": "Latios",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24507,7 +27235,8 @@
     "image": "cPK_20_001540_00_SAWAMULAR_S.webp",
     "name": "Hitmonlee",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24516,7 +27245,8 @@
     "image": "cPK_20_001550_00_EBIWALAR_S.webp",
     "name": "Hitmonchan",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24525,7 +27255,8 @@
     "image": "cPK_20_001580_00_KABUTO_S.webp",
     "name": "Kabuto",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24534,7 +27265,8 @@
     "image": "cPK_20_001590_00_KABUTOPS_S.webp",
     "name": "Kabutops",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24543,7 +27275,8 @@
     "image": "cPK_20_009550_00_GOMAZOU_S.webp",
     "name": "Phanpy",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24552,7 +27285,8 @@
     "image": "cPK_20_009570_00_BALKIE_S.webp",
     "name": "Tyrogue",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24561,7 +27295,8 @@
     "image": "cPK_20_002730_00_KENTAUROS_S.webp",
     "name": "Tauros",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24570,7 +27305,8 @@
     "image": "cPK_20_008050_02_BOOSTERex_SSR.webp",
     "name": "Flareon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24579,7 +27315,8 @@
     "image": "cPK_20_008900_04_HOUOUex_SSR.webp",
     "name": "Ho-Oh ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24588,7 +27325,8 @@
     "image": "cPK_20_008990_02_KINGDRAex_SSR.webp",
     "name": "Kingdra ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24597,7 +27335,8 @@
     "image": "cPK_20_009390_02_EIFIEex_SSR.webp",
     "name": "Espeon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24606,7 +27345,8 @@
     "image": "cPK_20_008280_02_NYMPHIAex_SSR.webp",
     "name": "Sylveon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24615,7 +27355,8 @@
     "image": "cPK_20_009560_02_DONFANex_SSR.webp",
     "name": "Donphan ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24624,7 +27365,8 @@
     "image": "cPK_20_009680_02_BRACKYex_SSR.webp",
     "name": "Umbreon ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24633,7 +27375,8 @@
     "image": "cPK_20_010050_04_LUGIAex_SSR.webp",
     "name": "Lugia ex",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2",
@@ -24642,7 +27385,8 @@
     "image": "cPK_20_014360_00_MELOETTA_UR.webp",
     "name": "Meloetta",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2",
@@ -24651,7 +27395,8 @@
     "image": "cTR_20_001080_00_MAMORINOPONCHO_UR.webp",
     "name": "Protective Poncho",
     "packs": ["Gardevoir"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24659,7 +27404,8 @@
     "rarity": "AR",
     "name": "Pikachu",
     "image": "cPK_90_004490_00_PIKACHU_AR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24668,7 +27414,8 @@
     "name": "Petilil",
     "image": "cPK_90_012930_00_CHURINE_C.webp",
     "packs": ["B Series Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24677,7 +27424,8 @@
     "name": "Froakie",
     "image": "cPK_90_012940_00_KEROMATSU_C.webp",
     "packs": ["B Series Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24686,7 +27434,8 @@
     "name": "Luxray",
     "image": "cPK_90_011700_00_RENTORAR_R.webp",
     "packs": ["B Series Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24695,7 +27444,8 @@
     "name": "Pidgey",
     "image": "cPK_90_012620_00_POPPO_C.webp",
     "packs": ["B Series Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24704,7 +27454,8 @@
     "name": "Mega Pidgeot ex",
     "image": "cPK_90_012950_00_MEGAPIGEOTex_RR.webp",
     "packs": ["B Series Vol. 1"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24712,7 +27463,8 @@
     "rarity": "R",
     "name": "Torchic",
     "image": "cPK_90_011150_00_ACHAMO_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24720,7 +27472,8 @@
     "rarity": "R",
     "name": "Psyduck",
     "image": "cPK_90_011300_00_KODUCK_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24728,7 +27481,8 @@
     "rarity": "RR",
     "name": "Mega Absol ex",
     "image": "cPK_90_012330_00_MEGAABSOLex_RR.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24736,7 +27490,8 @@
     "rarity": "R",
     "name": "Drifblim",
     "image": "cPK_90_011900_00_FUWARIDE_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24744,7 +27499,8 @@
     "rarity": "R",
     "name": "Eevee",
     "image": "cPK_90_012660_00_EIEVUI_R.webp",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24752,7 +27508,8 @@
     "rarity": "AR",
     "image": "cPK_90_013060_00_METAMON_AR.webp",
     "name": "Ditto",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24761,7 +27518,8 @@
     "image": "cPK_90_011110_00_WINDIE_C.webp",
     "name": "Arcanine",
     "packs": ["B Series Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24770,7 +27528,8 @@
     "image": "cPK_90_012960_00_KOIKING_C.webp",
     "name": "Magikarp",
     "packs": ["B Series Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24779,7 +27538,8 @@
     "image": "cPK_90_011640_00_MERRIEP_AR.webp",
     "name": "Mareep",
     "packs": ["B Series Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24788,7 +27548,8 @@
     "image": "cPK_90_012140_00_WARUVIAL_R.webp",
     "name": "Krookodile",
     "packs": ["B Series Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24797,7 +27558,8 @@
     "image": "cPK_90_012970_00_TYLTTO_C.webp",
     "name": "Swablu",
     "packs": ["B Series Vol. 2"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24805,7 +27567,8 @@
     "rarity": "R",
     "image": "cPK_90_013030_00_ELEZARD_R.webp",
     "name": "Heliolisk",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24813,7 +27576,8 @@
     "rarity": "R",
     "image": "cPK_90_013040_00_MIMIROL_R.webp",
     "name": "Buneary",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24822,7 +27586,8 @@
     "image": "cPK_90_012980_00_LIZARDO_C.webp",
     "name": "Charmeleon",
     "packs": ["B Series Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24831,7 +27596,8 @@
     "image": "cPK_90_012990_00_IWARK_C.webp",
     "name": "Onix",
     "packs": ["B Series Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24840,7 +27606,8 @@
     "image": "cPK_90_013000_00_LUCHABULL_C.webp",
     "name": "Hawlucha",
     "packs": ["B Series Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24849,7 +27616,8 @@
     "image": "cPK_90_013010_00_GENESECT_R.webp",
     "name": "Genesect",
     "packs": ["B Series Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24858,7 +27626,8 @@
     "image": "cPK_90_013020_00_MEGALATIOSex_RR.webp",
     "name": "Mega Latios ex",
     "packs": ["B Series Vol. 3"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24866,7 +27635,8 @@
     "rarity": "AR",
     "image": "cPK_90_011880_00_JIRACHI_AR.webp",
     "name": "Jirachi",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24875,7 +27645,8 @@
     "image": "cPK_90_015950_00_MIZUGOROU_C.webp",
     "name": "Mudkip",
     "packs": ["B Series Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24884,7 +27655,8 @@
     "image": "cPK_90_014180_00_PRASLE_C.webp",
     "name": "Plusle",
     "packs": ["B Series Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24893,7 +27665,8 @@
     "image": "cPK_90_015960_00_RALTS_C.webp",
     "name": "Ralts",
     "packs": ["B Series Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24902,7 +27675,8 @@
     "image": "cPK_90_015970_00_MEGACHAREMex_RR.webp",
     "name": "Mega Medicham ex",
     "packs": ["B Series Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24911,7 +27685,8 @@
     "image": "cPK_90_015040_00_TORNELOS_R.webp",
     "name": "Tornadus",
     "packs": ["B Series Vol. 4"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24919,7 +27694,8 @@
     "rarity": "R",
     "image": "cPK_90_013920_00_ACEBURN_R.webp",
     "name": "Cinderace",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24927,7 +27703,8 @@
     "rarity": "R",
     "image": "cPK_90_013940_00_ALOLAROKON_R.webp",
     "name": "Alolan Vulpix",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24935,7 +27712,8 @@
     "rarity": "AR",
     "image": "cPK_90_015310_00_KUWASSU_AR.webp",
     "name": "Quaxly",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24944,7 +27722,8 @@
     "image": "cPK_90_015980_00_MINIVE_C.webp",
     "name": "Smoliv",
     "packs": ["B Series Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24953,7 +27732,8 @@
     "image": "cPK_90_015280_00_CARBOU_AR.webp",
     "name": "Charcadet",
     "packs": ["B Series Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24962,7 +27742,8 @@
     "image": "cPK_90_015420_00_SYARITATSU_C.webp",
     "name": "Tatsugiri",
     "packs": ["B Series Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24971,7 +27752,8 @@
     "image": "cPK_90_015990_00_SEBIE_C.webp",
     "name": "Frigibax",
     "packs": ["B Series Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24980,7 +27762,8 @@
     "image": "cPK_90_015830_00_DEKANUCHAN_R.webp",
     "name": "Tinkaton",
     "packs": ["B Series Vol. 5"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24988,7 +27771,8 @@
     "rarity": "R",
     "image": "cPK_90_015470_00_PAMO_R.webp",
     "name": "Pawmi",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -24996,7 +27780,8 @@
     "rarity": "R",
     "image": "cPK_90_015740_00_PALDEADOOH_R.webp",
     "name": "Paldean Clodsire",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25004,7 +27789,8 @@
     "rarity": "RR",
     "image": "cPK_90_015460_00_PAOJIANex_RR.webp",
     "name": "Chien-Pao ex",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25013,7 +27799,8 @@
     "image": "cPK_90_016000_00_YADON_AR.webp",
     "name": "Slowpoke",
     "packs": ["B Series Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25022,7 +27809,8 @@
     "image": "cPK_90_016010_00_RAKURAI_C.webp",
     "name": "Electrike",
     "packs": ["B Series Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25031,7 +27819,8 @@
     "image": "cPK_90_016020_00_BURORON_C.webp",
     "name": "Varoom",
     "packs": ["B Series Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25040,7 +27829,8 @@
     "image": "cPK_90_016030_00_ONONOKUS_R.webp",
     "name": "Haxorus",
     "packs": ["B Series Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25049,7 +27839,8 @@
     "image": "cPK_90_016040_00_PERAP_C.webp",
     "name": "Chatot",
     "packs": ["B Series Vol. 6"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25057,7 +27848,8 @@
     "rarity": "R",
     "image": "cPK_90_016050_00_GHOS_R.webp",
     "name": "Gastly",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25065,7 +27857,8 @@
     "rarity": "R",
     "image": "cPK_90_016060_00_PUKURIN_R.webp",
     "name": "Wigglytuff",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25073,7 +27866,8 @@
     "rarity": "AR",
     "image": "cPK_90_016900_00_VICTINI_AR.webp",
     "name": "Victini",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25082,7 +27876,8 @@
     "image": "cPK_90_014360_00_MELOETTA_U.webp",
     "name": "Meloetta",
     "packs": ["B Series Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25091,7 +27886,8 @@
     "image": "cPK_90_018860_00_ZYGARDE10%EF%BC%85FORME_C.webp",
     "name": "Zygarde",
     "packs": ["B Series Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25100,7 +27896,8 @@
     "image": "cPK_90_018870_00_ZYGARDE50%EF%BC%85FORME_R.webp",
     "name": "Zygarde",
     "packs": ["B Series Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25109,7 +27906,8 @@
     "image": "cPK_90_018880_00_ZYGARDEPERFECTFORMEex_RR.webp",
     "name": "Zygarde ex",
     "packs": ["B Series Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25118,7 +27916,8 @@
     "image": "cPK_90_012660_01_EIEVUI_C.webp",
     "name": "Eevee",
     "packs": ["B Series Vol. 7"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25126,7 +27925,8 @@
     "rarity": "SR",
     "image": "cPK_90_018880_01_ZYGARDEPERFECTFORMEex_SR.webp",
     "name": "Zygarde ex",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25135,7 +27935,8 @@
     "image": "cPK_90_018900_00_MEGAHERACROSex_RR.webp",
     "name": "Mega Heracross ex",
     "packs": ["B Series Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25144,7 +27945,8 @@
     "image": "cPK_90_016890_00_POWALENTAIYOUNOSUGATA_C.webp",
     "name": "Castform Sunny Form",
     "packs": ["B Series Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25153,7 +27955,8 @@
     "image": "cPK_90_018910_00_POKABU_C.webp",
     "name": "Tepig",
     "packs": ["B Series Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25162,7 +27965,8 @@
     "image": "cPK_90_018920_00_ISHIZUMAI_C.webp",
     "name": "Dwebble",
     "packs": ["B Series Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25171,7 +27975,8 @@
     "image": "cPK_90_017790_00_ZARUDE_R.webp",
     "name": "Zarude",
     "packs": ["B Series Vol. 8"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25179,7 +27984,8 @@
     "rarity": "R",
     "image": "cPK_90_016700_00_KIMORI_R.webp",
     "name": "Treecko",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25187,7 +27993,8 @@
     "rarity": "R",
     "image": "cPK_90_017490_00_ERUREIDO_R.webp",
     "name": "Gallade",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25195,7 +28002,8 @@
     "rarity": "RR",
     "image": "cPK_90_015120_00_MASQUERNYAex_RR.webp",
     "name": "Meowscarada ex",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25204,7 +28012,8 @@
     "image": "cPK_90_018930_00_CARBOU_C.webp",
     "name": "Charcadet",
     "packs": ["B Series Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25213,7 +28022,8 @@
     "image": "cPK_90_018230_00_SHOWERS_C.webp",
     "name": "Vaporeon",
     "packs": ["B Series Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25222,7 +28032,8 @@
     "image": "cPK_90_018940_00_SOUBLADESex_RR.webp",
     "name": "Ceruledge ex",
     "packs": ["B Series Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25231,7 +28042,8 @@
     "image": "cPK_90_018950_00_KOMATANA_C.webp",
     "name": "Pawniard",
     "packs": ["B Series Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25240,7 +28052,8 @@
     "image": "cPK_90_018750_00_NOKOKOCCHI_R.webp",
     "name": "Dudunsparce",
     "packs": ["B Series Vol. 9"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25248,7 +28061,8 @@
     "rarity": "R",
     "image": "cPK_90_015110_00_NYAROTE_R.webp",
     "name": "Floragato",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25256,7 +28070,8 @@
     "rarity": "R",
     "image": "cPK_90_018550_00_YAMIRAMI_R.webp",
     "name": "Sableye",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25264,7 +28079,8 @@
     "rarity": "AR",
     "image": "cPK_90_019030_00_KODUCK_AR.webp",
     "name": "Psyduck",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25273,7 +28089,8 @@
     "image": "cPK_90_018960_00_HINBASS_C.webp",
     "name": "Feebas",
     "packs": ["B Series Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25282,7 +28099,8 @@
     "image": "cPK_90_018970_00_YUKIMENOKO_R.webp",
     "name": "Froslass",
     "packs": ["B Series Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25291,7 +28109,8 @@
     "image": "cPK_90_018980_00_RAICHU_U.webp",
     "name": "Raichu",
     "packs": ["B Series Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25300,7 +28119,8 @@
     "image": "cPK_90_018990_00_NUOH_C.webp",
     "name": "Quagsire",
     "packs": ["B Series Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25309,7 +28129,8 @@
     "image": "cPK_90_019000_00_HISUIZORUA_AR.webp",
     "name": "Hisuian Zorua",
     "packs": ["B Series Vol. 10"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25317,7 +28138,8 @@
     "rarity": "R",
     "image": "cPK_90_019010_00_GARDIE_R.webp",
     "name": "Growlithe",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "PROMO-B",
@@ -25325,7 +28147,8 @@
     "rarity": "R",
     "image": "cPK_90_019020_00_EMOLGA_R.webp",
     "name": "Emolga",
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25334,7 +28157,8 @@
     "image": "cPK_10_015100_00_NYAHOJA_C.webp",
     "name": "Sprigatito",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25343,7 +28167,8 @@
     "image": "cPK_10_015110_00_NYAROTE_C.webp",
     "name": "Floragato",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25352,7 +28177,8 @@
     "image": "cPK_10_015120_00_MASQUERNYAex_RR.webp",
     "name": "Meowscarada ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25361,7 +28187,8 @@
     "image": "cPK_10_015130_00_TAMANTULA_C.webp",
     "name": "Tarountula",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25370,7 +28197,8 @@
     "image": "cPK_10_015140_00_WANAIDER_U.webp",
     "name": "Spidops",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25379,7 +28207,8 @@
     "image": "cPK_10_015150_00_MAMEBATTA_C.webp",
     "name": "Nymble",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25388,7 +28217,8 @@
     "image": "cPK_10_015160_00_MINIVE_C.webp",
     "name": "Smoliv",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25397,7 +28227,8 @@
     "image": "cPK_10_015170_00_OLINYO_C.webp",
     "name": "Dolliv",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25406,7 +28237,8 @@
     "image": "cPK_10_015180_00_OLIVA_R.webp",
     "name": "Arboliva",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25415,7 +28247,8 @@
     "image": "cPK_10_015190_00_ANOKUSA_C.webp",
     "name": "Bramblin",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25424,7 +28257,8 @@
     "image": "cPK_10_015200_00_ANOHORAGUSA_U.webp",
     "name": "Brambleghast",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25433,7 +28267,8 @@
     "image": "cPK_10_015210_00_CAPSAIJI_C.webp",
     "name": "Capsakid",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25442,7 +28277,8 @@
     "image": "cPK_10_015220_00_SCOVILLAIN_U.webp",
     "name": "Scovillain",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25451,7 +28287,8 @@
     "image": "cPK_10_015230_00_SHIGAROKO_C.webp",
     "name": "Rellor",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25460,7 +28297,8 @@
     "image": "cPK_10_015240_00_CHIONJEN_R.webp",
     "name": "Wo-Chien",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25469,7 +28307,8 @@
     "image": "cPK_10_015250_00_HOGATOR_C.webp",
     "name": "Fuecoco",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25478,7 +28317,8 @@
     "image": "cPK_10_015260_00_ACHIGATOR_C.webp",
     "name": "Crocalor",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25487,7 +28327,8 @@
     "image": "cPK_10_015270_00_LAUDBON_R.webp",
     "name": "Skeledirge",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25496,7 +28337,8 @@
     "image": "cPK_10_015280_00_CARBOU_C.webp",
     "name": "Charcadet",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25505,7 +28347,8 @@
     "image": "cPK_10_015290_00_GURENARMAex_RR.webp",
     "name": "Armarouge ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25514,7 +28357,8 @@
     "image": "cPK_10_015300_00_YIYUI_R.webp",
     "name": "Chi-Yu",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25523,7 +28367,8 @@
     "image": "cPK_10_015310_00_KUWASSU_C.webp",
     "name": "Quaxly",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25532,7 +28377,8 @@
     "image": "cPK_10_015320_00_WELKAMO_C.webp",
     "name": "Quaxwell",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25541,7 +28387,8 @@
     "image": "cPK_10_015330_00_WANIVAL_R.webp",
     "name": "Quaquaval",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25550,7 +28397,8 @@
     "image": "cPK_10_015340_00_UMIDIGDA_C.webp",
     "name": "Wiglett",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25559,7 +28407,8 @@
     "image": "cPK_10_015350_00_UMITRIO_U.webp",
     "name": "Wugtrio",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25568,7 +28417,8 @@
     "image": "cPK_10_015360_00_NAMIIRUKA_C.webp",
     "name": "Finizen",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25577,7 +28427,8 @@
     "image": "cPK_10_015370_00_IRUKAMANMIGHTYFORME_R.webp",
     "name": "Palafin",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25586,7 +28437,8 @@
     "image": "cPK_10_015380_00_ARUKUJIRA_C.webp",
     "name": "Cetoddle",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25595,7 +28447,8 @@
     "image": "cPK_10_015390_00_HULKUJIRA_U.webp",
     "name": "Cetitan",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25604,7 +28457,8 @@
     "image": "cPK_10_015400_00_MIGALUSA_U.webp",
     "name": "Veluza",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25613,7 +28467,8 @@
     "image": "cPK_10_015410_00_HEYRUSHER_U.webp",
     "name": "Dondozo",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25622,7 +28477,8 @@
     "image": "cPK_10_015420_00_SYARITATSU_U.webp",
     "name": "Tatsugiri",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25631,7 +28487,8 @@
     "image": "cPK_10_015430_00_SEBIE_C.webp",
     "name": "Frigibax",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25640,7 +28497,8 @@
     "image": "cPK_10_015440_00_SEGOHRU_C.webp",
     "name": "Arctibax",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25649,7 +28507,8 @@
     "image": "cPK_10_015450_00_SEGLAIVE_R.webp",
     "name": "Baxcalibur",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25658,7 +28517,8 @@
     "image": "cPK_10_015460_00_PAOJIANex_RR.webp",
     "name": "Chien-Pao ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25667,7 +28527,8 @@
     "image": "cPK_10_015470_00_PAMO_C.webp",
     "name": "Pawmi",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25676,7 +28537,8 @@
     "image": "cPK_10_015480_00_PAMOT_C.webp",
     "name": "Pawmo",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25685,7 +28547,8 @@
     "image": "cPK_10_015490_00_PARMOT_U.webp",
     "name": "Pawmot",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25694,7 +28557,8 @@
     "image": "cPK_10_015500_00_ZUPIKA_C.webp",
     "name": "Tadbulb",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25703,7 +28567,8 @@
     "image": "cPK_10_015510_00_HARABARIEex_RR.webp",
     "name": "Bellibolt ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25712,7 +28577,8 @@
     "image": "cPK_10_015520_00_KAIDEN_C.webp",
     "name": "Wattrel",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25721,7 +28587,8 @@
     "image": "cPK_10_015530_00_TAIKAIDEN_U.webp",
     "name": "Kilowattrel",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25730,7 +28597,8 @@
     "image": "cPK_10_015540_00_MIRAIDONCOMPLETEMODE_R.webp",
     "name": "Miraidon",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25739,7 +28607,8 @@
     "image": "cPK_10_015550_00_PUPIMOCCHI_C.webp",
     "name": "Fidough",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25748,7 +28617,8 @@
     "image": "cPK_10_015560_00_BOWTZEL_U.webp",
     "name": "Dachsbun",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25757,7 +28627,8 @@
     "image": "cPK_10_015570_00_SOUBLADES_R.webp",
     "name": "Ceruledge",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25766,7 +28637,8 @@
     "image": "cPK_10_015580_00_BERACAS_U.webp",
     "name": "Rabsca",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25775,7 +28647,8 @@
     "image": "cPK_10_015590_00_HIRAHINA_C.webp",
     "name": "Flittle",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25784,7 +28657,8 @@
     "image": "cPK_10_015600_00_CUESPATRA_U.webp",
     "name": "Espathra",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25793,7 +28667,8 @@
     "image": "cPK_10_015610_00_BOCHI_C.webp",
     "name": "Greavard",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25802,7 +28677,8 @@
     "image": "cPK_10_015620_00_HAKADOG_U.webp",
     "name": "Houndstone",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25811,7 +28687,8 @@
     "image": "cPK_10_015630_00_COLLECUREI_C.webp",
     "name": "Gimmighoul",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25820,7 +28697,8 @@
     "image": "cPK_10_015640_00_MANKEY_C.webp",
     "name": "Mankey",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25829,7 +28707,8 @@
     "image": "cPK_10_015650_00_OKORIZARU_C.webp",
     "name": "Primeape",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25838,7 +28717,8 @@
     "image": "cPK_10_015660_00_KONOYOZARU_U.webp",
     "name": "Annihilape",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25847,7 +28727,8 @@
     "image": "cPK_10_015670_00_PALDEAKENTAUROS_U.webp",
     "name": "Paldean Tauros",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25856,7 +28737,8 @@
     "image": "cPK_10_015680_00_NONOKURAGE_C.webp",
     "name": "Toedscool",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25865,7 +28747,8 @@
     "image": "cPK_10_015690_00_RIKUKURAGE_U.webp",
     "name": "Toedscruel",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25874,7 +28757,8 @@
     "image": "cPK_10_015700_00_GAKEGANI_C.webp",
     "name": "Klawf",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25883,7 +28767,8 @@
     "image": "cPK_10_015710_00_DINLU_R.webp",
     "name": "Ting-Lu",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25892,7 +28777,8 @@
     "image": "cPK_10_015720_00_KORAIDON_R.webp",
     "name": "Koraidon",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25901,7 +28787,8 @@
     "image": "cPK_10_015730_00_PALDEAUPAH_C.webp",
     "name": "Paldean Wooper",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25910,7 +28797,8 @@
     "image": "cPK_10_015740_00_PALDEADOOH_U.webp",
     "name": "Paldean Clodsire",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25919,7 +28807,8 @@
     "image": "cPK_10_015750_00_EXLEG_U.webp",
     "name": "Lokix",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25928,7 +28817,8 @@
     "image": "cPK_10_015760_00_ORACHIFU_C.webp",
     "name": "Maschiff",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25937,7 +28827,8 @@
     "image": "cPK_10_015770_00_MAFITIFF_U.webp",
     "name": "Mabosstiff",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25946,7 +28837,8 @@
     "image": "cPK_10_015780_00_SHIRUSHREW_C.webp",
     "name": "Shroodle",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25955,7 +28847,8 @@
     "image": "cPK_10_015790_00_TAGGINGRU_U.webp",
     "name": "Grafaiai",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25964,7 +28857,8 @@
     "image": "cPK_10_015800_00_OTOSHIDORI_C.webp",
     "name": "Bombirdier",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25973,7 +28867,8 @@
     "image": "cPK_10_015810_00_KANUCHAN_C.webp",
     "name": "Tinkatink",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25982,7 +28877,8 @@
     "image": "cPK_10_015820_00_NAKANUCHAN_C.webp",
     "name": "Tinkatuff",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -25991,7 +28887,8 @@
     "image": "cPK_10_015830_00_DEKANUCHAN_R.webp",
     "name": "Tinkaton",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26000,7 +28897,8 @@
     "image": "cPK_10_015840_00_BURORON_C.webp",
     "name": "Varoom",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26009,7 +28907,8 @@
     "image": "cPK_10_015850_00_BUROROROOM_U.webp",
     "name": "Revavroom",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26018,7 +28917,8 @@
     "image": "cPK_10_015860_00_MIMIZUZU_U.webp",
     "name": "Orthworm",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26027,7 +28927,8 @@
     "image": "cPK_10_015870_00_SURFUGOex_RR.webp",
     "name": "Gholdengo ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26036,7 +28937,8 @@
     "image": "cPK_10_015880_00_GOURTON_C.webp",
     "name": "Lechonk",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26045,7 +28947,8 @@
     "image": "cPK_10_015890_00_PERFUTONOSUNOSUGATA_C.webp",
     "name": "Oinkologne",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26054,7 +28957,8 @@
     "image": "cPK_10_015900_00_WAKKANEZUMI_C.webp",
     "name": "Tandemaus",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26063,7 +28967,8 @@
     "image": "cPK_10_015910_00_IKKANEZUMISANBIKIKAZOKU_U.webp",
     "name": "Maushold",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26072,7 +28977,8 @@
     "image": "cPK_10_015920_00_IKIRINKOGREENFEATHER_C.webp",
     "name": "Squawkabilly",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26081,7 +28987,8 @@
     "image": "cPK_10_015930_00_MOTOTOKAGE_U.webp",
     "name": "Cyclizar",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26090,7 +28997,8 @@
     "image": "cPK_10_015940_00_KARAMINGO_C.webp",
     "name": "Flamigo",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26099,7 +29007,8 @@
     "image": "cTR_10_001170_00_ELECTRICGENERATOR_U.webp",
     "name": "Electric Generator",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26108,7 +29017,8 @@
     "image": "cTR_10_001180_00_BIGAIRBALLOON_U.webp",
     "name": "Big Air Balloon",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26117,7 +29027,8 @@
     "image": "cTR_10_001190_00_TEAMSTARGRUNT_U.webp",
     "name": "Team Star Grunt",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26126,7 +29037,8 @@
     "image": "cTR_10_000420_02_NANJYAMO_U.webp",
     "name": "Iono",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26135,7 +29047,8 @@
     "image": "cTR_10_001200_00_NEMO_U.webp",
     "name": "Nemona",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26144,7 +29057,8 @@
     "image": "cTR_10_001210_00_PEPER_U.webp",
     "name": "Arven",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26153,7 +29067,8 @@
     "image": "cTR_10_000700_01_BOTAN_U.webp",
     "name": "Penny",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26162,7 +29077,8 @@
     "image": "cTR_10_001220_00_TABLECITY_U.webp",
     "name": "Mesagoza",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26171,7 +29087,8 @@
     "image": "cPK_20_015250_00_HOGATOR_AR.webp",
     "name": "Fuecoco",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26180,7 +29097,8 @@
     "image": "cPK_20_015610_00_BOCHI_AR.webp",
     "name": "Greavard",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26189,7 +29107,8 @@
     "image": "cPK_20_015630_00_COLLECUREI_AR.webp",
     "name": "Gimmighoul",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26198,7 +29117,8 @@
     "image": "cPK_20_015730_00_PALDEAUPAH_AR.webp",
     "name": "Paldean Wooper",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26207,7 +29127,8 @@
     "image": "cPK_20_015860_00_MIMIZUZU_AR.webp",
     "name": "Orthworm",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26216,7 +29137,8 @@
     "image": "cPK_20_015910_00_IKKANEZUMISANBIKIKAZOKU_AR.webp",
     "name": "Maushold",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26225,7 +29147,8 @@
     "image": "cPK_20_015120_00_MASQUERNYAex_SR.webp",
     "name": "Meowscarada ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26234,7 +29157,8 @@
     "image": "cPK_20_015290_00_GURENARMAex_SR.webp",
     "name": "Armarouge ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26243,7 +29167,8 @@
     "image": "cPK_20_015460_00_PAOJIANex_SR.webp",
     "name": "Chien-Pao ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26252,7 +29177,8 @@
     "image": "cPK_20_015510_00_HARABARIEex_SR.webp",
     "name": "Bellibolt ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26261,7 +29187,8 @@
     "image": "cPK_20_015870_00_SURFUGOex_SR.webp",
     "name": "Gholdengo ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26270,7 +29197,8 @@
     "image": "cTR_20_001190_00_TEAMSTARGRUNT_SR.webp",
     "name": "Team Star Grunt",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26279,7 +29207,8 @@
     "image": "cTR_20_000420_01_NANJYAMO_SR.webp",
     "name": "Iono",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26288,7 +29217,8 @@
     "image": "cTR_20_001200_00_NEMO_SR.webp",
     "name": "Nemona",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26297,7 +29227,8 @@
     "image": "cTR_20_001210_00_PEPER_SR.webp",
     "name": "Arven",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26306,7 +29237,8 @@
     "image": "cTR_20_000700_01_BOTAN_SR.webp",
     "name": "Penny",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26315,7 +29247,8 @@
     "image": "cPK_20_015120_01_MASQUERNYAex_SAR.webp",
     "name": "Meowscarada ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26324,7 +29257,8 @@
     "image": "cPK_20_015290_01_GURENARMAex_SAR.webp",
     "name": "Armarouge ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26333,7 +29267,8 @@
     "image": "cPK_20_015460_01_PAOJIANex_SAR.webp",
     "name": "Chien-Pao ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26342,7 +29277,8 @@
     "image": "cPK_20_015510_01_HARABARIEex_SAR.webp",
     "name": "Bellibolt ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26351,7 +29287,8 @@
     "image": "cPK_20_015870_01_SURFUGOex_SAR.webp",
     "name": "Gholdengo ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26360,7 +29297,8 @@
     "image": "cTR_20_001210_01_PEPER_IM.webp",
     "name": "Arven",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26369,7 +29307,8 @@
     "image": "cPK_20_015100_00_NYAHOJA_S.webp",
     "name": "Sprigatito",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26378,7 +29317,8 @@
     "image": "cPK_20_015110_00_NYAROTE_S.webp",
     "name": "Floragato",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26387,7 +29327,8 @@
     "image": "cPK_20_005260_01_MASQUERNYA_S.webp",
     "name": "Meowscarada",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26396,7 +29337,8 @@
     "image": "cPK_20_015470_00_PAMO_S.webp",
     "name": "Pawmi",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26405,7 +29347,8 @@
     "image": "cPK_20_015480_00_PAMOT_S.webp",
     "name": "Pawmo",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26414,7 +29357,8 @@
     "image": "cPK_20_015490_00_PARMOT_S.webp",
     "name": "Pawmot",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26423,7 +29367,8 @@
     "image": "cPK_20_015630_01_COLLECUREI_S.webp",
     "name": "Gimmighoul",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26432,7 +29377,8 @@
     "image": "cPK_20_015810_00_KANUCHAN_S.webp",
     "name": "Tinkatink",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26441,7 +29387,8 @@
     "image": "cPK_20_015820_00_NAKANUCHAN_S.webp",
     "name": "Tinkatuff",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26450,7 +29397,8 @@
     "image": "cPK_20_005720_01_SURFUGO_S.webp",
     "name": "Gholdengo",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26459,7 +29407,8 @@
     "image": "cPK_20_010210_02_ENTEIex_SSR.webp",
     "name": "Entei ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26468,7 +29417,8 @@
     "image": "cPK_20_010400_02_SUICUNEex_SSR.webp",
     "name": "Suicune ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26477,7 +29427,8 @@
     "image": "cPK_20_010440_02_RAIKOUex_SSR.webp",
     "name": "Raikou ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26486,7 +29437,8 @@
     "image": "cPK_20_005690_02_DEKANUCHANex_SSR.webp",
     "name": "Tinkaton ex",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2a",
@@ -26495,7 +29447,8 @@
     "image": "cPK_20_015450_00_SEGLAIVE_UR.webp",
     "name": "Baxcalibur",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2a",
@@ -26504,7 +29457,8 @@
     "image": "cTR_20_001170_00_ELECTRICGENERATOR_UR.webp",
     "name": "Electric Generator",
     "packs": ["Paldean"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26513,7 +29467,8 @@
     "image": "cPK_10_016070_00_STRIKE_C.webp",
     "name": "Scyther",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26522,7 +29477,8 @@
     "image": "cPK_10_016080_00_KUNUGIDAMA_C.webp",
     "name": "Pineco",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26531,7 +29487,8 @@
     "image": "cPK_10_016090_00_BARUBEAT_C.webp",
     "name": "Volbeat",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26540,7 +29497,8 @@
     "image": "cPK_10_016100_00_ILLUMISE_C.webp",
     "name": "Illumise",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26549,7 +29507,8 @@
     "image": "cPK_10_016110_00_BOKUREI_C.webp",
     "name": "Phantump",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26558,7 +29517,8 @@
     "image": "cPK_10_016120_00_OHROT_U.webp",
     "name": "Trevenant",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26567,7 +29527,8 @@
     "image": "cPK_10_016130_00_HITOKAGE_C.webp",
     "name": "Charmander",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26576,7 +29537,8 @@
     "image": "cPK_10_016140_00_LIZARDO_U.webp",
     "name": "Charmeleon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26585,7 +29547,8 @@
     "image": "cPK_10_016150_00_MEGALIZARDONXex_RR.webp",
     "name": "Mega Charizard X ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26594,7 +29557,8 @@
     "image": "cPK_10_016160_00_PONYTA_C.webp",
     "name": "Ponyta",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26603,7 +29567,8 @@
     "image": "cPK_10_016170_00_GALLOP_C.webp",
     "name": "Rapidash",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26612,7 +29577,8 @@
     "image": "cPK_10_016180_00_BOOBER_C.webp",
     "name": "Magmar",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26621,7 +29587,8 @@
     "image": "cPK_10_016190_00_BOOBURN_U.webp",
     "name": "Magmortar",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26630,7 +29597,8 @@
     "image": "cPK_10_016200_00_PALDEAKENTAUROS_C.webp",
     "name": "Paldean Tauros",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26639,7 +29607,8 @@
     "image": "cPK_10_016000_00_YADON_C.webp",
     "name": "Slowpoke",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26648,7 +29617,8 @@
     "image": "cPK_10_016210_00_MEGAYADORANex_RR.webp",
     "name": "Mega Slowbro ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26657,7 +29627,8 @@
     "image": "cPK_10_016220_00_LAPLACE_U.webp",
     "name": "Lapras",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26666,7 +29637,8 @@
     "image": "cPK_10_016230_00_POCHAMA_C.webp",
     "name": "Piplup",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26675,7 +29647,8 @@
     "image": "cPK_10_016240_00_POTTAISHI_U.webp",
     "name": "Prinplup",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26684,7 +29657,8 @@
     "image": "cPK_10_016250_00_EMPERTE_R.webp",
     "name": "Empoleon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26693,7 +29667,8 @@
     "image": "cPK_10_016260_00_PHIONE_U.webp",
     "name": "Phione",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26702,7 +29677,8 @@
     "image": "cPK_10_016270_00_PIKACHU_C.webp",
     "name": "Pikachu",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26711,7 +29687,8 @@
     "image": "cPK_10_016280_00_RAICHU_U.webp",
     "name": "Raichu",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26720,7 +29697,8 @@
     "image": "cPK_10_016290_00_ELEBOO_C.webp",
     "name": "Electabuzz",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26729,7 +29707,8 @@
     "image": "cPK_10_016300_00_ELEKIBLE_U.webp",
     "name": "Electivire",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26738,7 +29717,8 @@
     "image": "cPK_10_016310_00_RAKURAI_C.webp",
     "name": "Electrike",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26747,7 +29727,8 @@
     "image": "cPK_10_016320_00_MEGALIVOLTex_RR.webp",
     "name": "Mega Manectric ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26756,7 +29737,8 @@
     "image": "cPK_10_016330_00_SLEEPE_C.webp",
     "name": "Drowzee",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26765,7 +29747,8 @@
     "image": "cPK_10_016340_00_SLEEPER_U.webp",
     "name": "Hypno",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26774,7 +29757,8 @@
     "image": "cPK_10_016350_00_MEW_R.webp",
     "name": "Mew",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26783,7 +29767,8 @@
     "image": "cPK_10_016360_00_BANEBOO_C.webp",
     "name": "Spoink",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26792,7 +29777,8 @@
     "image": "cPK_10_016370_00_BOOPIG_U.webp",
     "name": "Grumpig",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26801,7 +29787,8 @@
     "image": "cPK_10_016380_00_DIGDA_C.webp",
     "name": "Diglett",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26810,7 +29797,8 @@
     "image": "cPK_10_016390_00_DUGTRIO_U.webp",
     "name": "Dugtrio",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26819,7 +29807,8 @@
     "image": "cPK_10_016400_00_GROUDON_R.webp",
     "name": "Groudon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26828,7 +29817,8 @@
     "image": "cPK_10_016410_00_LUCHABULL_C.webp",
     "name": "Hawlucha",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26837,7 +29827,8 @@
     "image": "cPK_10_016050_00_GHOS_C.webp",
     "name": "Gastly",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26846,7 +29837,8 @@
     "image": "cPK_10_016420_00_GHOST_U.webp",
     "name": "Haunter",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26855,7 +29847,8 @@
     "image": "cPK_10_016430_00_MEGAGANGARex_RR.webp",
     "name": "Mega Gengar ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26864,7 +29857,8 @@
     "image": "cPK_10_016440_00_DARKRAI_R.webp",
     "name": "Darkrai",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26873,7 +29867,8 @@
     "image": "cPK_10_016450_00_YABUKURON_C.webp",
     "name": "Trubbish",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26882,7 +29877,8 @@
     "image": "cPK_10_016460_00_DUSTDAS_C.webp",
     "name": "Garbodor",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26891,7 +29887,8 @@
     "image": "cPK_10_016470_00_ZORUA_C.webp",
     "name": "Zorua",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26900,7 +29897,8 @@
     "image": "cPK_10_016480_00_ZOROARK_R.webp",
     "name": "Zoroark",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26909,7 +29907,8 @@
     "image": "cPK_10_016490_00_MORPEKO_C.webp",
     "name": "Morpeko",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26918,7 +29917,8 @@
     "image": "cPK_10_016500_00_FORETOS_U.webp",
     "name": "Forretress",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26927,7 +29927,8 @@
     "image": "cPK_10_016510_00_MEGAHASSAMex_RR.webp",
     "name": "Mega Scizor ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26936,7 +29937,8 @@
     "image": "cPK_10_016520_00_KAMITURUGI_U.webp",
     "name": "Kartana",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26945,7 +29947,8 @@
     "image": "cPK_10_016530_00_BURORON_C.webp",
     "name": "Varoom",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26954,7 +29957,8 @@
     "image": "cPK_10_016540_00_BUROROROOM_R.webp",
     "name": "Revavroom",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26963,7 +29967,8 @@
     "image": "cPK_10_016550_00_MINIRYU_C.webp",
     "name": "Dratini",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26972,7 +29977,8 @@
     "image": "cPK_10_016560_00_HAKURYU_U.webp",
     "name": "Dragonair",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26981,7 +29987,8 @@
     "image": "cPK_10_016570_00_KAIRYU_R.webp",
     "name": "Dragonite",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26990,7 +29997,8 @@
     "image": "cPK_10_016580_00_KIBAGO_C.webp",
     "name": "Axew",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -26999,7 +30007,8 @@
     "image": "cPK_10_016590_00_ONONDO_U.webp",
     "name": "Fraxure",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27008,7 +30017,8 @@
     "image": "cPK_10_016030_00_ONONOKUS_R.webp",
     "name": "Haxorus",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27017,7 +30027,8 @@
     "image": "cPK_10_016600_00_CRIMGAN_C.webp",
     "name": "Druddigon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27026,7 +30037,8 @@
     "image": "cPK_10_016610_00_PURIN_C.webp",
     "name": "Jigglypuff",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27035,7 +30047,8 @@
     "image": "cPK_10_016060_00_PUKURIN_C.webp",
     "name": "Wigglytuff",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27044,7 +30057,8 @@
     "image": "cPK_10_016620_00_MILTANK_U.webp",
     "name": "Miltank",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27053,7 +30067,8 @@
     "image": "cPK_10_016040_00_PERAP_C.webp",
     "name": "Chatot",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27062,7 +30077,8 @@
     "image": "cPK_10_016630_00_CHILLARMY_C.webp",
     "name": "Minccino",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27071,7 +30087,8 @@
     "image": "cPK_10_016640_00_CHILLACCINO_C.webp",
     "name": "Cinccino",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27080,7 +30097,8 @@
     "image": "cPK_10_016650_00_TRIMMIEN_U.webp",
     "name": "Furfrou",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27089,7 +30107,8 @@
     "image": "cTR_10_001230_00_IJIWARULETTER_U.webp",
     "name": "Nasty Notice",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27098,7 +30117,8 @@
     "image": "cTR_10_001240_00_MAINTENANCE_U.webp",
     "name": "Maintenance",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27107,7 +30127,8 @@
     "image": "cTR_10_001250_00_IRIS_U.webp",
     "name": "Iris",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27116,7 +30137,8 @@
     "image": "cTR_10_001260_00_CALME_U.webp",
     "name": "Calem",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27125,7 +30147,8 @@
     "image": "cTR_10_001270_00_HAIKINGUCOURSE_U.webp",
     "name": "Hiking Trail",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27134,7 +30157,8 @@
     "image": "cPK_20_016220_00_LAPLACE_AR.webp",
     "name": "Lapras",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27143,7 +30167,8 @@
     "image": "cPK_20_016250_00_EMPERTE_AR.webp",
     "name": "Empoleon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27152,7 +30177,8 @@
     "image": "cPK_20_016400_00_GROUDON_AR.webp",
     "name": "Groudon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27161,7 +30187,8 @@
     "image": "cPK_20_016490_00_MORPEKO_AR.webp",
     "name": "Morpeko",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27170,7 +30197,8 @@
     "image": "cPK_20_016540_00_BUROROROOM_AR.webp",
     "name": "Revavroom",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27179,7 +30207,8 @@
     "image": "cPK_20_016620_00_MILTANK_AR.webp",
     "name": "Miltank",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27188,7 +30217,8 @@
     "image": "cPK_20_016150_00_MEGALIZARDONXex_SR.webp",
     "name": "Mega Charizard X ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27197,7 +30227,8 @@
     "image": "cPK_20_016210_00_MEGAYADORANex_SR.webp",
     "name": "Mega Slowbro ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27206,7 +30237,8 @@
     "image": "cPK_20_016320_00_MEGALIVOLTex_SR.webp",
     "name": "Mega Manectric ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27215,7 +30247,8 @@
     "image": "cPK_20_016430_00_MEGAGANGARex_SR.webp",
     "name": "Mega Gengar ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27224,7 +30257,8 @@
     "image": "cPK_20_016510_00_MEGAHASSAMex_SR.webp",
     "name": "Mega Scizor ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27233,7 +30267,8 @@
     "image": "cTR_20_001250_00_IRIS_SR.webp",
     "name": "Iris",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27242,7 +30277,8 @@
     "image": "cTR_20_001260_00_CALME_SR.webp",
     "name": "Calem",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27251,7 +30287,8 @@
     "image": "cPK_20_016210_01_MEGAYADORANex_SAR.webp",
     "name": "Mega Slowbro ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27260,7 +30297,8 @@
     "image": "cPK_20_016320_01_MEGALIVOLTex_SAR.webp",
     "name": "Mega Manectric ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27269,7 +30307,8 @@
     "image": "cPK_20_016350_00_MEW_IM.webp",
     "name": "Mew",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27278,7 +30317,8 @@
     "image": "cPK_20_016350_01_MEW_IM.webp",
     "name": "Mew",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27287,7 +30327,8 @@
     "image": "cPK_20_016070_00_STRIKE_S.webp",
     "name": "Scyther",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27296,7 +30337,8 @@
     "image": "cPK_20_016080_00_KUNUGIDAMA_S.webp",
     "name": "Pineco",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27305,7 +30347,8 @@
     "image": "cPK_20_016110_00_BOKUREI_S.webp",
     "name": "Phantump",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27314,7 +30357,8 @@
     "image": "cPK_20_016120_00_OHROT_S.webp",
     "name": "Trevenant",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27323,7 +30367,8 @@
     "image": "cPK_20_016130_00_HITOKAGE_S.webp",
     "name": "Charmander",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27332,7 +30377,8 @@
     "image": "cPK_20_016140_00_LIZARDO_S.webp",
     "name": "Charmeleon",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27341,7 +30387,8 @@
     "image": "cPK_20_016160_00_PONYTA_S.webp",
     "name": "Ponyta",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27350,7 +30397,8 @@
     "image": "cPK_20_016170_00_GALLOP_S.webp",
     "name": "Rapidash",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27359,7 +30407,8 @@
     "image": "cPK_20_016000_00_YADON_S.webp",
     "name": "Slowpoke",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27368,7 +30417,8 @@
     "image": "cPK_20_016270_00_PIKACHU_S.webp",
     "name": "Pikachu",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27377,7 +30427,8 @@
     "image": "cPK_20_016280_00_RAICHU_S.webp",
     "name": "Raichu",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27386,7 +30437,8 @@
     "image": "cPK_20_016310_00_RAKURAI_S.webp",
     "name": "Electrike",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27395,7 +30447,8 @@
     "image": "cPK_20_016410_00_LUCHABULL_S.webp",
     "name": "Hawlucha",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27404,7 +30457,8 @@
     "image": "cPK_20_016050_00_GHOS_S.webp",
     "name": "Gastly",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27413,7 +30467,8 @@
     "image": "cPK_20_016420_00_GHOST_S.webp",
     "name": "Haunter",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27422,7 +30477,8 @@
     "image": "cPK_20_016470_00_ZORUA_S.webp",
     "name": "Zorua",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27431,7 +30487,8 @@
     "image": "cPK_20_016480_00_ZOROARK_S.webp",
     "name": "Zoroark",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27440,7 +30497,8 @@
     "image": "cPK_20_016500_00_FORETOS_S.webp",
     "name": "Forretress",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27449,7 +30507,8 @@
     "image": "cPK_20_016550_00_MINIRYU_S.webp",
     "name": "Dratini",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27458,7 +30517,8 @@
     "image": "cPK_20_016560_00_HAKURYU_S.webp",
     "name": "Dragonair",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27467,7 +30527,8 @@
     "image": "cPK_20_016570_00_KAIRYU_S.webp",
     "name": "Dragonite",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27476,7 +30537,8 @@
     "image": "cPK_20_016580_00_KIBAGO_S.webp",
     "name": "Axew",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27485,7 +30547,8 @@
     "image": "cPK_20_016590_00_ONONDO_S.webp",
     "name": "Fraxure",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27494,7 +30557,8 @@
     "image": "cPK_20_016030_00_ONONOKUS_S.webp",
     "name": "Haxorus",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27503,7 +30567,8 @@
     "image": "cPK_20_016150_01_MEGALIZARDONXex_SSR.webp",
     "name": "Mega Charizard X ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27512,7 +30577,8 @@
     "image": "cPK_20_016210_02_MEGAYADORANex_SSR.webp",
     "name": "Mega Slowbro ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27521,7 +30587,8 @@
     "image": "cPK_20_016320_02_MEGALIVOLTex_SSR.webp",
     "name": "Mega Manectric ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27530,7 +30597,8 @@
     "image": "cPK_20_016430_01_MEGAGANGARex_SSR.webp",
     "name": "Mega Gengar ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27539,7 +30607,8 @@
     "image": "cPK_20_016510_01_MEGAHASSAMex_SSR.webp",
     "name": "Mega Scizor ex",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B2b",
@@ -27548,7 +30617,8 @@
     "image": "cPK_20_015180_00_OLIVA_UR.webp",
     "name": "Arboliva",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B2b",
@@ -27557,7 +30627,8 @@
     "image": "cTR_20_001090_00_METARUKOABARIA_UR.webp",
     "name": "Metal Core Barrier",
     "packs": ["Mega Shine"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27566,7 +30637,8 @@
     "image": "cPK_10_016660_00_MONJARA_C.webp",
     "name": "Tangela",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27575,7 +30647,8 @@
     "image": "cPK_10_016670_00_MOJUMBO_U.webp",
     "name": "Tangrowth",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27584,7 +30657,8 @@
     "image": "cPK_10_016680_00_HERACROS_U.webp",
     "name": "Heracross",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27593,7 +30667,8 @@
     "image": "cPK_10_016690_00_CELEBI_R.webp",
     "name": "Celebi",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27602,7 +30677,8 @@
     "image": "cPK_10_016700_00_KIMORI_C.webp",
     "name": "Treecko",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27611,7 +30687,8 @@
     "image": "cPK_10_016710_00_JUPTILE_U.webp",
     "name": "Grovyle",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27620,7 +30697,8 @@
     "image": "cPK_10_016720_00_JUKAIN_R.webp",
     "name": "Sceptile",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27629,7 +30707,8 @@
     "image": "cPK_10_016730_00_MEGAJUKAINex_RR.webp",
     "name": "Mega Sceptile ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27638,7 +30717,8 @@
     "image": "cPK_10_016740_00_AMETAMA_C.webp",
     "name": "Surskit",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27647,7 +30727,8 @@
     "image": "cPK_10_016750_00_AMEMOTH_C.webp",
     "name": "Masquerain",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27656,7 +30737,8 @@
     "image": "cPK_10_016760_00_KINOCOCO_C.webp",
     "name": "Shroomish",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27665,7 +30747,8 @@
     "image": "cPK_10_016770_00_KINOGASSA_U.webp",
     "name": "Breloom",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27674,7 +30757,8 @@
     "image": "cPK_10_016780_00_SUBOMIE_R.webp",
     "name": "Budew",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27683,7 +30767,8 @@
     "image": "cPK_10_016790_00_MUSKIPPA_C.webp",
     "name": "Carnivine",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27692,7 +30777,8 @@
     "image": "cPK_10_016800_00_KURUMIRU_C.webp",
     "name": "Sewaddle",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27701,7 +30787,8 @@
     "image": "cPK_10_016810_00_KURUMAYU_C.webp",
     "name": "Swadloon",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27710,7 +30797,8 @@
     "image": "cPK_10_016820_00_HAHAKOMORI_U.webp",
     "name": "Leavanny",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27719,7 +30807,8 @@
     "image": "cPK_10_016830_00_AIANT_C.webp",
     "name": "Durant",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27728,7 +30817,8 @@
     "image": "cPK_10_016840_00_KAJICCHU_C.webp",
     "name": "Applin",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27737,7 +30827,8 @@
     "image": "cPK_10_016850_00_APPRYU_R.webp",
     "name": "Flapple",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27746,7 +30837,8 @@
     "image": "cPK_10_016860_00_DONMEL_C.webp",
     "name": "Numel",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27755,7 +30847,8 @@
     "image": "cPK_10_016870_00_BAKUUDA_U.webp",
     "name": "Camerupt",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27764,7 +30857,8 @@
     "image": "cPK_10_016880_00_MEGABAKUUDAex_RR.webp",
     "name": "Mega Camerupt ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27773,7 +30867,8 @@
     "image": "cPK_10_016890_00_POWALENTAIYOUNOSUGATA_C.webp",
     "name": "Castform Sunny Form",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27782,7 +30877,8 @@
     "image": "cPK_10_016900_00_VICTINI_R.webp",
     "name": "Victini",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27791,7 +30887,8 @@
     "image": "cPK_10_016910_00_POKABU_C.webp",
     "name": "Tepig",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27800,7 +30897,8 @@
     "image": "cPK_10_016920_00_CHAOBOO_U.webp",
     "name": "Pignite",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27809,7 +30907,8 @@
     "image": "cPK_10_016930_00_ENBUOH_R.webp",
     "name": "Emboar",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27818,7 +30917,8 @@
     "image": "cPK_10_016940_00_DARUMAKKA_C.webp",
     "name": "Darumaka",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27827,7 +30927,8 @@
     "image": "cPK_10_016950_00_HIHIDARUMA_U.webp",
     "name": "Darmanitan",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27836,7 +30937,8 @@
     "image": "cPK_10_016960_00_MERLARVA_C.webp",
     "name": "Larvesta",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27845,7 +30947,8 @@
     "image": "cPK_10_016970_00_ULGAMOTH_U.webp",
     "name": "Volcarona",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27854,7 +30957,8 @@
     "image": "cPK_10_016980_00_NYOROMO_C.webp",
     "name": "Poliwag",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27863,7 +30967,8 @@
     "image": "cPK_10_016990_00_NYOROZO_U.webp",
     "name": "Poliwhirl",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27872,7 +30977,8 @@
     "image": "cPK_10_017000_00_NYOROTONO_R.webp",
     "name": "Politoed",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27881,7 +30987,8 @@
     "image": "cPK_10_017010_00_PALDEAKENTAUROS_U.webp",
     "name": "Paldean Tauros",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27890,7 +30997,8 @@
     "image": "cPK_10_017020_00_SHOWERSex_RR.webp",
     "name": "Vaporeon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27899,7 +31007,8 @@
     "image": "cPK_10_017030_00_UPAH_C.webp",
     "name": "Wooper",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27908,7 +31017,8 @@
     "image": "cPK_10_017040_00_NUOH_U.webp",
     "name": "Quagsire",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27917,7 +31027,8 @@
     "image": "cPK_10_017050_00_POWALENAMAMIZUNOSUGATA_C.webp",
     "name": "Castform Rainy Form",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27926,7 +31037,8 @@
     "image": "cPK_10_017060_00_POWALENYUKIGUMONOSUGATA_C.webp",
     "name": "Castform Snowy Form",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27935,7 +31047,8 @@
     "image": "cPK_10_017070_00_PEARLULU_C.webp",
     "name": "Clamperl",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27944,7 +31057,8 @@
     "image": "cPK_10_017080_00_HUNTAIL_U.webp",
     "name": "Huntail",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27953,7 +31067,8 @@
     "image": "cPK_10_017090_00_SAKURABYSS_U.webp",
     "name": "Gorebyss",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27962,7 +31077,8 @@
     "image": "cPK_10_017100_00_REGICE_U.webp",
     "name": "Regice",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27971,7 +31087,8 @@
     "image": "cPK_10_017110_00_KUMASYUN_C.webp",
     "name": "Cubchoo",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27980,7 +31097,8 @@
     "image": "cPK_10_017120_00_TUNBEAR_U.webp",
     "name": "Beartic",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27989,7 +31107,8 @@
     "image": "cPK_10_017130_00_MESSON_C.webp",
     "name": "Sobble",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -27998,7 +31117,8 @@
     "image": "cPK_10_017140_00_JIMEREON_U.webp",
     "name": "Drizzile",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28007,7 +31127,8 @@
     "image": "cPK_10_017150_00_INTEREON_R.webp",
     "name": "Inteleon",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28016,7 +31137,8 @@
     "image": "cPK_10_017160_00_WULAOSURENGEKINOKATA_R.webp",
     "name": "Rapid Strike Urshifu",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28025,7 +31147,8 @@
     "image": "cPK_10_017170_00_COIL_C.webp",
     "name": "Magnemite",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28034,7 +31157,8 @@
     "image": "cPK_10_017180_00_RARECOIL_U.webp",
     "name": "Magneton",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28043,7 +31167,8 @@
     "image": "cPK_10_017190_00_JIBACOILex_RR.webp",
     "name": "Magnezone ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28052,7 +31177,8 @@
     "image": "cPK_10_017200_00_BIRIRIDAMA_C.webp",
     "name": "Voltorb",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28061,7 +31187,8 @@
     "image": "cPK_10_017210_00_MARUMINE_C.webp",
     "name": "Electrode",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28070,7 +31197,8 @@
     "image": "cPK_10_017220_00_CHONCHIE_C.webp",
     "name": "Chinchou",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28079,7 +31207,8 @@
     "image": "cPK_10_017230_00_LANTERN_U.webp",
     "name": "Lanturn",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28088,7 +31217,8 @@
     "image": "cPK_10_017240_00_ZEKROM_R.webp",
     "name": "Zekrom",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28097,7 +31227,8 @@
     "image": "cPK_10_017250_00_ELESON_C.webp",
     "name": "Toxel",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28106,7 +31237,8 @@
     "image": "cPK_10_017260_00_STRINDER_R.webp",
     "name": "Toxtricity",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28115,7 +31247,8 @@
     "image": "cPK_10_017270_00_MORPEKO_C.webp",
     "name": "Morpeko",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28124,7 +31257,8 @@
     "image": "cPK_10_017280_00_RALTS_C.webp",
     "name": "Ralts",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28133,7 +31267,8 @@
     "image": "cPK_10_017290_00_KIRLIA_U.webp",
     "name": "Kirlia",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28142,7 +31277,8 @@
     "image": "cPK_10_017300_00_NYASPER_C.webp",
     "name": "Espurr",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28151,7 +31287,8 @@
     "image": "cPK_10_017310_00_NYAONIX_R.webp",
     "name": "Meowstic",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28160,7 +31297,8 @@
     "image": "cPK_10_017320_00_DIANCIE_R.webp",
     "name": "Diancie",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28169,7 +31307,8 @@
     "image": "cPK_10_017330_00_ODORIDORI_C.webp",
     "name": "Oricorio",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28178,7 +31317,8 @@
     "image": "cPK_10_017340_00_MIBRIM_C.webp",
     "name": "Hatenna",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28187,7 +31327,8 @@
     "image": "cPK_10_017350_00_TEBRIM_U.webp",
     "name": "Hattrem",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28196,7 +31337,8 @@
     "image": "cPK_10_017360_00_BRIMUON_R.webp",
     "name": "Hatterene",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28205,7 +31347,8 @@
     "image": "cPK_10_017370_00_ANOKUSA_C.webp",
     "name": "Bramblin",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28214,7 +31357,8 @@
     "image": "cPK_10_017380_00_ANOHORAGUSA_R.webp",
     "name": "Brambleghast",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28223,7 +31367,8 @@
     "image": "cPK_10_017390_00_GLIGER_C.webp",
     "name": "Gligar",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28232,7 +31377,8 @@
     "image": "cPK_10_017400_00_GLION_U.webp",
     "name": "Gliscor",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28241,7 +31387,8 @@
     "image": "cPK_10_017410_00_NUCKRAR_C.webp",
     "name": "Trapinch",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28250,7 +31397,8 @@
     "image": "cPK_10_017420_00_REGIROCK_U.webp",
     "name": "Regirock",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28259,7 +31407,8 @@
     "image": "cPK_10_017430_00_USOHACHI_R.webp",
     "name": "Bonsly",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28268,7 +31417,8 @@
     "image": "cPK_10_017440_00_RIOLU_C.webp",
     "name": "Riolu",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28277,7 +31427,8 @@
     "image": "cPK_10_017450_00_LUCARIO_R.webp",
     "name": "Lucario",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28286,7 +31437,8 @@
     "image": "cPK_10_017460_00_MEGALUCARIOex_RR.webp",
     "name": "Mega Lucario ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28295,7 +31447,8 @@
     "image": "cPK_10_017470_00_GUREGGRU_C.webp",
     "name": "Croagunk",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28304,7 +31457,8 @@
     "image": "cPK_10_017480_00_DOKUROG_U.webp",
     "name": "Toxicroak",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28313,7 +31467,8 @@
     "image": "cPK_10_017490_00_ERUREIDO_R.webp",
     "name": "Gallade",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28322,7 +31477,8 @@
     "image": "cPK_10_017500_00_NAGEKI_C.webp",
     "name": "Throh",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28331,7 +31487,8 @@
     "image": "cPK_10_017510_00_DAGEKI_C.webp",
     "name": "Sawk",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28340,7 +31497,8 @@
     "image": "cPK_10_017520_00_ISHIZUMAI_C.webp",
     "name": "Dwebble",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28349,7 +31507,8 @@
     "image": "cPK_10_017530_00_IWAPALACEex_RR.webp",
     "name": "Crustle ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28358,7 +31517,8 @@
     "image": "cPK_10_017540_00_MELOETTA_R.webp",
     "name": "Meloetta",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28367,7 +31527,8 @@
     "image": "cPK_10_017550_00_NUIKOGUMA_C.webp",
     "name": "Stufful",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28376,7 +31537,8 @@
     "image": "cPK_10_017560_00_KITERUGUMA_U.webp",
     "name": "Bewear",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28385,7 +31547,8 @@
     "image": "cPK_10_017570_00_TANDON_C.webp",
     "name": "Rolycoly",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28394,7 +31557,8 @@
     "image": "cPK_10_017580_00_TOROGGON_U.webp",
     "name": "Carkol",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28403,7 +31567,8 @@
     "image": "cPK_10_017590_00_SEKITANZAN_R.webp",
     "name": "Coalossal",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28412,7 +31577,8 @@
     "image": "cPK_10_017600_00_SUNAHEBI_C.webp",
     "name": "Silicobra",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28421,7 +31587,8 @@
     "image": "cPK_10_017610_00_SADAIJA_U.webp",
     "name": "Sandaconda",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28430,7 +31597,8 @@
     "image": "cPK_10_017620_00_DAKUMA_C.webp",
     "name": "Kubfu",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28439,7 +31607,8 @@
     "image": "cPK_10_017630_00_ZUBAT_C.webp",
     "name": "Zubat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28448,7 +31617,8 @@
     "image": "cPK_10_017640_00_GOLBAT_U.webp",
     "name": "Golbat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28457,7 +31627,8 @@
     "image": "cPK_10_017650_00_CROBAT_R.webp",
     "name": "Crobat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28466,7 +31637,8 @@
     "image": "cPK_10_017660_00_DOGARS_C.webp",
     "name": "Koffing",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28475,7 +31647,8 @@
     "image": "cPK_10_017670_00_MATADOGAS_U.webp",
     "name": "Weezing",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28484,7 +31657,8 @@
     "image": "cPK_10_017680_00_HARYSEN_C.webp",
     "name": "Qwilfish",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28493,7 +31667,8 @@
     "image": "cPK_10_017690_00_HABUNAKE_C.webp",
     "name": "Seviper",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28502,7 +31677,8 @@
     "image": "cPK_10_017700_00_ZORUA_C.webp",
     "name": "Zorua",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28511,7 +31687,8 @@
     "image": "cPK_10_017710_00_ZOROARKex_RR.webp",
     "name": "Zoroark ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28520,7 +31697,8 @@
     "image": "cPK_10_017720_00_TAMAGETAKE_C.webp",
     "name": "Foongus",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28529,7 +31707,8 @@
     "image": "cPK_10_017730_00_MOROBARERU_U.webp",
     "name": "Amoonguss",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28538,7 +31717,8 @@
     "image": "cPK_10_017740_00_VALCHAI_C.webp",
     "name": "Vullaby",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28547,7 +31727,8 @@
     "image": "cPK_10_017750_00_VULGINA_U.webp",
     "name": "Mandibuzz",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28556,7 +31737,8 @@
     "image": "cPK_10_017760_00_MAAIIKA_C.webp",
     "name": "Inkay",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28565,7 +31747,8 @@
     "image": "cPK_10_017770_00_CALAMANERO_U.webp",
     "name": "Malamar",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28574,7 +31757,8 @@
     "image": "cPK_10_017780_00_WULAOSUICHIGEKINOKATA_R.webp",
     "name": "Single Strike Urshifu",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28583,7 +31767,8 @@
     "image": "cPK_10_017790_00_ZARUDE_R.webp",
     "name": "Zarude",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28592,7 +31777,8 @@
     "image": "cPK_10_017800_00_OTOSHIDORI_R.webp",
     "name": "Bombirdier",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28601,7 +31787,8 @@
     "image": "cPK_10_017810_00_REGISTEEL_U.webp",
     "name": "Registeel",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28610,7 +31797,8 @@
     "image": "cPK_10_017820_00_DOHMIRROR_C.webp",
     "name": "Bronzor",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28619,7 +31807,8 @@
     "image": "cPK_10_017830_00_DOHTAKUN_U.webp",
     "name": "Bronzong",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28628,7 +31817,8 @@
     "image": "cPK_10_017840_00_KOMATANA_C.webp",
     "name": "Pawniard",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28637,7 +31827,8 @@
     "image": "cPK_10_017850_00_KIRIKIZAN_U.webp",
     "name": "Bisharp",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28646,7 +31837,8 @@
     "image": "cPK_10_017860_00_MAGEARNA_U.webp",
     "name": "Magearna",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28655,7 +31847,8 @@
     "image": "cPK_10_017870_00_MELTAN_C.webp",
     "name": "Meltan",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28664,7 +31857,8 @@
     "image": "cPK_10_017880_00_MELMETAL_R.webp",
     "name": "Melmetal",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28673,7 +31867,8 @@
     "image": "cPK_10_017890_00_ARMORGAex_RR.webp",
     "name": "Corviknight ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28682,7 +31877,8 @@
     "image": "cPK_10_017900_00_VIBRAVA_U.webp",
     "name": "Vibrava",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28691,7 +31887,8 @@
     "image": "cPK_10_017910_00_FLYGONex_RR.webp",
     "name": "Flygon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28700,7 +31897,8 @@
     "image": "cPK_10_017920_00_LUCKY_C.webp",
     "name": "Chansey",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28709,7 +31907,8 @@
     "image": "cPK_10_017930_00_HAPPINAS_R.webp",
     "name": "Blissey",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28718,7 +31917,8 @@
     "image": "cPK_10_017940_00_EIEVUI_C.webp",
     "name": "Eevee",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28727,7 +31927,8 @@
     "image": "cPK_10_017950_00_NOKOCCHI_R.webp",
     "name": "Dunsparce",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28736,7 +31937,8 @@
     "image": "cPK_10_017960_00_HIMEGUMA_C.webp",
     "name": "Teddiursa",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28745,7 +31947,8 @@
     "image": "cPK_10_017970_00_RINGUMA_U.webp",
     "name": "Ursaring",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28754,7 +31957,8 @@
     "image": "cPK_10_017980_00_POWALEN_C.webp",
     "name": "Castform",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28763,7 +31967,8 @@
     "image": "cPK_10_017990_00_REGIGIGAS_R.webp",
     "name": "Regigigas",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28772,7 +31977,8 @@
     "image": "cPK_10_018000_00_MINEZUMI_C.webp",
     "name": "Patrat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28781,7 +31987,8 @@
     "image": "cPK_10_018010_00_MIRUHOG_C.webp",
     "name": "Watchog",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28790,7 +31997,8 @@
     "image": "cPK_10_018020_00_YORTERRIE_C.webp",
     "name": "Lillipup",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28799,7 +32007,8 @@
     "image": "cPK_10_018030_00_HERDERRIE_U.webp",
     "name": "Herdier",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28808,7 +32017,8 @@
     "image": "cPK_10_018040_00_MOOLAND_R.webp",
     "name": "Stoutland",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28817,7 +32027,8 @@
     "image": "cPK_10_018050_00_TABUNNE_U.webp",
     "name": "Audino",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28826,7 +32037,8 @@
     "image": "cPK_10_018060_00_MEGATABUNNEex_RR.webp",
     "name": "Mega Audino ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28835,7 +32047,8 @@
     "image": "cPK_10_018070_00_CHILLARMY_C.webp",
     "name": "Minccino",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28844,7 +32057,8 @@
     "image": "cPK_10_018080_00_CHILLACCINO_C.webp",
     "name": "Cinccino",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28853,7 +32067,8 @@
     "image": "cPK_10_018090_00_TRIMMIEN_U.webp",
     "name": "Furfrou",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28862,7 +32077,8 @@
     "image": "cPK_10_018100_00_KOKOGARA_C.webp",
     "name": "Rookidee",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28871,7 +32087,8 @@
     "image": "cPK_10_018110_00_AOGARASU_U.webp",
     "name": "Corvisquire",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28880,7 +32097,8 @@
     "image": "cTR_10_001280_00_FIELDBLOWER_U.webp",
     "name": "Field Blower",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28889,7 +32107,8 @@
     "image": "cTR_10_001290_00_HAPPINESSEGG_U.webp",
     "name": "Lucky Egg",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28898,7 +32117,8 @@
     "image": "cTR_10_001300_00_CORNI_U.webp",
     "name": "Korrina",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28907,7 +32127,8 @@
     "image": "cTR_10_001310_00_TAXIDRIVER_U.webp",
     "name": "Cabbie",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28916,7 +32137,8 @@
     "image": "cTR_10_001320_00_CHEREN_U.webp",
     "name": "Cheren",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28925,7 +32147,8 @@
     "image": "cTR_10_001330_00_PARASOLGIRL_U.webp",
     "name": "Parasol Lady",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28934,7 +32157,8 @@
     "image": "cTR_10_001340_00_AMAKUKAORUMORI_U.webp",
     "name": "Fragrant Forest",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28943,7 +32167,8 @@
     "image": "cTR_10_001350_00_INISHIENOTOUGIJYOU_U.webp",
     "name": "Arena of Antiquity",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28952,7 +32177,8 @@
     "image": "cTR_10_001360_00_KEKKAINOFIELD_U.webp",
     "name": "Bounded Field",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28961,7 +32187,8 @@
     "image": "cPK_20_016700_00_KIMORI_AR.webp",
     "name": "Treecko",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28970,7 +32197,8 @@
     "image": "cPK_20_016710_00_JUPTILE_AR.webp",
     "name": "Grovyle",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28979,7 +32207,8 @@
     "image": "cPK_20_016760_00_KINOCOCO_AR.webp",
     "name": "Shroomish",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28988,7 +32217,8 @@
     "image": "cPK_20_016780_00_SUBOMIE_AR.webp",
     "name": "Budew",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -28997,7 +32227,8 @@
     "image": "cPK_20_016850_00_APPRYU_AR.webp",
     "name": "Flapple",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29006,7 +32237,8 @@
     "image": "cPK_20_016910_00_POKABU_AR.webp",
     "name": "Tepig",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29015,7 +32247,8 @@
     "image": "cPK_20_017040_00_NUOH_AR.webp",
     "name": "Quagsire",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29024,7 +32257,8 @@
     "image": "cPK_20_017240_00_ZEKROM_AR.webp",
     "name": "Zekrom",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29033,7 +32267,8 @@
     "image": "cPK_20_017270_00_MORPEKO_AR.webp",
     "name": "Morpeko",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29042,7 +32277,8 @@
     "image": "cPK_20_017310_00_NYAONIX_AR.webp",
     "name": "Meowstic",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29051,7 +32287,8 @@
     "image": "cPK_20_017330_00_ODORIDORI_AR.webp",
     "name": "Oricorio",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29060,7 +32297,8 @@
     "image": "cPK_20_017380_00_ANOHORAGUSA_AR.webp",
     "name": "Brambleghast",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29069,7 +32307,8 @@
     "image": "cPK_20_017430_00_USOHACHI_AR.webp",
     "name": "Bonsly",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29078,7 +32317,8 @@
     "image": "cPK_20_017440_00_RIOLU_AR.webp",
     "name": "Riolu",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29087,7 +32327,8 @@
     "image": "cPK_20_017540_00_MELOETTA_AR.webp",
     "name": "Meloetta",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29096,7 +32337,8 @@
     "image": "cPK_20_017580_00_TOROGGON_AR.webp",
     "name": "Carkol",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29105,7 +32347,8 @@
     "image": "cPK_20_017620_00_DAKUMA_AR.webp",
     "name": "Kubfu",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29114,7 +32357,8 @@
     "image": "cPK_20_017690_00_HABUNAKE_AR.webp",
     "name": "Seviper",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29123,7 +32367,8 @@
     "image": "cPK_20_017700_00_ZORUA_AR.webp",
     "name": "Zorua",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29132,7 +32377,8 @@
     "image": "cPK_20_017770_00_CALAMANERO_AR.webp",
     "name": "Malamar",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29141,7 +32387,8 @@
     "image": "cPK_20_017850_00_KIRIKIZAN_AR.webp",
     "name": "Bisharp",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29150,7 +32397,8 @@
     "image": "cPK_20_017870_00_MELTAN_AR.webp",
     "name": "Meltan",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29159,7 +32407,8 @@
     "image": "cPK_20_017980_00_POWALEN_AR.webp",
     "name": "Castform",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29168,7 +32417,8 @@
     "image": "cPK_20_018080_00_CHILLACCINO_AR.webp",
     "name": "Cinccino",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29177,7 +32427,8 @@
     "image": "cPK_20_016730_00_MEGAJUKAINex_SR.webp",
     "name": "Mega Sceptile ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29186,7 +32437,8 @@
     "image": "cPK_20_016880_00_MEGABAKUUDAex_SR.webp",
     "name": "Mega Camerupt ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29195,7 +32447,8 @@
     "image": "cPK_20_017020_00_SHOWERSex_SR.webp",
     "name": "Vaporeon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29204,7 +32457,8 @@
     "image": "cPK_20_017190_00_JIBACOILex_SR.webp",
     "name": "Magnezone ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29213,7 +32467,8 @@
     "image": "cPK_20_017460_00_MEGALUCARIOex_SR.webp",
     "name": "Mega Lucario ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29222,7 +32477,8 @@
     "image": "cPK_20_017530_00_IWAPALACEex_SR.webp",
     "name": "Crustle ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29231,7 +32487,8 @@
     "image": "cPK_20_017710_00_ZOROARKex_SR.webp",
     "name": "Zoroark ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29240,7 +32497,8 @@
     "image": "cPK_20_017890_00_ARMORGAex_SR.webp",
     "name": "Corviknight ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29249,7 +32507,8 @@
     "image": "cPK_20_017910_00_FLYGONex_SR.webp",
     "name": "Flygon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29258,7 +32517,8 @@
     "image": "cPK_20_018060_00_MEGATABUNNEex_SR.webp",
     "name": "Mega Audino ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29267,7 +32527,8 @@
     "image": "cTR_20_001300_00_CORNI_SR.webp",
     "name": "Korrina",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29276,7 +32537,8 @@
     "image": "cTR_20_001310_00_TAXIDRIVER_SR.webp",
     "name": "Cabbie",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29285,7 +32547,8 @@
     "image": "cTR_20_001320_00_CHEREN_SR.webp",
     "name": "Cheren",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29294,7 +32557,8 @@
     "image": "cTR_20_001330_00_PARASOLGIRL_SR.webp",
     "name": "Parasol Lady",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29303,7 +32567,8 @@
     "image": "cPK_20_016730_01_MEGAJUKAINex_SAR.webp",
     "name": "Mega Sceptile ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29312,7 +32577,8 @@
     "image": "cPK_20_016880_01_MEGABAKUUDAex_SAR.webp",
     "name": "Mega Camerupt ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29321,7 +32587,8 @@
     "image": "cPK_20_017020_01_SHOWERSex_SAR.webp",
     "name": "Vaporeon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29330,7 +32597,8 @@
     "image": "cPK_20_017190_01_JIBACOILex_SAR.webp",
     "name": "Magnezone ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29339,7 +32607,8 @@
     "image": "cPK_20_017530_01_IWAPALACEex_SAR.webp",
     "name": "Crustle ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29348,7 +32617,8 @@
     "image": "cPK_20_017710_01_ZOROARKex_SAR.webp",
     "name": "Zoroark ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29357,7 +32627,8 @@
     "image": "cPK_20_017890_01_ARMORGAex_SAR.webp",
     "name": "Corviknight ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29366,7 +32637,8 @@
     "image": "cPK_20_017910_01_FLYGONex_SAR.webp",
     "name": "Flygon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29375,7 +32647,8 @@
     "image": "cPK_20_018060_01_MEGATABUNNEex_SAR.webp",
     "name": "Mega Audino ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29384,7 +32657,8 @@
     "image": "cPK_20_017130_00_MESSON_IM.webp",
     "name": "Sobble",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29393,7 +32667,8 @@
     "image": "cPK_20_017460_01_MEGALUCARIOex_IM.webp",
     "name": "Mega Lucario ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29402,7 +32677,8 @@
     "image": "cPK_20_010970_00_MONMEN_S.webp",
     "name": "Cottonee",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29411,7 +32687,8 @@
     "image": "cPK_20_011150_00_ACHAMO_S.webp",
     "name": "Torchic",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29420,7 +32697,8 @@
     "image": "cPK_20_011160_00_WAKASYAMO_S.webp",
     "name": "Combusken",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29429,7 +32707,8 @@
     "image": "cPK_20_011170_00_BURSYAMO_S.webp",
     "name": "Blaziken",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29438,7 +32717,8 @@
     "image": "cPK_20_011500_00_PURURILL_S.webp",
     "name": "Frillish",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29447,7 +32727,8 @@
     "image": "cPK_20_011510_01_BURUNGEL_S.webp",
     "name": "Jellicent",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29456,7 +32737,8 @@
     "image": "cPK_20_013420_00_IWARK_S.webp",
     "name": "Onix",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29465,7 +32747,8 @@
     "image": "cPK_20_017630_00_ZUBAT_S.webp",
     "name": "Zubat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29474,7 +32757,8 @@
     "image": "cPK_20_017640_00_GOLBAT_S.webp",
     "name": "Golbat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29483,7 +32767,8 @@
     "image": "cPK_20_017650_00_CROBAT_S.webp",
     "name": "Crobat",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29492,7 +32777,8 @@
     "image": "cPK_20_013490_00_BETBETER_S.webp",
     "name": "Grimer",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29501,7 +32787,8 @@
     "image": "cPK_20_013500_00_BETBETON_S.webp",
     "name": "Muk",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29510,7 +32797,8 @@
     "image": "cPK_20_012320_00_ABSOL_S.webp",
     "name": "Absol",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29519,7 +32807,8 @@
     "image": "cPK_20_012410_00_KUZUMO_S.webp",
     "name": "Skrelp",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29528,7 +32817,8 @@
     "image": "cPK_20_013550_00_HAGANEIL_S.webp",
     "name": "Steelix",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29537,7 +32827,8 @@
     "image": "cPK_20_017920_00_LUCKY_S.webp",
     "name": "Chansey",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29546,7 +32837,8 @@
     "image": "cPK_20_017930_00_HAPPINAS_S.webp",
     "name": "Blissey",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29555,7 +32847,8 @@
     "image": "cPK_20_013580_00_PORYGON_S.webp",
     "name": "Porygon",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29564,7 +32857,8 @@
     "image": "cPK_20_013590_00_PORYGON2_S.webp",
     "name": "Porygon2",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29573,7 +32867,8 @@
     "image": "cPK_20_013600_00_PORYGON-Z_S.webp",
     "name": "Porygon-Z",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29582,7 +32877,8 @@
     "image": "cPK_20_010980_02_ELFUUNex_SSR.webp",
     "name": "Whimsicott ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29591,7 +32887,8 @@
     "image": "cPK_20_011180_02_MEGABURSYAMOex_SSR.webp",
     "name": "Mega Blaziken ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29600,7 +32897,8 @@
     "image": "cPK_20_011550_02_GEKKOUGAex_SSR.webp",
     "name": "Greninja ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29609,7 +32907,8 @@
     "image": "cPK_20_011630_02_THUNDERSex_SSR.webp",
     "name": "Jolteon ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29618,7 +32917,8 @@
     "image": "cPK_20_012060_02_EBIWALARex_SSR.webp",
     "name": "Hitmonchan ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29627,7 +32927,8 @@
     "image": "cPK_20_012330_02_MEGAABSOLex_SSR.webp",
     "name": "Mega Absol ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29636,7 +32937,8 @@
     "image": "cPK_20_012420_02_DRAMIDOROex_SSR.webp",
     "name": "Dragalge ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29645,7 +32947,8 @@
     "image": "cPK_20_013560_02_MEGAHAGANEILex_SSR.webp",
     "name": "Mega Steelix ex",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3",
@@ -29654,7 +32957,8 @@
     "image": "cPK_20_016690_00_CELEBI_UR.webp",
     "name": "Celebi",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3",
@@ -29663,7 +32967,8 @@
     "image": "cPK_20_017800_00_OTOSHIDORI_UR.webp",
     "name": "Bombirdier",
     "packs": ["Pulsing Aura"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29672,7 +32977,8 @@
     "image": "cPK_10_018160_00_AMETAMA_C.webp",
     "name": "Surskit",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29681,7 +32987,8 @@
     "image": "cPK_10_018170_00_AMEMOTH_C.webp",
     "name": "Masquerain",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29690,7 +32997,8 @@
     "image": "cPK_10_018180_00_ARABURUTAKE_C.webp",
     "name": "Brute Bonnet",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29699,7 +33007,8 @@
     "image": "cPK_10_018190_00_CHIWOHAUHANE_U.webp",
     "name": "Slither Wing",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29708,7 +33017,8 @@
     "image": "cPK_10_018200_00_TETSUNODOKUGA_U.webp",
     "name": "Iron Moth",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29717,7 +33027,8 @@
     "image": "cPK_10_018210_00_KODUCK_C.webp",
     "name": "Psyduck",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29726,7 +33037,8 @@
     "image": "cPK_10_018220_00_GOLDUCK_C.webp",
     "name": "Golduck",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29735,7 +33047,8 @@
     "image": "cPK_10_018230_00_SHOWERS_U.webp",
     "name": "Vaporeon",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29744,7 +33057,8 @@
     "image": "cPK_10_018240_00_BUOYSEL_C.webp",
     "name": "Buizel",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29753,7 +33067,8 @@
     "image": "cPK_10_018250_00_FLOAZEL_C.webp",
     "name": "Floatzel",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29762,7 +33077,8 @@
     "image": "cPK_10_018260_00_YUKIHAMI_C.webp",
     "name": "Snom",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29771,7 +33087,8 @@
     "image": "cPK_10_018270_00_MOTHNOW_C.webp",
     "name": "Frosmoth",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29780,7 +33097,8 @@
     "image": "cPK_10_018280_00_TETSUNOTSUTSUMIex_RR.webp",
     "name": "Iron Bundle ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29789,7 +33107,8 @@
     "image": "cPK_10_018290_00_PAMO_C.webp",
     "name": "Pawmi",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29798,7 +33117,8 @@
     "image": "cPK_10_018300_00_PAMOT_C.webp",
     "name": "Pawmo",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29807,7 +33127,8 @@
     "image": "cPK_10_018310_00_PARMOT_U.webp",
     "name": "Pawmot",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29816,7 +33137,8 @@
     "image": "cPK_10_018320_00_TETSUNOKAINA_C.webp",
     "name": "Iron Hands",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29825,7 +33147,8 @@
     "image": "cPK_10_018330_00_TETSUNOIBARA_U.webp",
     "name": "Iron Thorns",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29834,7 +33157,8 @@
     "image": "cPK_10_018340_00_MIRAIDONex_RR.webp",
     "name": "Miraidon ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29843,7 +33167,8 @@
     "image": "cPK_10_018350_00_EIFIE_U.webp",
     "name": "Espeon",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29852,7 +33177,8 @@
     "image": "cPK_10_018360_00_HIRAHINA_C.webp",
     "name": "Flittle",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29861,7 +33187,8 @@
     "image": "cPK_10_018370_00_CUESPATRA_U.webp",
     "name": "Espathra",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29870,7 +33197,8 @@
     "image": "cPK_10_018380_00_BOCHI_C.webp",
     "name": "Greavard",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29879,7 +33207,8 @@
     "image": "cPK_10_018390_00_HAKADOG_U.webp",
     "name": "Houndstone",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29888,7 +33217,8 @@
     "image": "cPK_10_018400_00_SAKEBUSHIPPO_C.webp",
     "name": "Scream Tail",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29897,7 +33227,8 @@
     "image": "cPK_10_018410_00_HABATAKUKAMIex_RR.webp",
     "name": "Flutter Mane ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29906,7 +33237,8 @@
     "image": "cPK_10_018420_00_TETSUNOBUJIN_R.webp",
     "name": "Iron Valiant",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29915,7 +33247,8 @@
     "image": "cPK_10_018430_00_TETSUNOISAHA_R.webp",
     "name": "Iron Leaves",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29924,7 +33257,8 @@
     "image": "cPK_10_018440_00_TETSUNOIWAO_R.webp",
     "name": "Iron Boulder",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29933,7 +33267,8 @@
     "image": "cPK_10_018450_00_TETSUNOKASHIRA_R.webp",
     "name": "Iron Crown",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29942,7 +33277,8 @@
     "image": "cPK_10_018460_00_KOJIO_C.webp",
     "name": "Nacli",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29951,7 +33287,8 @@
     "image": "cPK_10_018470_00_JIODUMU_C.webp",
     "name": "Naclstack",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29960,7 +33297,8 @@
     "image": "cPK_10_018480_00_KYOJIOHN_R.webp",
     "name": "Garganacl",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29969,7 +33307,8 @@
     "image": "cPK_10_018490_00_IDAINAKIBA_U.webp",
     "name": "Great Tusk",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29978,7 +33317,8 @@
     "image": "cPK_10_018500_00_SUNANOKEGAWA_U.webp",
     "name": "Sandy Shocks",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29987,7 +33327,8 @@
     "image": "cPK_10_018510_00_KORAIDONex_RR.webp",
     "name": "Koraidon ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -29996,7 +33337,8 @@
     "image": "cPK_10_018520_00_BRACKY_U.webp",
     "name": "Umbreon",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30005,7 +33347,8 @@
     "image": "cPK_10_018530_00_NYULA_C.webp",
     "name": "Sneasel",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30014,7 +33357,8 @@
     "image": "cPK_10_018540_00_MANYULA_U.webp",
     "name": "Weavile",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30023,7 +33367,8 @@
     "image": "cPK_10_018550_00_YAMIRAMI_U.webp",
     "name": "Sableye",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30032,7 +33377,8 @@
     "image": "cPK_10_018560_00_KOMATANA_C.webp",
     "name": "Pawniard",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30041,7 +33387,8 @@
     "image": "cPK_10_018570_00_KIRIKIZAN_C.webp",
     "name": "Bisharp",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30050,7 +33397,8 @@
     "image": "cPK_10_018580_00_DODOGEZAN_R.webp",
     "name": "Kingambit",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30059,7 +33407,8 @@
     "image": "cPK_10_018590_00_KIRAME_C.webp",
     "name": "Glimmet",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30068,7 +33417,8 @@
     "image": "cPK_10_018600_00_KIRAFLOR_R.webp",
     "name": "Glimmora",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30077,7 +33427,8 @@
     "image": "cPK_10_018610_00_TETSUNOKOUBE_U.webp",
     "name": "Iron Jugulis",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30086,7 +33437,8 @@
     "image": "cPK_10_018620_00_TODOROKUTSUKI_R.webp",
     "name": "Roaring Moon",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30095,7 +33447,8 @@
     "image": "cPK_10_018630_00_ARMORGA_U.webp",
     "name": "Corviknight",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30104,7 +33457,8 @@
     "image": "cPK_10_018640_00_ZOUDOU_C.webp",
     "name": "Cufant",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30113,7 +33467,8 @@
     "image": "cPK_10_018650_00_DAIOUDOU_U.webp",
     "name": "Copperajah",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30122,7 +33477,8 @@
     "image": "cPK_10_018660_00_TETSUNOWADACHI_U.webp",
     "name": "Iron Treads",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30131,7 +33487,8 @@
     "image": "cPK_10_018670_00_TYLTALIS_U.webp",
     "name": "Altaria",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30140,7 +33497,8 @@
     "image": "cPK_10_018680_00_UNERUMINAMO_R.webp",
     "name": "Walking Wake",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30149,7 +33507,8 @@
     "image": "cPK_10_018690_00_UGATSUHOMURA_R.webp",
     "name": "Gouging Fire",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30158,7 +33517,8 @@
     "image": "cPK_10_018700_00_TAKERURAIKO_R.webp",
     "name": "Raging Bolt",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30167,7 +33527,8 @@
     "image": "cPK_10_018710_00_EIEVUI_C.webp",
     "name": "Eevee",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30176,7 +33537,8 @@
     "image": "cPK_10_018720_00_KIRINRIKI_C.webp",
     "name": "Girafarig",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30185,7 +33547,8 @@
     "image": "cPK_10_018730_00_RIKIKIRIN_C.webp",
     "name": "Farigiraf",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30194,7 +33557,8 @@
     "image": "cPK_10_018740_00_NOKOCCHI_U.webp",
     "name": "Dunsparce",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30203,7 +33567,8 @@
     "image": "cPK_10_018750_00_NOKOKOCCHI_R.webp",
     "name": "Dudunsparce",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30212,7 +33577,8 @@
     "image": "cPK_10_018760_00_TYLTTO_C.webp",
     "name": "Swablu",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30221,7 +33587,8 @@
     "image": "cPK_10_018770_00_WASHIBON_C.webp",
     "name": "Rufflet",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30230,7 +33597,8 @@
     "image": "cPK_10_018780_00_WARRGLE_C.webp",
     "name": "Braviary",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30239,7 +33607,8 @@
     "image": "cPK_10_018790_00_LUCHABULL_C.webp",
     "name": "Hawlucha",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30248,7 +33617,8 @@
     "image": "cPK_10_018800_00_KOKOGARA_C.webp",
     "name": "Rookidee",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30257,7 +33627,8 @@
     "image": "cPK_10_018810_00_AOGARASU_C.webp",
     "name": "Corvisquire",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30266,7 +33637,8 @@
     "image": "cPK_10_018820_00_KARAMINGO_C.webp",
     "name": "Flamigo",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30275,7 +33647,8 @@
     "image": "cPK_10_018830_00_TERAPAGOSex_RR.webp",
     "name": "Terapagos ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30284,7 +33657,8 @@
     "image": "cTR_10_001370_00_BUSUTOENAJIKODAI_U.webp",
     "name": "Ancient Booster Energy Capsule",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30293,7 +33667,8 @@
     "image": "cTR_10_001380_00_BUSUTOENAJIMIRAI_U.webp",
     "name": "Future Booster Energy Capsule",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30302,7 +33677,8 @@
     "image": "cTR_10_001390_00_AOI_U.webp",
     "name": "Juliana",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30311,7 +33687,8 @@
     "image": "cTR_10_001400_00_OLIMHAKASE_U.webp",
     "name": "Professor Sada",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30320,7 +33697,8 @@
     "image": "cTR_10_001410_00_FUTUHAKASE_U.webp",
     "name": "Professor Turo",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30329,7 +33707,8 @@
     "image": "cTR_10_001420_00_ERIAZERO_U.webp",
     "name": "Area Zero",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30338,7 +33717,8 @@
     "image": "cPK_20_018260_00_YUKIHAMI_AR.webp",
     "name": "Snom",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30347,7 +33727,8 @@
     "image": "cPK_20_018360_00_HIRAHINA_AR.webp",
     "name": "Flittle",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30356,7 +33737,8 @@
     "image": "cPK_20_018440_00_TETSUNOIWAO_AR.webp",
     "name": "Iron Boulder",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30365,7 +33747,8 @@
     "image": "cPK_20_018600_00_KIRAFLOR_AR.webp",
     "name": "Glimmora",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30374,7 +33757,8 @@
     "image": "cPK_20_018700_00_TAKERURAIKO_AR.webp",
     "name": "Raging Bolt",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30383,7 +33767,8 @@
     "image": "cPK_20_018790_00_LUCHABULL_AR.webp",
     "name": "Hawlucha",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30392,7 +33777,8 @@
     "image": "cPK_20_018280_00_TETSUNOTSUTSUMIex_SR.webp",
     "name": "Iron Bundle ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30401,7 +33787,8 @@
     "image": "cPK_20_018340_00_MIRAIDONex_SR.webp",
     "name": "Miraidon ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30410,7 +33797,8 @@
     "image": "cPK_20_018410_00_HABATAKUKAMIex_SR.webp",
     "name": "Flutter Mane ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30419,7 +33807,8 @@
     "image": "cPK_20_018510_00_KORAIDONex_SR.webp",
     "name": "Koraidon ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30428,7 +33817,8 @@
     "image": "cPK_20_018830_00_TERAPAGOSex_SR.webp",
     "name": "Terapagos ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30437,7 +33827,8 @@
     "image": "cTR_20_001390_00_AOI_SR.webp",
     "name": "Juliana",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30446,7 +33837,8 @@
     "image": "cTR_20_001400_00_OLIMHAKASE_SR.webp",
     "name": "Professor Sada",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30455,7 +33847,8 @@
     "image": "cTR_20_001410_00_FUTUHAKASE_SR.webp",
     "name": "Professor Turo",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30464,7 +33857,8 @@
     "image": "cPK_20_018280_01_TETSUNOTSUTSUMIex_SAR.webp",
     "name": "Iron Bundle ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30473,7 +33867,8 @@
     "image": "cPK_20_018340_01_MIRAIDONex_SAR.webp",
     "name": "Miraidon ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30482,7 +33877,8 @@
     "image": "cPK_20_018410_01_HABATAKUKAMIex_SAR.webp",
     "name": "Flutter Mane ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30491,7 +33887,8 @@
     "image": "cPK_20_018510_01_KORAIDONex_SAR.webp",
     "name": "Koraidon ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30500,7 +33897,8 @@
     "image": "cPK_20_018830_01_TERAPAGOSex_IM.webp",
     "name": "Terapagos ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30509,7 +33907,8 @@
     "image": "cPK_20_015230_00_SHIGAROKO_S.webp",
     "name": "Rellor",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30518,7 +33917,8 @@
     "image": "cPK_20_015280_00_CARBOU_S.webp",
     "name": "Charcadet",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30527,7 +33927,8 @@
     "image": "cPK_20_014220_00_ZUPIKA_S.webp",
     "name": "Tadbulb",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30536,7 +33937,8 @@
     "image": "cPK_20_015580_00_BERACAS_S.webp",
     "name": "Rabsca",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30545,7 +33947,8 @@
     "image": "cPK_20_016380_00_DIGDA_S.webp",
     "name": "Diglett",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30554,7 +33957,8 @@
     "image": "cPK_20_016390_00_DUGTRIO_S.webp",
     "name": "Dugtrio",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30563,7 +33967,8 @@
     "image": "cPK_20_015700_00_GAKEGANI_S.webp",
     "name": "Klawf",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30572,7 +33977,8 @@
     "image": "cPK_20_015860_01_MIMIZUZU_S.webp",
     "name": "Orthworm",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30581,7 +33987,8 @@
     "image": "cPK_20_012780_00_TYLTTO_S.webp",
     "name": "Swablu",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30590,7 +33997,8 @@
     "image": "cPK_20_012790_00_TYLTALIS_S.webp",
     "name": "Altaria",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30599,7 +34007,8 @@
     "image": "cPK_20_015120_02_MASQUERNYAex_SSR.webp",
     "name": "Meowscarada ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30608,7 +34017,8 @@
     "image": "cPK_20_015290_02_GURENARMAex_SSR.webp",
     "name": "Armarouge ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30617,7 +34027,8 @@
     "image": "cPK_20_015510_02_HARABARIEex_SSR.webp",
     "name": "Bellibolt ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30626,7 +34037,8 @@
     "image": "cPK_20_011840_02_MEGATYLTALISex_SSR.webp",
     "name": "Mega Altaria ex",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3a",
@@ -30635,7 +34047,8 @@
     "image": "cPK_20_018420_00_TETSUNOBUJIN_UR.webp",
     "name": "Iron Valiant",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3a",
@@ -30644,7 +34057,8 @@
     "image": "cPK_20_018620_00_TODOROKUTSUKI_UR.webp",
     "name": "Roaring Moon",
     "packs": ["Paradox Drive"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30653,7 +34067,8 @@
     "image": "cPK_10_019040_00_CATERPIE_C.webp",
     "name": "Caterpie",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30662,7 +34077,8 @@
     "image": "cPK_10_019050_00_TRANSEL_U.webp",
     "name": "Metapod",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30671,7 +34087,8 @@
     "image": "cPK_10_019060_00_BUTTERFREE_R.webp",
     "name": "Butterfree",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30680,7 +34097,8 @@
     "image": "cPK_10_019070_00_SABONEA_C.webp",
     "name": "Cacnea",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30689,7 +34107,8 @@
     "image": "cPK_10_019080_00_TROPIUS_U.webp",
     "name": "Tropius",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30698,7 +34117,8 @@
     "image": "cPK_10_019090_00_CHURINE_C.webp",
     "name": "Petilil",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30707,7 +34127,8 @@
     "image": "cPK_10_019100_00_HISUIDREDEAR_U.webp",
     "name": "Hisuian Lilligant",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30716,7 +34137,8 @@
     "image": "cPK_10_019110_00_ROKON_C.webp",
     "name": "Vulpix",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30725,7 +34147,8 @@
     "image": "cPK_10_019120_00_KYUKON_U.webp",
     "name": "Ninetales",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30734,7 +34157,8 @@
     "image": "cPK_10_019010_00_GARDIE_C.webp",
     "name": "Growlithe",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30743,7 +34167,8 @@
     "image": "cPK_10_019030_00_KODUCK_C.webp",
     "name": "Psyduck",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30752,7 +34177,8 @@
     "image": "cPK_10_019130_00_TOSAKINTO_C.webp",
     "name": "Goldeen",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30761,7 +34187,8 @@
     "image": "cPK_10_019140_00_AZUMAO_U.webp",
     "name": "Seaking",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30770,7 +34197,8 @@
     "image": "cPK_10_019150_00_HINBASS_C.webp",
     "name": "Feebas",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30779,7 +34207,8 @@
     "image": "cPK_10_019160_00_MILOKAROSSex_RR.webp",
     "name": "Milotic ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30788,7 +34217,8 @@
     "image": "cPK_10_019170_00_YUKIWARASHI_C.webp",
     "name": "Snorunt",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30797,7 +34227,8 @@
     "image": "cPK_10_018970_00_YUKIMENOKO_R.webp",
     "name": "Froslass",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30806,7 +34237,8 @@
     "image": "cPK_10_019180_00_LOVECUS_C.webp",
     "name": "Luvdisc",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30815,7 +34247,8 @@
     "image": "cPK_10_019190_00_POCHAMA_C.webp",
     "name": "Piplup",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30824,7 +34257,8 @@
     "image": "cPK_10_019200_00_TETSUNOTSUTSUMI_U.webp",
     "name": "Iron Bundle",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30833,7 +34267,8 @@
     "image": "cPK_10_019210_00_PIKACHU_C.webp",
     "name": "Pikachu",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30842,7 +34277,8 @@
     "image": "cPK_10_018980_00_RAICHU_U.webp",
     "name": "Raichu",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30851,7 +34287,8 @@
     "image": "cPK_10_019020_00_EMOLGA_C.webp",
     "name": "Emolga",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30860,7 +34297,8 @@
     "image": "cPK_10_019220_00_DEDENNEex_RR.webp",
     "name": "Dedenne ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30869,7 +34307,8 @@
     "image": "cPK_10_019230_00_WANPACHI_C.webp",
     "name": "Yamper",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30878,7 +34317,8 @@
     "image": "cPK_10_019240_00_YADON_C.webp",
     "name": "Slowpoke",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30887,7 +34327,8 @@
     "image": "cPK_10_019250_00_YADORAN_U.webp",
     "name": "Slowbro",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30896,7 +34337,8 @@
     "image": "cPK_10_019260_00_MUNNA_C.webp",
     "name": "Munna",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30905,7 +34347,8 @@
     "image": "cPK_10_019270_00_MUSHARNA_U.webp",
     "name": "Musharna",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30914,7 +34357,8 @@
     "image": "cPK_10_019280_00_NYMPHIA_R.webp",
     "name": "Sylveon",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30923,7 +34367,8 @@
     "image": "cPK_10_019290_00_MELECIE_U.webp",
     "name": "Carbink",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30932,7 +34377,8 @@
     "image": "cPK_10_019300_00_MEGADIANCIEex_RR.webp",
     "name": "Mega Diancie ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30941,7 +34387,8 @@
     "image": "cPK_10_019310_00_LOVETOLOS_R.webp",
     "name": "Enamorus",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30950,7 +34397,8 @@
     "image": "cPK_10_019320_00_PUPIMOCCHI_C.webp",
     "name": "Fidough",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30959,7 +34407,8 @@
     "image": "cPK_10_019330_00_HABATAKUKAMI_U.webp",
     "name": "Flutter Mane",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30968,7 +34417,8 @@
     "image": "cPK_10_019340_00_UPAH_C.webp",
     "name": "Wooper",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30977,7 +34427,8 @@
     "image": "cPK_10_019350_00_NUOH_U.webp",
     "name": "Quagsire",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30986,7 +34437,8 @@
     "image": "cPK_10_019360_00_IWANKO_C.webp",
     "name": "Rockruff",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -30995,7 +34447,8 @@
     "image": "cPK_10_019370_00_SUNABA_C.webp",
     "name": "Sandygast",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31004,7 +34457,8 @@
     "image": "cPK_10_019380_00_SIRODETHNA_U.webp",
     "name": "Palossand",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31013,7 +34467,8 @@
     "image": "cPK_10_019390_00_MEGAYAMIRAMIex_RR.webp",
     "name": "Mega Sableye ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31022,7 +34477,8 @@
     "image": "cPK_10_019400_00_NOCTUS_U.webp",
     "name": "Cacturne",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31031,7 +34487,8 @@
     "image": "cPK_10_019410_00_MIKARUGE_U.webp",
     "name": "Spiritomb",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31040,7 +34497,8 @@
     "image": "cPK_10_019420_00_ZURUGGU_C.webp",
     "name": "Scraggy",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31049,7 +34507,8 @@
     "image": "cPK_10_019430_00_ZURUZUKIN_U.webp",
     "name": "Scrafty",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31058,7 +34517,8 @@
     "image": "cPK_10_019440_00_HIDOIDE_C.webp",
     "name": "Mareanie",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31067,7 +34527,8 @@
     "image": "cPK_10_019450_00_DOHIDOIDE_U.webp",
     "name": "Toxapex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31076,7 +34537,8 @@
     "image": "cPK_10_019460_00_NUMERA_C.webp",
     "name": "Goomy",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31085,7 +34547,8 @@
     "image": "cPK_10_019470_00_HISUINUMEIL_U.webp",
     "name": "Hisuian Sliggoo",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31094,7 +34557,8 @@
     "image": "cPK_10_019480_00_HISUINUMELGON_R.webp",
     "name": "Hisuian Goodra",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31103,7 +34567,8 @@
     "image": "cPK_10_019490_00_PURIN_C.webp",
     "name": "Jigglypuff",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31112,7 +34577,8 @@
     "image": "cPK_10_019500_00_PUKURIN_U.webp",
     "name": "Wigglytuff",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31121,7 +34587,8 @@
     "image": "cPK_10_019510_00_EIEVUI_C.webp",
     "name": "Eevee",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31130,7 +34597,8 @@
     "image": "cPK_10_019520_00_GONBE_R.webp",
     "name": "Munchlax",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31139,7 +34607,8 @@
     "image": "cPK_10_019530_00_KABIGON_R.webp",
     "name": "Snorlax",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31148,7 +34617,8 @@
     "image": "cPK_10_019540_00_HIMEGUMA_C.webp",
     "name": "Teddiursa",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31157,7 +34627,8 @@
     "image": "cPK_10_019550_00_RINGUMA_U.webp",
     "name": "Ursaring",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31166,7 +34637,8 @@
     "image": "cPK_10_019560_00_GACHIGUMA_R.webp",
     "name": "Ursaluna",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31175,7 +34647,8 @@
     "image": "cPK_10_019000_00_HISUIZORUA_C.webp",
     "name": "Hisuian Zorua",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31184,7 +34657,8 @@
     "image": "cPK_10_019570_00_HISUIZOROARKex_RR.webp",
     "name": "Hisuian Zoroark ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31193,7 +34667,8 @@
     "image": "cPK_10_019580_00_TRIMMIEN_C.webp",
     "name": "Furfrou",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31202,7 +34677,8 @@
     "image": "cPK_10_019590_00_HOSHIGARISU_C.webp",
     "name": "Skwovet",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31211,7 +34687,8 @@
     "image": "cPK_10_019600_00_YOKUBARISU_U.webp",
     "name": "Greedent",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31220,7 +34697,8 @@
     "image": "cTR_10_001430_00_CHIISANAFUUSEN_U.webp",
     "name": "Small Balloon",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31229,7 +34707,8 @@
     "image": "cTR_10_001440_00_YUUGANAMANTO_U.webp",
     "name": "Elegant Cape",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31238,7 +34717,8 @@
     "image": "cTR_10_001450_00_KAMITSURE_U.webp",
     "name": "Elesa",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31247,7 +34727,8 @@
     "image": "cTR_10_001460_00_KOINUDAISUKIGARL_U.webp",
     "name": "Puppy-Loving Girl",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31256,16 +34737,18 @@
     "image": "cTR_10_001470_00_MIKURI_U.webp",
     "name": "Wallace",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
     "number": 69,
     "rarity": "U",
     "image": "cTR_10_001480_00_KODOMOBEYA_U.webp",
-    "name": "Kid\u2019s Room",
+    "name": "Kid’s Room",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31274,7 +34757,8 @@
     "image": "cPK_20_019110_00_ROKON_AR.webp",
     "name": "Vulpix",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31283,7 +34767,8 @@
     "image": "cPK_20_019190_00_POCHAMA_AR.webp",
     "name": "Piplup",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31292,7 +34777,8 @@
     "image": "cPK_20_019210_00_PIKACHU_AR.webp",
     "name": "Pikachu",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31301,7 +34787,8 @@
     "image": "cPK_20_019280_00_NYMPHIA_AR.webp",
     "name": "Sylveon",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31310,7 +34797,8 @@
     "image": "cPK_20_019440_00_HIDOIDE_AR.webp",
     "name": "Mareanie",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31319,7 +34807,8 @@
     "image": "cPK_20_019490_00_PURIN_AR.webp",
     "name": "Jigglypuff",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31328,7 +34817,8 @@
     "image": "cPK_20_019530_00_KABIGON_AR.webp",
     "name": "Snorlax",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31337,7 +34827,8 @@
     "image": "cPK_20_019600_00_YOKUBARISU_AR.webp",
     "name": "Greedent",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31346,7 +34837,8 @@
     "image": "cPK_20_019160_00_MILOKAROSSex_SR.webp",
     "name": "Milotic ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31355,7 +34847,8 @@
     "image": "cPK_20_019220_00_DEDENNEex_SR.webp",
     "name": "Dedenne ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31364,7 +34857,8 @@
     "image": "cPK_20_019300_00_MEGADIANCIEex_SR.webp",
     "name": "Mega Diancie ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31373,7 +34867,8 @@
     "image": "cPK_20_019390_00_MEGAYAMIRAMIex_SR.webp",
     "name": "Mega Sableye ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31382,7 +34877,8 @@
     "image": "cPK_20_019570_00_HISUIZOROARKex_SR.webp",
     "name": "Hisuian Zoroark ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31391,7 +34887,8 @@
     "image": "cTR_20_001450_00_KAMITSURE_SR.webp",
     "name": "Elesa",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31400,7 +34897,8 @@
     "image": "cTR_20_001460_00_KOINUDAISUKIGARL_SR.webp",
     "name": "Puppy-Loving Girl",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31409,7 +34907,8 @@
     "image": "cTR_20_001470_00_MIKURI_SR.webp",
     "name": "Wallace",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31418,7 +34917,8 @@
     "image": "cPK_20_019160_01_MILOKAROSSex_SAR.webp",
     "name": "Milotic ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31427,7 +34927,8 @@
     "image": "cPK_20_019300_01_MEGADIANCIEex_SAR.webp",
     "name": "Mega Diancie ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31436,7 +34937,8 @@
     "image": "cPK_20_019390_01_MEGAYAMIRAMIex_SAR.webp",
     "name": "Mega Sableye ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31445,7 +34947,8 @@
     "image": "cPK_20_019570_01_HISUIZOROARKex_SAR.webp",
     "name": "Hisuian Zoroark ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31454,7 +34957,8 @@
     "image": "cPK_20_019220_01_DEDENNEex_IM.webp",
     "name": "Dedenne ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31463,7 +34967,8 @@
     "image": "cPK_20_019040_00_CATERPIE_S.webp",
     "name": "Caterpie",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31472,7 +34977,8 @@
     "image": "cPK_20_019050_00_TRANSEL_S.webp",
     "name": "Metapod",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31481,7 +34987,8 @@
     "image": "cPK_20_019060_00_BUTTERFREE_S.webp",
     "name": "Butterfree",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31490,7 +34997,8 @@
     "image": "cPK_20_011640_00_MERRIEP_S.webp",
     "name": "Mareep",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31499,7 +35007,8 @@
     "image": "cPK_20_011650_00_MOKOKO_S.webp",
     "name": "Flaaffy",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31508,7 +35017,8 @@
     "image": "cPK_20_011660_00_DENRYU_S.webp",
     "name": "Ampharos",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31517,7 +35027,8 @@
     "image": "cPK_20_019250_00_YADORAN_S.webp",
     "name": "Slowbro",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31526,7 +35037,8 @@
     "image": "cPK_20_014920_00_GARURA_S.webp",
     "name": "Kangaskhan",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31535,7 +35047,8 @@
     "image": "cPK_20_013060_00_METAMON_S.webp",
     "name": "Ditto",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31544,7 +35057,8 @@
     "image": "cPK_20_019530_01_KABIGON_S.webp",
     "name": "Snorlax",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31553,7 +35067,8 @@
     "image": "cPK_20_011340_02_MEGAGYARADOSex_SSR.webp",
     "name": "Mega Gyarados ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31562,7 +35077,8 @@
     "image": "cPK_20_017020_02_SHOWERSex_SSR.webp",
     "name": "Vaporeon ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31571,7 +35087,8 @@
     "image": "cPK_20_011670_02_MEGADENRYUex_SSR.webp",
     "name": "Mega Ampharos ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31580,7 +35097,8 @@
     "image": "cPK_20_012030_02_YESSANex_SSR.webp",
     "name": "Indeedee ex",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": true
   },
   {
     "set": "B3b",
@@ -31589,7 +35107,8 @@
     "image": "cPK_20_019520_00_GONBE_UR.webp",
     "name": "Munchlax",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   },
   {
     "set": "B3b",
@@ -31598,6 +35117,7 @@
     "image": "cTR_20_001430_00_CHIISANAFUUSEN_UR.webp",
     "name": "Small Balloon",
     "packs": ["Everyday Wonders"],
-    "parallel": false
+    "parallel": false,
+    "shiny": false
   }
 ]


### PR DESCRIPTION
This adds 2 attributes to each entry in cards.json:
* parallel: If the card is a parallel foil card (only true for deluxe pack right now)
* shiny: True if card is a shiny (this allows special case handling for IM Mew from Mega Shine)

For shiny the idea is to only include them for the `Regular Pack +1` packs in B series.

This addresses #12 #19 

I will do another PR for cards.extra.json and pullRates.json at a later point, there is still some stuff I need to script up for this